### PR TITLE
fix(ai): add missing LangGraph example runtime deps

### DIFF
--- a/apps/cli/test/ai-deps.test.ts
+++ b/apps/cli/test/ai-deps.test.ts
@@ -143,6 +143,58 @@ describe("AI SDK Dependencies", () => {
     }
   });
 
+  it("should install langgraph example runtime deps when AI example is enabled", async () => {
+    const result = await runTRPCTest({
+      projectName: "ai-deps-langgraph-example",
+      ecosystem: "typescript",
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "drizzle",
+      api: "trpc",
+      auth: "none",
+      payments: "none",
+      addons: ["none"],
+      examples: ["ai"],
+      dbSetup: "none",
+      webDeploy: "none",
+      serverDeploy: "none",
+      ai: "langgraph",
+      cssFramework: "tailwind",
+      uiLibrary: "none",
+      effect: "none",
+      email: "none",
+      stateManagement: "none",
+      forms: "react-hook-form",
+      testing: "vitest",
+      validation: "zod",
+      realtime: "none",
+      jobQueue: "none",
+      animation: "none",
+      logging: "none",
+      observability: "none",
+      cms: "none",
+      caching: "none",
+      fileUpload: "none",
+      packageManager: "bun",
+    });
+    expectSuccess(result);
+
+    if (result.projectDir) {
+      const serverPkg = await Bun.file(`${result.projectDir}/apps/server/package.json`).json();
+      const webPkg = await Bun.file(`${result.projectDir}/apps/web/package.json`).json();
+
+      expect(serverPkg.dependencies["ai"]).toBeDefined();
+      expect(serverPkg.dependencies["@ai-sdk/google"]).toBeDefined();
+      expect(serverPkg.dependencies["@ai-sdk/devtools"]).toBeDefined();
+      expect(serverPkg.dependencies["@langchain/langgraph"]).toBeDefined();
+
+      expect(webPkg.dependencies["ai"]).toBeDefined();
+      expect(webPkg.dependencies["streamdown"]).toBeDefined();
+    }
+  });
+
   it("should install llamaindex SDK when selected", async () => {
     const result = await runTRPCTest({
       projectName: "ai-deps-llamaindex",

--- a/packages/template-generator/src/processors/examples-deps.ts
+++ b/packages/template-generator/src/processors/examples-deps.ts
@@ -67,7 +67,14 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       addPackageDependency({
         vfs,
         packagePath: webPkgPath,
-        dependencies: ["@langchain/langgraph", "@langchain/core", "@langchain/google-genai"],
+        dependencies: [
+          "@langchain/langgraph",
+          "@langchain/core",
+          "@langchain/google-genai",
+          "ai",
+          "@ai-sdk/google",
+          "@ai-sdk/devtools",
+        ],
       });
     } else if (useOpenAIAgents) {
       addPackageDependency({
@@ -114,7 +121,14 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       addPackageDependency({
         vfs,
         packagePath: serverPkgPath,
-        dependencies: ["@langchain/langgraph", "@langchain/core", "@langchain/google-genai"],
+        dependencies: [
+          "@langchain/langgraph",
+          "@langchain/core",
+          "@langchain/google-genai",
+          "ai",
+          "@ai-sdk/google",
+          "@ai-sdk/devtools",
+        ],
       });
     } else if (useOpenAIAgents) {
       addPackageDependency({
@@ -157,7 +171,8 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       if (hasReactWeb) deps.push("@ai-sdk/react", "streamdown");
     } else if (useLangGraph) {
       // LangGraph uses native streaming - no special frontend SDK needed
-      // Just add streamdown for markdown rendering
+      // Frontend still uses Vercel AI SDK transport primitives + streamdown for React markdown rendering
+      deps.push("ai");
       if (hasReactWeb) deps.push("streamdown");
     } else if (useOpenAIAgents) {
       // OpenAI Agents SDK uses native streaming - no special frontend SDK needed


### PR DESCRIPTION
## Summary
- add missing LangGraph AI example runtime dependencies to generated server/web packages
- fix the `ai-langgraph-hono-router` scaffold `check-types` failure
- add a regression test covering LangGraph with `examples=["ai"]`

## Root cause
LangGraph example templates import `ai`, `@ai-sdk/google`, and `@ai-sdk/devtools` (server) and `ai` (web transport), but `processExamplesDeps()` only added the LangChain packages and `streamdown`.

## Validation
- `bun test apps/cli/test/ai-deps.test.ts`
- fresh scaffold repro: generated `ai-langgraph-hono-router`, ran `bun install`, then `bun run --filter '*' check-types` (passes)
