### PR TITLE
ci: add CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Add CodeQL SAST scanning workflow for JavaScript/TypeScript
- Runs on push to main, PRs targeting main, and weekly Monday 6am UTC
- Proper permissions (actions: read, contents: read, security-events: write)
- Concurrency group matching repo conventions
- SARIF category for future multi-language support

## Test plan
- [x] Workflow file is valid YAML
- [x] Permissions match official CodeQL starter template
- [x] Concurrency pattern matches existing workflows
- [x] Schedule doesn't collide with other cron jobs (smoke 3am, e2e 4am, deps 9/10am)