### PR TITLE
fix(cli): improve help text and post-install instructions

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -143,7 +143,7 @@ export async function displayPostInstallInstructions(
   }
 
   if (hasFresh) {
-    output += `${pc.yellow("NOTE:")} Fresh projects require ${pc.white("deno")} on your PATH\n`;
+    output += `${pc.yellow("NOTE:")} Fresh projects require ${pc.white("deno")} on your PATH.\n   Install: ${pc.underline("https://docs.deno.com/runtime/getting_started/installation/")}\n`;
   }
 
   if (database === "sqlite" && dbSetup !== "d1") {
@@ -350,7 +350,7 @@ async function getDatabaseInstructions(
   if (orm === "prisma") {
     if (database === "mongodb" && dbSetup === "docker") {
       instructions.push(
-        `${pc.yellow("WARNING:")} Prisma + MongoDB + Docker combination\n   may not work.`,
+        `${pc.yellow("WARNING:")} Prisma + MongoDB + Docker: this combination has known issues.\n   Consider using MongoDB Atlas (${pc.underline("https://www.mongodb.com/atlas")}) for reliable Prisma + MongoDB support.`,
       );
     }
     if (dbSetup === "docker") {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -298,7 +298,7 @@ export const router = os.router({
       log.message(`Please visit ${DOCS_URL}`);
     }
   }),
-  builder: os.meta({ description: "Open the web-based stack builder" }).handler(async () => {
+  builder: os.meta({ description: "Open the interactive web-based stack builder at better-fullstack.dev" }).handler(async () => {
     const BUILDER_URL = "https://better-fullstack-web.vercel.app/new";
     try {
       await openUrl(BUILDER_URL);
@@ -308,7 +308,7 @@ export const router = os.router({
     }
   }),
   add: os
-    .meta({ description: "Add addons to an existing Better Fullstack project" })
+    .meta({ description: "Add addons or deployment targets to an existing Better Fullstack project" })
     .input(
       z.object({
         addons: z.array(AddonsSchema).optional().describe("Addons to add"),
@@ -327,7 +327,7 @@ export const router = os.router({
       await addHandler(input as AddInput);
     }),
   history: os
-    .meta({ description: "Show project creation history" })
+    .meta({ description: "Show history of scaffolded projects with reproducible commands" })
     .input(
       z.object({
         limit: z.number().optional().default(10).describe("Number of entries to show"),


### PR DESCRIPTION
## Summary

- Improve terse help text descriptions for `add`, `builder`, `history` commands
- Fix incomplete post-install instructions for Prisma + MongoDB + Docker and Fresh + Deno

## Changes

**Help text (`apps/cli/src/index.ts`):**
- `add`: now mentions deployment targets
- `builder`: now includes the URL
- `history`: now mentions reproducible commands

**Post-install (`apps/cli/src/helpers/core/post-installation.ts`):**
- Prisma + MongoDB + Docker: changed vague "may not work" to actionable guidance with MongoDB Atlas link
- Fresh: added Deno installation link

## Test plan

- [ ] Run `create-better-fullstack --help` and verify improved descriptions
- [ ] Scaffold a Fresh project, verify Deno link in post-install output