### PR TITLE
fix: repair template smoke regressions

### DIFF
--- a/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
+++ b/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
@@ -1177,7 +1177,7 @@ export default defineConfig({
     "db:migrate": "bun run --filter @snapshot-tanstack-router-minimal/db db:migrate",
     "db:local": "bun run --filter @snapshot-tanstack-router-minimal/db db:local"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -1785,7 +1785,7 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
     "db:generate": "bun run --filter @snapshot-next-self-fullstack/db db:generate",
     "db:migrate": "bun run --filter @snapshot-next-self-fullstack/db db:migrate"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -2429,7 +2429,7 @@ export const client = createORPCClient<typeof appRouter>(link);
     "db:migrate": "bun run --filter @snapshot-astro-react-integration/db db:migrate",
     "db:local": "bun run --filter @snapshot-astro-react-integration/db db:local"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -2939,7 +2939,7 @@ export default defineNuxtConfig({
     "db:migrate": "bun run --filter @snapshot-nuxt-standalone/db db:migrate",
     "db:local": "bun run --filter @snapshot-nuxt-standalone/db db:local"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -3698,7 +3698,7 @@ export default defineConfig({
     "db:generate": "bun run --filter @snapshot-express-node-trpc/db db:generate",
     "db:migrate": "bun run --filter @snapshot-express-node-trpc/db db:migrate"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -4480,7 +4480,7 @@ export default defineConfig({
     "db:migrate": "bun run --filter @snapshot-hono-bun-orpc/db db:migrate",
     "db:local": "bun run --filter @snapshot-hono-bun-orpc/db db:local"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -5276,7 +5276,7 @@ export default defineConfig({
     "db:generate": "bun run --filter @snapshot-better-auth-full/db db:generate",
     "db:migrate": "bun run --filter @snapshot-better-auth-full/db db:migrate"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -6101,7 +6101,7 @@ export default defineConfig({
     "dev:server": "bun run --filter @snapshot-convex-clerk/backend dev",
     "dev:setup": "bun run --filter @snapshot-convex-clerk/backend dev:setup"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -6594,7 +6594,7 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
     "db:migrate": "bun run --filter @snapshot-self-next-clerk/db db:migrate",
     "db:local": "bun run --filter @snapshot-self-next-clerk/db db:local"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -7275,7 +7275,7 @@ export default defineConfig({
     "db:migrate": "bun run --filter @snapshot-self-tanstack-start-clerk/db db:migrate",
     "db:local": "bun run --filter @snapshot-self-tanstack-start-clerk/db db:local"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -8026,7 +8026,7 @@ export default defineConfig({
     "dev:web": "bun run --filter web dev",
     "dev:server": "bun run --filter server dev"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -8750,7 +8750,7 @@ export default defineConfig({
     "db:generate": "bun run --filter @snapshot-postgres-prisma/db db:generate",
     "db:migrate": "bun run --filter @snapshot-postgres-prisma/db db:migrate"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -9308,7 +9308,7 @@ export default defineConfig({
     "dev:native": "bun run --filter native dev",
     "dev:web": "bun run --filter web dev"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",
@@ -9908,7 +9908,7 @@ export default app;
     "db:migrate": "bun run --filter @snapshot-native-react-native/db db:migrate",
     "db:local": "bun run --filter @snapshot-native-react-native/db db:local"
   },
-  "packageManager": "bun@latest",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "dotenv": "catalog:",
     "zod": "catalog:",

--- a/apps/cli/test/virtual-generator-regressions.test.ts
+++ b/apps/cli/test/virtual-generator-regressions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+
+import { createVirtual } from "../src/index";
+
+function readJsonFromTree(
+  tree: NonNullable<Awaited<ReturnType<typeof createVirtual>>["tree"]>,
+  targetPath: string,
+) {
+  const stack = [...tree.root.children];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node.type === "file" && node.path === targetPath) {
+      return JSON.parse(node.content) as {
+        packageManager?: string;
+        dependencies?: Record<string, string>;
+      };
+    }
+    if (node.type === "directory") {
+      stack.push(...node.children);
+    }
+  }
+  return undefined;
+}
+
+describe("Virtual Generator Regressions", () => {
+  const packageManagers = ["npm", "pnpm", "bun", "yarn"] as const;
+
+  for (const packageManager of packageManagers) {
+    it(`writes a concrete ${packageManager} packageManager version`, async () => {
+      const result = await createVirtual({
+        projectName: `pm-${packageManager}`,
+        packageManager,
+        frontend: ["tanstack-router"],
+        backend: "hono",
+        api: "trpc",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+      });
+
+      expect(result.success).toBe(true);
+
+      const rootPackageJson = result.tree ? readJsonFromTree(result.tree, "package.json") : undefined;
+      expect(rootPackageJson?.packageManager).toMatch(
+        new RegExp(`^${packageManager}@\\d+\\.\\d+\\.\\d+(?:-.+)?$`),
+      );
+    });
+  }
+
+  const aiExamples = [
+    { ai: "mastra", sdkPackage: "mastra" },
+    { ai: "voltagent", sdkPackage: "@voltagent/core" },
+    { ai: "openai-agents", sdkPackage: "@openai/agents" },
+    { ai: "google-adk", sdkPackage: "@google/adk" },
+  ] as const;
+
+  for (const { ai, sdkPackage } of aiExamples) {
+    it(`adds transport deps for ${ai} self-hosted AI examples`, async () => {
+      const result = await createVirtual({
+        projectName: `ai-${ai}`,
+        frontend: ["tanstack-start"],
+        backend: "self",
+        runtime: "none",
+        api: "trpc",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "better-auth",
+        examples: ["ai"],
+        ai,
+      });
+
+      expect(result.success).toBe(true);
+
+      const webPackageJson = result.tree ? readJsonFromTree(result.tree, "apps/web/package.json") : undefined;
+
+      expect(webPackageJson?.dependencies?.[sdkPackage]).toBeDefined();
+      expect(webPackageJson?.dependencies?.ai).toBeDefined();
+      expect(webPackageJson?.dependencies?.["@ai-sdk/google"]).toBeDefined();
+      expect(webPackageJson?.dependencies?.["@ai-sdk/devtools"]).toBeDefined();
+      expect(webPackageJson?.dependencies?.["@ai-sdk/react"]).toBeDefined();
+      expect(webPackageJson?.dependencies?.streamdown).toBeDefined();
+    });
+  }
+});

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -24,6 +24,13 @@ type PackageManagerConfig = {
   filter: (workspace: string, script: string) => string;
 };
 
+const VIRTUAL_PACKAGE_MANAGER_VERSIONS: Record<ProjectConfig["packageManager"], string> = {
+  npm: "10.9.2",
+  pnpm: "10.17.1",
+  bun: "1.3.5",
+  yarn: "4.12.0",
+};
+
 /**
  * Update all package.json files with proper names, scripts, and workspaces
  */
@@ -119,8 +126,11 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
     scripts["db:down"] = pmConfig.filter(dbPackageName, "db:down");
   }
 
-  pkgJson.packageManager =
-    packageManager === "yarn" ? "yarn@4.12.0" : `${packageManager}@latest`;
+  // Virtual generation runs in preview and test contexts where we cannot shell out
+  // to discover the user's installed package manager version. Keep the field valid
+  // so generated workspaces remain buildable; the CLI create() path rewrites this to
+  // the actual local version after scaffolding.
+  pkgJson.packageManager = `${packageManager}@${VIRTUAL_PACKAGE_MANAGER_VERSIONS[packageManager]}`;
 
   if (backend === "convex") {
     if (!workspaces.includes("packages/*")) {

--- a/packages/template-generator/src/processors/examples-deps.ts
+++ b/packages/template-generator/src/processors/examples-deps.ts
@@ -101,6 +101,7 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
   const useOpenAIAgents = ai === "openai-agents";
   const useGoogleADK = ai === "google-adk";
   const useModelFusion = ai === "modelfusion";
+  const sharedAIExampleServerDeps: AvailableDependencies[] = ["ai", "@ai-sdk/google", "@ai-sdk/devtools"];
 
   if (backend === "convex" && convexBackendExists) {
     addPackageDependency({
@@ -114,13 +115,18 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       addPackageDependency({
         vfs,
         packagePath: webPkgPath,
-        dependencies: ["mastra", "@mastra/core"],
+        dependencies: ["mastra", "@mastra/core", ...sharedAIExampleServerDeps],
       });
     } else if (useVoltAgent) {
       addPackageDependency({
         vfs,
         packagePath: webPkgPath,
-        dependencies: ["@voltagent/core", "@voltagent/server-hono", "@voltagent/libsql"],
+        dependencies: [
+          "@voltagent/core",
+          "@voltagent/server-hono",
+          "@voltagent/libsql",
+          ...sharedAIExampleServerDeps,
+        ],
         customDependencies: { ai: "^6.0.0", "@ai-sdk/google": "^3.0.1", zod: "^3.25.76" },
       });
     } else if (useLangGraph) {
@@ -140,14 +146,14 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       addPackageDependency({
         vfs,
         packagePath: webPkgPath,
-        dependencies: ["@openai/agents"],
+        dependencies: ["@openai/agents", ...sharedAIExampleServerDeps],
         customDependencies: { zod: "^3.25.67" },
       });
     } else if (useGoogleADK) {
       addPackageDependency({
         vfs,
         packagePath: webPkgPath,
-        dependencies: ["@google/adk"],
+        dependencies: ["@google/adk", ...sharedAIExampleServerDeps],
         customDependencies: { zod: "^3.25.67" },
       });
     } else if (useModelFusion) {
@@ -168,13 +174,18 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       addPackageDependency({
         vfs,
         packagePath: serverPkgPath,
-        dependencies: ["mastra", "@mastra/core"],
+        dependencies: ["mastra", "@mastra/core", ...sharedAIExampleServerDeps],
       });
     } else if (useVoltAgent) {
       addPackageDependency({
         vfs,
         packagePath: serverPkgPath,
-        dependencies: ["@voltagent/core", "@voltagent/server-hono", "@voltagent/libsql"],
+        dependencies: [
+          "@voltagent/core",
+          "@voltagent/server-hono",
+          "@voltagent/libsql",
+          ...sharedAIExampleServerDeps,
+        ],
         customDependencies: { ai: "^6.0.0", "@ai-sdk/google": "^3.0.1", zod: "^3.25.76" },
       });
     } else if (useLangGraph) {
@@ -194,14 +205,14 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       addPackageDependency({
         vfs,
         packagePath: serverPkgPath,
-        dependencies: ["@openai/agents"],
+        dependencies: ["@openai/agents", ...sharedAIExampleServerDeps],
         customDependencies: { zod: "^3.25.67" },
       });
     } else if (useGoogleADK) {
       addPackageDependency({
         vfs,
         packagePath: serverPkgPath,
-        dependencies: ["@google/adk"],
+        dependencies: ["@google/adk", ...sharedAIExampleServerDeps],
         customDependencies: { zod: "^3.25.67" },
       });
     } else if (useModelFusion) {
@@ -224,33 +235,24 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
     if (backend === "convex") {
       if (hasReactWeb) deps.push("@convex-dev/agent", "streamdown");
     } else if (useMastra) {
-      // Mastra uses @ai-sdk/react for frontend integration
-      if (hasReactWeb) deps.push("@ai-sdk/react", "streamdown");
+      addAITransportClientDeps(deps, { hasReactWeb, hasNuxt, hasSvelte });
     } else if (useVoltAgent) {
-      // VoltAgent uses @ai-sdk/react for frontend integration (built on Vercel AI SDK)
-      if (hasReactWeb) deps.push("@ai-sdk/react", "streamdown");
+      addAITransportClientDeps(deps, { hasReactWeb, hasNuxt, hasSvelte });
     } else if (useLangGraph) {
       // LangGraph uses native streaming - no special frontend SDK needed
       // Frontend still uses Vercel AI SDK transport primitives + streamdown for React markdown rendering
       deps.push("ai");
       if (hasReactWeb) deps.push("streamdown");
     } else if (useOpenAIAgents) {
-      // OpenAI Agents SDK uses native streaming - no special frontend SDK needed
-      // Just add streamdown for markdown rendering
-      if (hasReactWeb) deps.push("streamdown");
+      addAITransportClientDeps(deps, { hasReactWeb, hasNuxt, hasSvelte });
     } else if (useGoogleADK) {
-      // Google ADK uses native streaming - no special frontend SDK needed
-      // Just add streamdown for markdown rendering
-      if (hasReactWeb) deps.push("streamdown");
+      addAITransportClientDeps(deps, { hasReactWeb, hasNuxt, hasSvelte });
     } else if (useModelFusion) {
       // ModelFusion uses native streaming - no special frontend SDK needed
       // Just add streamdown for markdown rendering
       if (hasReactWeb) deps.push("streamdown");
     } else {
-      deps.push("ai");
-      if (hasNuxt) deps.push("@ai-sdk/vue");
-      else if (hasSvelte) deps.push("@ai-sdk/svelte");
-      else if (hasReactWeb) deps.push("@ai-sdk/react", "streamdown");
+      addAITransportClientDeps(deps, { hasReactWeb, hasNuxt, hasSvelte });
     }
     // AI example React templates always use lucide-react icons (Send, Loader2)
     // regardless of the configured shadcn icon library
@@ -278,6 +280,16 @@ function setupAIDependencies(vfs: VirtualFileSystem, config: ProjectConfig): voi
       });
     }
   }
+}
+
+function addAITransportClientDeps(
+  deps: AvailableDependencies[],
+  options: { hasReactWeb: boolean; hasNuxt: boolean; hasSvelte: boolean },
+): void {
+  deps.push("ai");
+  if (options.hasNuxt) deps.push("@ai-sdk/vue");
+  else if (options.hasSvelte) deps.push("@ai-sdk/svelte");
+  else if (options.hasReactWeb) deps.push("@ai-sdk/react", "streamdown");
 }
 
 function setupTanStackShowcaseDependencies(vfs: VirtualFileSystem, _config: ProjectConfig): void {

--- a/packages/template-generator/templates/frontend/redwood/package.json.hbs
+++ b/packages/template-generator/templates/frontend/redwood/package.json.hbs
@@ -16,6 +16,5 @@
   },
   "engines": {
     "node": ">=20.x"
-  },
-  "packageManager": "{{packageManager}}@latest"
+  }
 }


### PR DESCRIPTION
## Summary
- replace virtual workspace `packageManager` placeholders with concrete package manager versions and remove Redwood's `@latest` override
- add the shared AI transport dependencies required by self-hosted AI example templates
- add regression coverage and refresh snapshots for the new virtual generator output

## Testing
- `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun run test:release`
- `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun test apps/cli/test/virtual-generator-regressions.test.ts`
- `PATH=$HOME/.bun/bin:$PATH ~/.bun/bin/bun /tmp/fixpatch-smoke.ts`