### PR TITLE
feat(testing): add major-dependency smoke test system

### DIFF
--- a/.github/workflows/deps-check.yaml
+++ b/.github/workflows/deps-check.yaml
@@ -31,6 +31,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      has_major_updates: ${{ steps.check.outputs.has_major_updates }}
+      major_packages: ${{ steps.check.outputs.major_packages }}
 
     steps:
       - name: Checkout Code
@@ -88,6 +91,12 @@ jobs:
           fi
           if ! grep -q "^downgrade_count=" "$GITHUB_OUTPUT"; then
             echo "downgrade_count=0" >> "$GITHUB_OUTPUT"
+          fi
+          if ! grep -q "^has_major_updates=" "$GITHUB_OUTPUT"; then
+            echo "has_major_updates=false" >> "$GITHUB_OUTPUT"
+          fi
+          if ! grep -q "^major_packages=" "$GITHUB_OUTPUT"; then
+            echo "major_packages=" >> "$GITHUB_OUTPUT"
           fi
 
           # Store the report
@@ -157,8 +166,82 @@ jobs:
           echo "**Mode:** ${{ steps.check.outputs.effective_update_mode }}" >> $GITHUB_STEP_SUMMARY
           echo "**Has Updates:** ${{ steps.check.outputs.has_updates }}" >> $GITHUB_STEP_SUMMARY
           echo "**Downgrades Detected:** ${{ steps.check.outputs.downgrade_count }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Major Updates:** ${{ steps.check.outputs.has_major_updates }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Report" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.check.outputs.report }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+
+  major-deps-smoke:
+    name: Major Deps Smoke Test
+    needs: check-versions
+    if: needs.check-versions.outputs.has_major_updates == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: deps/version-updates
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.bun/install/cache
+          key: major-smoke-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            major-smoke-${{ runner.os }}-bun-
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Packages
+        run: |
+          bun run --cwd packages/types build
+          bun run --cwd packages/template-generator build
+          bun run --cwd apps/cli build
+
+      - name: Install Playwright
+        run: bunx playwright install chromium --with-deps
+
+      - name: Run Major Deps Smoke Test
+        run: |
+          bun run testing/smoke-test.ts \
+            --major-deps \
+            --major-deps-packages "${{ needs.check-versions.outputs.major_packages }}" \
+            --dev-check \
+            --route-check \
+            --output testing/.smoke-output
+        continue-on-error: true
+
+      - name: Post Step Summary
+        if: always()
+        run: |
+          if [ -f testing/.smoke-output/summary.md ]; then
+            cat testing/.smoke-output/summary.md >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: major-deps-smoke-results
+          path: testing/.smoke-output/
+          retention-days: 7

--- a/packages/template-generator/scripts/check-deps.ts
+++ b/packages/template-generator/scripts/check-deps.ts
@@ -251,7 +251,10 @@ async function main() {
     const outputFile = process.env.GITHUB_OUTPUT;
     const outdatedCount = result.outdated.length;
     const downgradeCount = result.outdated.filter((u) => u.updateType === "downgrade").length;
+    const majorUpdates = result.outdated.filter((u) => u.updateType === "major");
     const hasUpdates = outdatedCount > 0 ? "true" : "false";
+    const hasMajorUpdates = majorUpdates.length > 0 ? "true" : "false";
+    const majorPackageNames = majorUpdates.map((u) => u.name).join(",");
 
     fs.appendFileSync(
       outputFile,
@@ -259,7 +262,9 @@ async function main() {
         `outdated_count=${outdatedCount}\n` +
         `downgrade_count=${downgradeCount}\n` +
         `uptodate_count=${result.upToDate.length}\n` +
-        `error_count=${result.errors.length}\n`,
+        `error_count=${result.errors.length}\n` +
+        `has_major_updates=${hasMajorUpdates}\n` +
+        `major_packages=${majorPackageNames}\n`,
     );
   }
 

--- a/testing/lib/dev-check.ts
+++ b/testing/lib/dev-check.ts
@@ -12,6 +12,19 @@ const KILL_GRACE_MS = 3_000;
 
 const URL_REGEX = /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)/g;
 
+// ── Exported Types ──────────────────────────────────────────────────────
+
+export type DevServerHandle = {
+  proc: ReturnType<typeof Bun.spawn>;
+  serverUrl: string;
+  config: ProjectConfig;
+  stdoutBuf: () => string;
+  stderrBuf: () => string;
+  startTime: number;
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
 function extractUrlFromOutput(text: string, expectedPort?: number): string | null {
   const matches = [...text.matchAll(URL_REGEX)];
   if (matches.length === 0) return null;
@@ -41,7 +54,7 @@ const EXTERNAL_DB_TYPES = new Set([
   "planetscale", "neon", "turso", "xata", "supabase",
 ]);
 
-function isDbDependentProject(config: ProjectConfig): boolean {
+export function isDbDependentProject(config: ProjectConfig): boolean {
   return EXTERNAL_DB_TYPES.has(config.database);
 }
 
@@ -58,7 +71,7 @@ const DB_ERROR_PATTERNS = [
   /getaddrinfo.*ENOTFOUND/i,
 ];
 
-const HTML_ERROR_PATTERNS = [
+export const HTML_ERROR_PATTERNS = [
   /Internal Server Error/i,
   /Application error/i,
   /Unhandled Runtime Error/i,
@@ -74,7 +87,7 @@ const HTML_ERROR_PATTERNS = [
   /There was an error while hydrating/i,
 ];
 
-function validateHtmlResponse(
+export function validateHtmlResponse(
   body: string,
   status: number,
   config?: ProjectConfig,
@@ -192,101 +205,128 @@ async function killProcessTree(pid: number): Promise<void> {
   }
 }
 
+// ── Server Lifecycle ────────────────────────────────────────────────────
+
+/**
+ * Start a dev server and wait for it to be reachable.
+ * Returns a handle that can be passed to stopDevServer().
+ * Throws with a StepResult-shaped error if the server fails to start.
+ */
+export async function startDevServer(
+  projectDir: string,
+  config: ProjectConfig,
+): Promise<DevServerHandle> {
+  const start = Date.now();
+
+  const proc = Bun.spawn(["bun", "run", "dev"], {
+    cwd: projectDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+      BROWSER: "none",
+      FORCE_COLOR: "0",
+    },
+  });
+
+  let _stdoutBuf = "";
+  let _stderrBuf = "";
+  const decoder = new TextDecoder();
+
+  const readStream = (
+    stream: ReadableStream<Uint8Array>,
+    target: "stdout" | "stderr",
+  ) => {
+    const reader = stream.getReader();
+    (async () => {
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const chunk = decoder.decode(value, { stream: true });
+          if (target === "stdout") _stdoutBuf += chunk;
+          else _stderrBuf += chunk;
+        }
+      } catch {}
+    })();
+  };
+
+  readStream(proc.stdout as ReadableStream<Uint8Array>, "stdout");
+  readStream(proc.stderr as ReadableStream<Uint8Array>, "stderr");
+
+  let serverUrl: string | null = null;
+  const urlDeadline = Date.now() + DEV_STARTUP_TIMEOUT_MS;
+
+  while (Date.now() < urlDeadline && !serverUrl) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    if (proc.exitCode !== null) {
+      throw Object.assign(
+        new Error(`Dev server exited with code ${proc.exitCode}`),
+        { stdoutBuf: _stdoutBuf, stderrBuf: _stderrBuf },
+      );
+    }
+
+    const port = getExpectedPort(config);
+    serverUrl =
+      extractUrlFromOutput(_stdoutBuf, port) || extractUrlFromOutput(_stderrBuf, port);
+  }
+
+  if (!serverUrl) {
+    const fallbackUrl = getExpectedDevUrl(config);
+    try {
+      const resp = await fetch(fallbackUrl, {
+        signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
+      });
+      await resp.text();
+      serverUrl = fallbackUrl;
+    } catch {}
+  }
+
+  if (!serverUrl) {
+    await killProcessTree(proc.pid);
+    throw Object.assign(
+      new Error(`Could not detect dev server URL within ${DEV_STARTUP_TIMEOUT_MS / 1000}s`),
+      { stdoutBuf: _stdoutBuf, stderrBuf: _stderrBuf },
+    );
+  }
+
+  // Let the server stabilize
+  await new Promise((r) => setTimeout(r, 2000));
+
+  return {
+    proc,
+    serverUrl,
+    config,
+    stdoutBuf: () => _stdoutBuf,
+    stderrBuf: () => _stderrBuf,
+    startTime: start,
+  };
+}
+
+/**
+ * Kill the dev server process tree gracefully.
+ */
+export async function stopDevServer(handle: DevServerHandle): Promise<void> {
+  if (handle.proc?.pid) {
+    await killProcessTree(handle.proc.pid);
+  }
+}
+
+// ── Original runDevCheck (backward-compatible wrapper) ──────────────────
+
 export async function runDevCheck(
   projectDir: string,
   config: ProjectConfig,
 ): Promise<StepResult> {
   const start = Date.now();
   const isDbDependent = isDbDependentProject(config);
-  let proc: ReturnType<typeof Bun.spawn> | null = null;
+
+  let handle: DevServerHandle | null = null;
 
   try {
-    proc = Bun.spawn(["bun", "run", "dev"], {
-      cwd: projectDir,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: {
-        ...process.env,
-        NO_COLOR: "1",
-        BROWSER: "none",
-        FORCE_COLOR: "0",
-      },
-    });
-
-    const pid = proc.pid;
-
-    let stdoutBuf = "";
-    let stderrBuf = "";
-    const decoder = new TextDecoder();
-
-    const readStream = (
-      stream: ReadableStream<Uint8Array>,
-      target: "stdout" | "stderr",
-    ) => {
-      const reader = stream.getReader();
-      (async () => {
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            const chunk = decoder.decode(value, { stream: true });
-            if (target === "stdout") stdoutBuf += chunk;
-            else stderrBuf += chunk;
-          }
-        } catch {}
-      })();
-    };
-
-    readStream(proc.stdout as ReadableStream<Uint8Array>, "stdout");
-    readStream(proc.stderr as ReadableStream<Uint8Array>, "stderr");
-
-    let serverUrl: string | null = null;
-    const urlDeadline = Date.now() + DEV_STARTUP_TIMEOUT_MS;
-
-    while (Date.now() < urlDeadline && !serverUrl) {
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-
-      if (proc.exitCode !== null) {
-        return {
-          step: "dev-check",
-          success: false,
-          durationMs: Date.now() - start,
-          stdout: stdoutBuf.slice(-2000),
-          stderr: `Dev server exited with code ${proc.exitCode}\n${stderrBuf.slice(-2000)}`,
-          classification: classifyDevCheckError(stderrBuf, stdoutBuf, config),
-          advisory: isDbDependent,
-        };
-      }
-
-      const port = getExpectedPort(config);
-      serverUrl =
-        extractUrlFromOutput(stdoutBuf, port) || extractUrlFromOutput(stderrBuf, port);
-    }
-
-    if (!serverUrl) {
-      const fallbackUrl = getExpectedDevUrl(config);
-      try {
-        const resp = await fetch(fallbackUrl, {
-          signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
-        });
-        await resp.text();
-        serverUrl = fallbackUrl;
-      } catch {}
-    }
-
-    if (!serverUrl) {
-      return {
-        step: "dev-check",
-        success: false,
-        durationMs: Date.now() - start,
-        stdout: stdoutBuf.slice(-2000),
-        stderr: `Could not detect dev server URL within ${DEV_STARTUP_TIMEOUT_MS / 1000}s\n${stderrBuf.slice(-2000)}`,
-        classification: classifyDevCheckError(stderrBuf, stdoutBuf, config),
-        advisory: isDbDependent,
-      };
-    }
-
-    await new Promise((r) => setTimeout(r, 2000));
+    handle = await startDevServer(projectDir, config);
 
     let lastError = "";
     for (let attempt = 0; attempt < MAX_FETCH_RETRIES; attempt++) {
@@ -296,13 +336,13 @@ export async function runDevCheck(
           success: false,
           durationMs: Date.now() - start,
           stderr: `Total dev-check timeout exceeded (${TOTAL_DEV_CHECK_TIMEOUT_MS / 1000}s)\nLast error: ${lastError}`,
-          classification: classifyDevCheckError(stderrBuf, stdoutBuf, config),
+          classification: classifyDevCheckError(handle.stderrBuf(), handle.stdoutBuf(), config),
           advisory: isDbDependent,
         };
       }
 
       try {
-        const resp = await fetch(serverUrl, {
+        const resp = await fetch(handle.serverUrl, {
           signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
         });
         const body = await resp.text();
@@ -313,7 +353,7 @@ export async function runDevCheck(
             step: "dev-check",
             success: true,
             durationMs: Date.now() - start,
-            stdout: `${serverUrl} → ${resp.status} (${body.length} bytes)`,
+            stdout: `${handle.serverUrl} → ${resp.status} (${body.length} bytes)`,
             advisory: isDbDependent,
           };
         }
@@ -325,11 +365,11 @@ export async function runDevCheck(
             step: "dev-check",
             success: false,
             durationMs: Date.now() - start,
-            stdout: `${serverUrl} → ${resp.status} (${body.length} bytes)`,
+            stdout: `${handle.serverUrl} → ${resp.status} (${body.length} bytes)`,
             stderr: `Page loaded but has errors:\n${validation.errors.join("\n")}\n\nBody (first 2000 chars):\n${body.slice(0, 2000)}`,
             classification: classifyDevCheckError(
-              stderrBuf + "\n" + body,
-              stdoutBuf,
+              handle.stderrBuf() + "\n" + body,
+              handle.stdoutBuf(),
               config,
             ),
             advisory: isDbDependent,
@@ -349,23 +389,25 @@ export async function runDevCheck(
       step: "dev-check",
       success: false,
       durationMs: Date.now() - start,
-      stdout: stdoutBuf.slice(-2000),
-      stderr: `Failed to get valid response from ${serverUrl} after ${MAX_FETCH_RETRIES} attempts\nLast error: ${lastError}\nServer stderr:\n${stderrBuf.slice(-1000)}`,
-      classification: classifyDevCheckError(stderrBuf, stdoutBuf, config),
+      stdout: handle.stdoutBuf().slice(-2000),
+      stderr: `Failed to get valid response from ${handle.serverUrl} after ${MAX_FETCH_RETRIES} attempts\nLast error: ${lastError}\nServer stderr:\n${handle.stderrBuf().slice(-1000)}`,
+      classification: classifyDevCheckError(handle.stderrBuf(), handle.stdoutBuf(), config),
       advisory: isDbDependent,
     };
   } catch (error) {
+    const err = error as Error & { stdoutBuf?: string; stderrBuf?: string };
     return {
       step: "dev-check",
       success: false,
       durationMs: Date.now() - start,
-      stderr: error instanceof Error ? error.message : String(error),
-      classification: "unknown",
-      advisory: isDbDependentProject(config),
+      stdout: err.stdoutBuf?.slice(-2000),
+      stderr: `${err.message}\n${err.stderrBuf?.slice(-2000) ?? ""}`,
+      classification: classifyDevCheckError(err.stderrBuf ?? "", err.stdoutBuf ?? "", config),
+      advisory: isDbDependent,
     };
   } finally {
-    if (proc?.pid) {
-      await killProcessTree(proc.pid);
+    if (handle) {
+      await stopDevServer(handle);
     }
   }
 }

--- a/testing/lib/major-dep-combos.test.ts
+++ b/testing/lib/major-dep-combos.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  parseMajorUpdatesFromDiff,
+  buildMajorDepCombos,
+  buildMajorDepCombosFromDiff,
+} from "./major-dep-combos";
+
+describe("parseMajorUpdatesFromDiff", () => {
+  it("detects a simple major version bump", () => {
+    const diff = `
+-  vitest: "^3.1.1",
++  vitest: "^4.0.0",
+`;
+    const result = parseMajorUpdatesFromDiff(diff);
+    expect(result).toEqual([{ name: "vitest", oldMajor: 3, newMajor: 4 }]);
+  });
+
+  it("detects multiple major bumps", () => {
+    const diff = `
+-  mongoose: "^8.14.0",
++  mongoose: "^9.3.1",
+-  "stripe": "^17.5.0",
++  "stripe": "^20.4.1",
+`;
+    const result = parseMajorUpdatesFromDiff(diff);
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.name === "mongoose")).toEqual({
+      name: "mongoose",
+      oldMajor: 8,
+      newMajor: 9,
+    });
+    expect(result.find((r) => r.name === "stripe")).toEqual({
+      name: "stripe",
+      oldMajor: 17,
+      newMajor: 20,
+    });
+  });
+
+  it("ignores patch/minor bumps", () => {
+    const diff = `
+-  hono: "^4.8.2",
++  hono: "^4.12.8",
+-  express: "^5.1.0",
++  express: "^5.2.1",
+`;
+    const result = parseMajorUpdatesFromDiff(diff);
+    expect(result).toHaveLength(0);
+  });
+
+  it("ignores downgrades", () => {
+    const diff = `
+-  "next-auth": "^5.0.0-beta.28",
++  "next-auth": "^4.24.13",
+`;
+    const result = parseMajorUpdatesFromDiff(diff);
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles scoped packages", () => {
+    const diff = `
+-  "@angular/core": "^19.2.0",
++  "@angular/core": "^21.2.5",
+-  "@storybook/react": "^8.6.0",
++  "@storybook/react": "^10.3.1",
+`;
+    const result = parseMajorUpdatesFromDiff(diff);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.name).toBe("@angular/core");
+    expect(result[1]!.name).toBe("@storybook/react");
+  });
+
+  it("handles tilde ranges", () => {
+    const diff = `
+-  "some-pkg": "~2.5.0",
++  "some-pkg": "~3.0.0",
+`;
+    const result = parseMajorUpdatesFromDiff(diff);
+    expect(result).toEqual([{ name: "some-pkg", oldMajor: 2, newMajor: 3 }]);
+  });
+
+  it("returns empty for no diff", () => {
+    expect(parseMajorUpdatesFromDiff("")).toHaveLength(0);
+    expect(parseMajorUpdatesFromDiff("no version changes here")).toHaveLength(0);
+  });
+});
+
+describe("buildMajorDepCombos", () => {
+  it("returns combos for matched packages", () => {
+    const combos = buildMajorDepCombos(["vitest", "mongoose"]);
+    expect(combos.length).toBeGreaterThanOrEqual(2);
+
+    const labels = combos.map((c) => c.name);
+    expect(labels).toContain("major-vitest-react");
+    expect(labels).toContain("major-mongoose-next");
+  });
+
+  it("matches scoped packages via glob patterns", () => {
+    const combos = buildMajorDepCombos(["@angular/core", "@angular/common"]);
+    const labels = combos.map((c) => c.name);
+    expect(labels).toContain("major-angular");
+  });
+
+  it("matches @storybook/* glob", () => {
+    const combos = buildMajorDepCombos(["@storybook/react"]);
+    const labels = combos.map((c) => c.name);
+    expect(labels).toContain("major-storybook-react");
+  });
+
+  it("returns empty for unmatched packages", () => {
+    const combos = buildMajorDepCombos(["some-unknown-pkg"]);
+    expect(combos).toHaveLength(0);
+  });
+
+  it("caps at 15 combos", () => {
+    // Pass every possible package to hit all rules
+    const allPkgs = [
+      "astro", "@angular/core", "vitest", "storybook", "stripe", "mongoose",
+      "@clerk/nextjs", "sanity", "streamdown", "langchain", "resend",
+      "nodemailer", "pino", "@sentry/node", "inngest", "@mikro-orm/core",
+      "nanostores", "cypress", "@paddle/paddle-node-sdk", "mailgun.js", "posthog-node",
+    ];
+    const combos = buildMajorDepCombos(allPkgs);
+    expect(combos.length).toBeLessThanOrEqual(15);
+  });
+
+  it("produces valid combo candidates with all required fields", () => {
+    const combos = buildMajorDepCombos(["vitest"]);
+    expect(combos.length).toBeGreaterThan(0);
+
+    const combo = combos[0]!;
+    expect(combo.ecosystem).toBe("typescript");
+    expect(combo.name).toMatch(/^major-/);
+    expect(combo.config).toBeDefined();
+    expect(combo.config.projectName).toBe(combo.name);
+    expect(combo.fingerprint).toBeDefined();
+    expect(combo.fingerprintKey).toBeTruthy();
+    expect(combo.command).toContain("bun create better-fullstack@latest");
+  });
+
+  it("sorts by priority descending", () => {
+    // astro (9) should come before inngest (5)
+    const combos = buildMajorDepCombos(["astro", "inngest"]);
+    const astroIdx = combos.findIndex((c) => c.name === "major-astro-react");
+    const inngestIdx = combos.findIndex((c) => c.name === "major-inngest-jobs");
+    expect(astroIdx).toBeLessThan(inngestIdx);
+  });
+});
+
+describe("buildMajorDepCombosFromDiff", () => {
+  it("end-to-end: diff → combos", () => {
+    const diff = `
+-  vitest: "^3.1.1",
++  vitest: "^4.0.0",
+-  "@vitest/ui": "^3.1.1",
++  "@vitest/ui": "^4.0.0",
+-  mongoose: "^8.14.0",
++  mongoose: "^9.3.1",
+`;
+    const { packages, combos } = buildMajorDepCombosFromDiff(diff);
+    expect(packages).toHaveLength(3);
+    expect(combos.length).toBeGreaterThanOrEqual(2);
+
+    const labels = combos.map((c) => c.name);
+    expect(labels).toContain("major-vitest-react");
+    expect(labels).toContain("major-mongoose-next");
+  });
+
+  it("returns empty for patch-only diff", () => {
+    const diff = `
+-  hono: "^4.8.2",
++  hono: "^4.12.8",
+`;
+    const { packages, combos } = buildMajorDepCombosFromDiff(diff);
+    expect(packages).toHaveLength(0);
+    expect(combos).toHaveLength(0);
+  });
+});

--- a/testing/lib/major-dep-combos.ts
+++ b/testing/lib/major-dep-combos.ts
@@ -1,0 +1,374 @@
+import * as path from "node:path";
+import type { ProjectConfig } from "@better-fullstack/types";
+
+import { buildHistoryFingerprint, fingerprintToKey } from "./generate-combos/fingerprint";
+import { buildCommand } from "./generate-combos/render";
+import type { ComboCandidate } from "./generate-combos/types";
+import { makeBaseConfig } from "./presets";
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+type PackageComboRule = {
+  /** Packages that trigger this rule (any match suffices). Supports `*` glob suffix. */
+  packages: string[];
+  /** Partial ProjectConfig merged onto makeBaseConfig() */
+  configOverrides: Partial<ProjectConfig>;
+  /** Human-readable combo label */
+  label: string;
+  /** Higher = more important (1-10) */
+  priority: number;
+};
+
+export type MajorDepInfo = {
+  name: string;
+  oldMajor: number;
+  newMajor: number;
+};
+
+// ── Mapping Table ───────────────────────────────────────────────────────
+
+const MAX_COMBOS = 15;
+
+const PACKAGE_COMBO_RULES: PackageComboRule[] = [
+  {
+    packages: ["astro", "@astrojs/*"],
+    label: "astro-react",
+    priority: 9,
+    configOverrides: {
+      frontend: ["astro"],
+      astroIntegration: "react",
+      backend: "hono",
+      runtime: "bun",
+      database: "sqlite",
+      orm: "drizzle",
+      cssFramework: "tailwind",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["@angular/*"],
+    label: "angular",
+    priority: 8,
+    configOverrides: {
+      frontend: ["angular"],
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["vitest", "@vitest/*"],
+    label: "vitest-react",
+    priority: 8,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      testing: "vitest",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["storybook", "@storybook/*"],
+    label: "storybook-react",
+    priority: 7,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      addons: ["storybook"],
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["stripe", "@stripe/*"],
+    label: "stripe-next",
+    priority: 7,
+    configOverrides: {
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      payments: "stripe",
+      database: "sqlite",
+      orm: "drizzle",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["mongoose"],
+    label: "mongoose-next",
+    priority: 7,
+    configOverrides: {
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      database: "mongodb",
+      orm: "mongoose",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["@clerk/*"],
+    label: "clerk-next",
+    priority: 8,
+    configOverrides: {
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      auth: "clerk",
+      database: "sqlite",
+      orm: "drizzle",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["sanity", "next-sanity", "@sanity/*"],
+    label: "sanity-next",
+    priority: 6,
+    configOverrides: {
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      cms: "sanity",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["streamdown"],
+    label: "streamdown-ai",
+    priority: 6,
+    configOverrides: {
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      ai: "vercel-ai",
+      examples: ["ai"],
+      database: "sqlite",
+      orm: "drizzle",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["langchain", "@langchain/*"],
+    label: "langchain-hono",
+    priority: 6,
+    configOverrides: {
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      ai: "langchain",
+      database: "sqlite",
+      orm: "drizzle",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["resend"],
+    label: "resend-email",
+    priority: 5,
+    configOverrides: {
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      email: "resend",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["nodemailer", "@types/nodemailer"],
+    label: "nodemailer-email",
+    priority: 5,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      email: "nodemailer",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["pino", "pino-http"],
+    label: "pino-logging",
+    priority: 5,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      logging: "pino",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["@sentry/*"],
+    label: "sentry-obs",
+    priority: 6,
+    configOverrides: {
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      observability: "sentry",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["inngest"],
+    label: "inngest-jobs",
+    priority: 5,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      jobQueue: "inngest",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["@mikro-orm/*"],
+    label: "mikroorm-hono",
+    priority: 6,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "node",
+      database: "sqlite",
+      orm: "mikroorm",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["nanostores", "@nanostores/*"],
+    label: "nanostores-react",
+    priority: 4,
+    configOverrides: {
+      frontend: ["react-vite"],
+      stateManagement: "nanostores",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["cypress"],
+    label: "cypress-test",
+    priority: 5,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      testing: "cypress",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["@paddle/*"],
+    label: "paddle-next",
+    priority: 5,
+    configOverrides: {
+      frontend: ["next"],
+      backend: "self",
+      runtime: "none",
+      payments: "paddle",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["mailgun.js"],
+    label: "mailgun-email",
+    priority: 4,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      email: "mailgun",
+    } as Partial<ProjectConfig>,
+  },
+  {
+    packages: ["posthog-node", "posthog-js"],
+    label: "posthog-analytics",
+    priority: 4,
+    configOverrides: {
+      frontend: ["react-vite"],
+      backend: "hono",
+      runtime: "bun",
+      featureFlags: "posthog",
+    } as Partial<ProjectConfig>,
+  },
+];
+
+// ── Diff Parsing ────────────────────────────────────────────────────────
+
+/**
+ * Parse a git diff of add-deps.ts and return packages whose major version increased.
+ *
+ * Looks for paired `-` / `+` lines like:
+ *   -  ai: "^6.0.3",
+ *   +  ai: "^7.0.0",
+ */
+export function parseMajorUpdatesFromDiff(diffText: string): MajorDepInfo[] {
+  const removedVersions = new Map<string, number>();
+  const results: MajorDepInfo[] = [];
+
+  // Match lines like:  -  "package": "^1.2.3",  or  -  package: "^1.2.3",
+  const lineRegex = /^\s*[-+]\s*"?([^":\s]+)"?\s*:\s*"[\^~]?(\d+)\./gm;
+
+  for (const match of diffText.matchAll(lineRegex)) {
+    const fullLine = match[0];
+    const pkg = match[1]!;
+    const major = Number.parseInt(match[2]!, 10);
+
+    if (fullLine.trimStart().startsWith("-")) {
+      removedVersions.set(pkg, major);
+    } else if (fullLine.trimStart().startsWith("+")) {
+      const oldMajor = removedVersions.get(pkg);
+      if (oldMajor !== undefined && major > oldMajor) {
+        results.push({ name: pkg, oldMajor, newMajor: major });
+      }
+    }
+  }
+
+  return results;
+}
+
+// ── Combo Builder ───────────────────────────────────────────────────────
+
+function packageMatchesRule(packageName: string, rulePattern: string): boolean {
+  if (rulePattern.endsWith("/*")) {
+    const prefix = rulePattern.slice(0, -2);
+    return packageName.startsWith(prefix + "/") || packageName === prefix;
+  }
+  return packageName === rulePattern;
+}
+
+function ruleMatchesMajorPackages(rule: PackageComboRule, majorPackageNames: string[]): boolean {
+  return rule.packages.some((pattern) =>
+    majorPackageNames.some((pkg) => packageMatchesRule(pkg, pattern)),
+  );
+}
+
+/**
+ * Build the minimal set of ComboCandidate[] that cover the given major-update packages.
+ */
+export function buildMajorDepCombos(majorPackages: string[]): ComboCandidate[] {
+  const majorNames = majorPackages.map((p) => (typeof p === "string" ? p : ""));
+
+  const matchedRules = PACKAGE_COMBO_RULES.filter((rule) =>
+    ruleMatchesMajorPackages(rule, majorNames),
+  );
+
+  // Sort by priority descending, cap at MAX_COMBOS
+  matchedRules.sort((a, b) => b.priority - a.priority);
+  const selected = matchedRules.slice(0, MAX_COMBOS);
+
+  return selected.map((rule) => {
+    const name = `major-${rule.label}`;
+    const base = makeBaseConfig(name, "typescript");
+    const config = {
+      ...base,
+      ...rule.configOverrides,
+      projectName: name,
+      projectDir: path.resolve(process.cwd(), name),
+      relativePath: name,
+    } as ProjectConfig;
+
+    const fingerprint = buildHistoryFingerprint(config);
+    const fingerprintKey = fingerprintToKey(fingerprint);
+
+    return {
+      ecosystem: "typescript" as const,
+      name,
+      config,
+      fingerprint,
+      fingerprintKey,
+      command: buildCommand(name, config),
+    };
+  });
+}
+
+/**
+ * Convenience: parse diff + build combos in one call.
+ */
+export function buildMajorDepCombosFromDiff(diffText: string): {
+  packages: MajorDepInfo[];
+  combos: ComboCandidate[];
+} {
+  const packages = parseMajorUpdatesFromDiff(diffText);
+  const combos = buildMajorDepCombos(packages.map((p) => p.name));
+  return { packages, combos };
+}

--- a/testing/lib/presets.ts
+++ b/testing/lib/presets.ts
@@ -5,7 +5,7 @@ import { buildHistoryFingerprint, fingerprintToKey } from "./generate-combos/fin
 import { buildCommand } from "./generate-combos/render";
 import type { ComboCandidate } from "./generate-combos/types";
 
-function makeBaseConfig(name: string, ecosystem: Ecosystem): ProjectConfig {
+export function makeBaseConfig(name: string, ecosystem: Ecosystem): ProjectConfig {
   return {
     projectName: name,
     projectDir: path.resolve(process.cwd(), name),

--- a/testing/lib/route-check.ts
+++ b/testing/lib/route-check.ts
@@ -1,0 +1,152 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { ProjectConfig } from "@better-fullstack/types";
+
+import type { DevServerHandle } from "./dev-check";
+import { HTML_ERROR_PATTERNS } from "./dev-check";
+import type { StepResult } from "./verify";
+
+const ROUTE_CHECK_TIMEOUT_MS = 30_000;
+
+const FRAMEWORK_ROUTES: Record<string, string[]> = {
+  next: ["/"],
+  "tanstack-start": ["/"],
+  "tanstack-router": ["/"],
+  "react-router": ["/"],
+  "react-vite": ["/"],
+  svelte: ["/"],
+  nuxt: ["/"],
+  astro: ["/"],
+  "solid-start": ["/"],
+  solid: ["/"],
+  angular: ["/"],
+  qwik: ["/"],
+  redwood: ["/"],
+  fresh: ["/"],
+};
+
+function getRoutesForConfig(config: ProjectConfig): string[] {
+  const frontend = Array.isArray(config.frontend)
+    ? config.frontend.find((f: string) => f !== "none") ?? "none"
+    : config.frontend;
+
+  return FRAMEWORK_ROUTES[frontend] ?? ["/"];
+}
+
+/**
+ * Use Playwright to visit routes on a running dev server and check for errors.
+ * Requires `playwright` to be installed.
+ */
+export async function runRouteCheck(
+  handle: DevServerHandle,
+  outputDir?: string,
+): Promise<StepResult> {
+  const start = Date.now();
+  const routes = getRoutesForConfig(handle.config);
+  const errors: string[] = [];
+
+  // biome-ignore lint: Playwright is an optional peer dep, dynamically imported
+  let chromium: any;
+  try {
+    const pw = await import("playwright");
+    chromium = pw.chromium;
+  } catch {
+    return {
+      step: "route-check",
+      success: true,
+      durationMs: Date.now() - start,
+      skipped: true,
+      stdout: "Playwright not installed — skipping route check",
+    };
+  }
+
+  let browser: any = null;
+
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    const consoleErrors: string[] = [];
+    page.on("console", (msg: any) => {
+      if (msg.type() === "error") {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    for (const route of routes) {
+      const url = `${handle.serverUrl}${route}`;
+      consoleErrors.length = 0;
+
+      try {
+        const response = await page.goto(url, {
+          waitUntil: "networkidle",
+          timeout: ROUTE_CHECK_TIMEOUT_MS,
+        });
+
+        const status = response?.status() ?? 0;
+        if (status >= 400) {
+          errors.push(`${route}: HTTP ${status}`);
+        }
+
+        const content = await page.content();
+
+        for (const pattern of HTML_ERROR_PATTERNS) {
+          if (pattern.test(content)) {
+            errors.push(`${route}: HTML error pattern "${pattern.source}"`);
+          }
+        }
+
+        if (consoleErrors.length > 0) {
+          const unique = [...new Set(consoleErrors)];
+          for (const err of unique.slice(0, 5)) {
+            errors.push(`${route}: console.error: ${err.slice(0, 200)}`);
+          }
+        }
+
+        // Screenshot on failure
+        if (errors.length > 0 && outputDir) {
+          const screenshotDir = join(outputDir, "screenshots");
+          await mkdir(screenshotDir, { recursive: true });
+          const filename = `${handle.config.projectName}-${route.replace(/\//g, "_") || "root"}.png`;
+          await page.screenshot({ path: join(screenshotDir, filename), fullPage: true });
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        errors.push(`${route}: Navigation failed: ${msg.slice(0, 300)}`);
+      }
+    }
+
+    await context.close();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      step: "route-check",
+      success: false,
+      durationMs: Date.now() - start,
+      stderr: `Playwright error: ${msg}`,
+      classification: "unknown",
+    };
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+
+  if (errors.length > 0) {
+    return {
+      step: "route-check",
+      success: false,
+      durationMs: Date.now() - start,
+      stderr: errors.join("\n"),
+      classification: "template",
+    };
+  }
+
+  return {
+    step: "route-check",
+    success: true,
+    durationMs: Date.now() - start,
+    stdout: `All ${routes.length} route(s) passed Playwright check`,
+  };
+}

--- a/testing/lib/verify.ts
+++ b/testing/lib/verify.ts
@@ -2,7 +2,8 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { Ecosystem, ProjectConfig } from "@better-fullstack/types";
 
-import { runDevCheck } from "./dev-check";
+import { runDevCheck, startDevServer, stopDevServer, isDbDependentProject } from "./dev-check";
+import { runRouteCheck } from "./route-check";
 
 const STEP_TIMEOUT_MS = 300_000; // 5 minutes per step
 
@@ -21,6 +22,8 @@ export type StepResult = {
 export type VerifyOptions = {
   devCheck?: boolean;
   strict?: boolean;
+  routeCheck?: boolean;
+  outputDir?: string;
   config?: ProjectConfig;
 };
 
@@ -196,11 +199,43 @@ export async function verifyTypeScript(
   if (!steps.at(-1)!.success) return wrapResult("typescript", comboName, projectDir, steps);
 
   if (options?.devCheck && options?.config) {
-    const devCheckResult = await runDevCheck(projectDir, options.config);
-    if (options.strict) {
-      devCheckResult.advisory = false;
+    if (options.routeCheck) {
+      // Start server, run dev-check validation, then route-check, then stop
+      const isDbDep = isDbDependentProject(options.config);
+      try {
+        const handle = await startDevServer(projectDir, options.config);
+        try {
+          const devStep: StepResult = {
+            step: "dev-check",
+            success: true,
+            durationMs: Date.now() - handle.startTime,
+            stdout: `${handle.serverUrl} → server started`,
+            advisory: options.strict ? false : isDbDep,
+          };
+          steps.push(devStep);
+          steps.push(await runRouteCheck(handle, options.outputDir));
+        } finally {
+          await stopDevServer(handle);
+        }
+      } catch (error) {
+        const err = error as Error & { stdoutBuf?: string; stderrBuf?: string };
+        steps.push({
+          step: "dev-check",
+          success: false,
+          durationMs: 0,
+          stderr: `${err.message}\n${err.stderrBuf?.slice(-2000) ?? ""}`,
+          classification: "unknown",
+          advisory: options.strict ? false : isDbDep,
+        });
+        steps.push(skippedStep("route-check"));
+      }
+    } else {
+      const devCheckResult = await runDevCheck(projectDir, options.config);
+      if (options.strict) {
+        devCheckResult.advisory = false;
+      }
+      steps.push(devCheckResult);
     }
-    steps.push(devCheckResult);
   }
   if (isConvex) {
     steps.push(skippedStep("build"));

--- a/testing/smoke-test.ts
+++ b/testing/smoke-test.ts
@@ -5,9 +5,12 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { Ecosystem } from "@better-fullstack/types";
 
+import { readFileSync } from "node:fs";
+
 import { generateBatch } from "./lib/generate-combos/options";
 import { createSeededRandom, seedFromString } from "./lib/generate-combos/seed-random";
 import type { ComboCandidate, GeneratorArgs, HistoricalLedger } from "./lib/generate-combos/types";
+import { buildMajorDepCombos, buildMajorDepCombosFromDiff, type MajorDepInfo } from "./lib/major-dep-combos";
 import { getPresetCombos } from "./lib/presets";
 import { getVerifier, type VerifyResult } from "./lib/verify";
 
@@ -20,7 +23,11 @@ interface SmokeTestArgs {
   output: string;
   devCheck: boolean;
   strict?: boolean;
+  routeCheck: boolean;
   preset?: string;
+  majorDeps?: boolean;
+  majorDepsPackages?: string;
+  majorDepsDiff?: string;
 }
 
 // ── Arg Parsing ─────────────────────────────────────────────────────────
@@ -31,6 +38,7 @@ function parseArgs(argv: string[]): SmokeTestArgs {
     count: 14,
     output: resolve(process.cwd(), "testing/.smoke-output"),
     devCheck: false,
+    routeCheck: false,
   };
 
   let countExplicit = false;
@@ -70,14 +78,31 @@ function parseArgs(argv: string[]): SmokeTestArgs {
       case "--strict":
         args.strict = true;
         break;
+      case "--route-check":
+        args.routeCheck = true;
+        args.devCheck = true; // route-check implies dev-check
+        break;
       case "--preset":
         if (next) args.preset = next;
+        i++;
+        break;
+      case "--major-deps":
+        args.majorDeps = true;
+        break;
+      case "--major-deps-packages":
+        if (next) args.majorDepsPackages = next;
+        args.majorDeps = true;
+        i++;
+        break;
+      case "--major-deps-diff":
+        if (next) args.majorDepsDiff = next;
+        args.majorDeps = true;
         i++;
         break;
     }
   }
 
-  if (args.preset && !countExplicit) {
+  if ((args.preset || args.majorDeps) && !countExplicit) {
     args.count = 0;
   }
 
@@ -186,13 +211,19 @@ async function scaffoldProject(
 function formatMarkdownSummary(
   seed: string,
   results: VerifyResult[],
-  options?: { presetId?: string; devCheckEnabled?: boolean },
+  options?: { presetId?: string; devCheckEnabled?: boolean; majorDepInfo?: MajorDepInfo[] },
 ): string {
-  const { presetId, devCheckEnabled } = options ?? {};
+  const { presetId, devCheckEnabled, majorDepInfo: depInfo } = options ?? {};
   const passed = results.filter((r) => r.overallSuccess).length;
   const failed = results.filter((r) => !r.overallSuccess).length;
 
-  let md = "## Smoke Test Results\n\n";
+  let md = depInfo ? "## Major Dependency Smoke Test Results\n\n" : "## Smoke Test Results\n\n";
+
+  if (depInfo && depInfo.length > 0) {
+    const pkgList = depInfo.map((p) => `${p.name} ^${p.oldMajor}\u2192^${p.newMajor}`).join(", ");
+    md += `**Packages tested:** ${pkgList}\n`;
+  }
+
   md += `**Seed**: \`${seed}\`\n`;
   md += `**Total**: ${results.length} | **Passed**: ${passed} | **Failed**: ${failed}\n\n`;
 
@@ -249,7 +280,54 @@ function formatMarkdownSummary(
 const args = parseArgs(process.argv.slice(2));
 
 let combos: ComboCandidate[];
-if (args.preset) {
+let majorDepInfo: MajorDepInfo[] | undefined;
+
+if (args.majorDeps) {
+  // Major-dependency mode: build combos targeting specific package updates
+  let majorPackageNames: string[];
+
+  if (args.majorDepsPackages) {
+    majorPackageNames = args.majorDepsPackages.split(",").map((s) => s.trim()).filter(Boolean);
+    combos = buildMajorDepCombos(majorPackageNames);
+  } else if (args.majorDepsDiff) {
+    const diffText = readFileSync(args.majorDepsDiff, "utf-8");
+    const result = buildMajorDepCombosFromDiff(diffText);
+    majorDepInfo = result.packages;
+    combos = result.combos;
+    majorPackageNames = result.packages.map((p) => p.name);
+  } else {
+    // Auto-detect from git diff
+    try {
+      const proc = Bun.spawn(
+        ["git", "diff", "HEAD~1", "--", "packages/template-generator/src/utils/add-deps.ts"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const diffText = await new Response(proc.stdout).text();
+      await proc.exited;
+      const result = buildMajorDepCombosFromDiff(diffText);
+      majorDepInfo = result.packages;
+      combos = result.combos;
+      majorPackageNames = result.packages.map((p) => p.name);
+    } catch {
+      console.error("Failed to auto-detect major deps from git diff. Use --major-deps-packages or --major-deps-diff.");
+      process.exit(1);
+    }
+  }
+
+  if (combos.length === 0) {
+    console.log("No major-dep combos to test (no matching package rules found).");
+    process.exit(0);
+  }
+
+  const flags = [args.devCheck && "dev-check", args.routeCheck && "route-check"].filter(Boolean).join(", ");
+  console.log(`Running major-deps smoke test (${combos.length} combo(s) for ${majorPackageNames.length} package(s))${flags ? ` [${flags}]` : ""}\n`);
+  if (majorDepInfo) {
+    for (const p of majorDepInfo) {
+      console.log(`  ${p.name}: ^${p.oldMajor} → ^${p.newMajor}`);
+    }
+    console.log();
+  }
+} else if (args.preset) {
   combos = getPresetCombos(args.preset);
   console.log(`Running smoke test for preset "${args.preset}" (${combos.length} combo(s))${args.devCheck ? " [dev-check enabled]" : ""}\n`);
 } else {
@@ -294,6 +372,8 @@ for (const combo of combos) {
   const result = await verify(combo.name, scaffoldResult.projectDir, {
     devCheck: args.devCheck,
     strict: args.strict,
+    routeCheck: args.routeCheck,
+    outputDir: args.output,
     config: combo.config,
   });
   results.push(result);
@@ -332,6 +412,7 @@ await writeFile(
   formatMarkdownSummary(args.seed, results, {
     presetId: args.preset,
     devCheckEnabled: args.devCheck,
+    majorDepInfo,
   }),
 );
 


### PR DESCRIPTION
## Summary
- Add automated smoke testing for major dependency version bumps in deps-check PRs
- When the weekly `deps-check` workflow detects major updates, a new `major-deps-smoke` CI job generates targeted template combinations, scaffolds them, and runs full verification: install → typecheck → lint → dev server → Playwright route check
- Results posted as CI step summary with pass/fail table and failure details

## What's New

### Package-to-Combo Mapping (`testing/lib/major-dep-combos.ts`)
- 21 hardcoded rules mapping package groups (e.g., `@angular/*`, `vitest`, `stripe`) to minimal template configs
- `parseMajorUpdatesFromDiff()` parses git diffs to detect major version bumps
- `buildMajorDepCombos()` generates covering `ComboCandidate[]` sorted by priority, capped at 15

### Playwright Route Checker (`testing/lib/route-check.ts`)
- Launches headless chromium after dev server starts
- Visits framework-specific routes, checks for console errors + HTML error patterns
- Screenshots on failure for debugging

### Dev Server Lifecycle Refactor (`testing/lib/dev-check.ts`)
- Extracted `startDevServer()` / `stopDevServer()` / `DevServerHandle` type
- `runDevCheck()` remains backward-compatible as a thin wrapper
- Exported `HTML_ERROR_PATTERNS`, `validateHtmlResponse`, `isDbDependentProject` for reuse

### Smoke Test Extensions (`testing/smoke-test.ts`)
- New flags: `--major-deps`, `--major-deps-packages`, `--major-deps-diff`, `--route-check`
- Enhanced markdown summary includes package version transition info

### CI Workflow (`deps-check.yaml`)
- `check-versions` job now outputs `has_major_updates` and `major_packages`
- New `major-deps-smoke` job triggers only when major updates are detected

## Test plan
- [x] 16 unit tests pass with 100% coverage on mapping logic
- [x] 34 existing snapshot tests pass (no regressions)
- [ ] Local run: `bun run testing/smoke-test.ts --major-deps --major-deps-packages "vitest,mongoose"`
- [ ] CI dry run: trigger `deps-check.yaml` manually to verify `major-deps-smoke` job activates