### PR TITLE
fix(templates): inngest v4 API and unused param fixes in context templates

### DIFF
--- a/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/orpc/server/src/context.ts.hbs
@@ -4,72 +4,80 @@ import type { NextRequest } from "next/server";
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 
-export async function createContext(req: NextRequest) {
 {{#if (eq auth "better-auth")}}
+export async function createContext(req: NextRequest) {
   const session = await auth.api.getSession({
     headers: req.headers,
   });
   return {
     session,
   };
-{{else}}
-  return {}
-{{/if}}
 }
+{{else}}
+export async function createContext(_req: NextRequest) {
+  return {}
+}
+{{/if}}
 
 {{else if (and (eq backend 'self') (includes frontend "tanstack-start"))}}
 {{#if (eq auth "better-auth")}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 
-export async function createContext({ req }: { req: Request }) {
 {{#if (eq auth "better-auth")}}
+export async function createContext({ req }: { req: Request }) {
 	const session = await auth.api.getSession({
 		headers: req.headers,
 	});
 	return {
 		session,
 	};
-{{else}}
-	return {};
-{{/if}}
 }
+{{else}}
+export async function createContext(_opts: { req: Request }) {
+	return {};
+}
+{{/if}}
 
 {{else if (and (eq backend 'self') (includes frontend "svelte"))}}
 {{#if (eq auth "better-auth")}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 
-export async function createContext(req: Request) {
 {{#if (eq auth "better-auth")}}
+export async function createContext(req: Request) {
   const session = await auth.api.getSession({
     headers: req.headers,
   });
   return {
     session,
   };
-{{else}}
-  return {}
-{{/if}}
 }
+{{else}}
+export async function createContext(_req: Request) {
+  return {}
+}
+{{/if}}
 
 {{else if (and (eq backend 'self') (includes frontend "solid-start"))}}
 {{#if (eq auth "better-auth")}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 
-export async function createContext(req: Request) {
 {{#if (eq auth "better-auth")}}
+export async function createContext(req: Request) {
   const session = await auth.api.getSession({
     headers: req.headers,
   });
   return {
     session,
   };
-{{else}}
-  return {}
-{{/if}}
 }
+{{else}}
+export async function createContext(_req: Request) {
+  return {}
+}
+{{/if}}
 
 {{else if (eq backend 'hono')}}
 import type { Context as HonoContext } from "hono";
@@ -162,21 +170,23 @@ import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 
-export async function createContext(req: IncomingHttpHeaders) {
 {{#if (eq auth "better-auth")}}
+export async function createContext(req: IncomingHttpHeaders) {
   const session = await auth.api.getSession({
     headers: fromNodeHeaders(req),
   });
   return {
     session,
   };
+}
 {{else}}
+export async function createContext(_req: IncomingHttpHeaders) {
   // No auth configured
   return {
     session: null,
   };
-{{/if}}
 }
+{{/if}}
 
 {{else if (eq backend 'nitro')}}
 import type { IncomingMessage } from "node:http";

--- a/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
+++ b/packages/template-generator/templates/api/trpc/server/src/context.ts.hbs
@@ -4,42 +4,46 @@ import type { NextRequest } from "next/server";
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 
-export async function createContext(req: NextRequest) {
 {{#if (eq auth "better-auth")}}
+export async function createContext(req: NextRequest) {
   const session = await auth.api.getSession({
     headers: req.headers,
   });
   return {
     session,
   };
+}
 {{else}}
+export async function createContext(_req: NextRequest) {
   // No auth configured
   return {
     session: null,
   };
-{{/if}}
 }
+{{/if}}
 
 {{else if (and (eq backend 'self') (includes frontend "tanstack-start"))}}
 {{#if (eq auth "better-auth")}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 
-export async function createContext({ req }: { req: Request }) {
 {{#if (eq auth "better-auth")}}
+export async function createContext({ req }: { req: Request }) {
 	const session = await auth.api.getSession({
 		headers: req.headers,
 	});
 	return {
 		session,
 	};
+}
 {{else}}
+export async function createContext(_opts: { req: Request }) {
 	// No auth configured
 	return {
 		session: null,
 	};
-{{/if}}
 }
+{{/if}}
 
 {{else if (eq backend 'hono')}}
 import type { Context as HonoContext } from "hono";

--- a/packages/template-generator/templates/job-queue/inngest/server/base/src/inngest/functions.ts.hbs
+++ b/packages/template-generator/templates/job-queue/inngest/server/base/src/inngest/functions.ts.hbs
@@ -10,8 +10,8 @@ export const sendEmail = inngest.createFunction(
     id: "send-email",
     // Retry configuration
     retries: 3,
+    triggers: [{ event: "app/email.send" }],
   },
-  { event: "app/email.send" },
   async ({ event, step }) => {
     const { to } = event.data;
 
@@ -43,8 +43,8 @@ export const sendNotification = inngest.createFunction(
   {
     id: "send-notification",
     retries: 3,
+    triggers: [{ event: "app/notification.send" }],
   },
-  { event: "app/notification.send" },
   async ({ event, step }) => {
     const { userId, type } = event.data;
 
@@ -92,8 +92,8 @@ export const processData = inngest.createFunction(
         match: "data.dataId",
       },
     ],
+    triggers: [{ event: "app/data.process" }],
   },
-  { event: "app/data.process" },
   async ({ event, step }) => {
     const { dataId, operation } = event.data;
 
@@ -151,8 +151,10 @@ export const processData = inngest.createFunction(
  * @see https://www.inngest.com/docs/guides/scheduled-functions
  */
 export const hourlyCleanup = inngest.createFunction(
-  { id: "hourly-cleanup" },
-  { cron: "0 * * * *" }, // Every hour at minute 0
+  {
+    id: "hourly-cleanup",
+    triggers: [{ cron: "0 * * * *" }], // Every hour at minute 0
+  },
   async ({ step }) => {
     const result = await step.run("cleanup", async () => {
       // TODO: Implement your cleanup logic here
@@ -177,8 +179,10 @@ export const hourlyCleanup = inngest.createFunction(
  * Runs at 9 AM UTC - change timezone as needed
  */
 export const dailyReport = inngest.createFunction(
-  { id: "daily-report" },
-  { cron: "TZ=UTC 0 9 * * *" }, // 9 AM UTC every day
+  {
+    id: "daily-report",
+    triggers: [{ cron: "TZ=UTC 0 9 * * *" }], // 9 AM UTC every day
+  },
   async ({ step }) => {
     // Step 1: Generate report data
     const reportData = await step.run("generate-report", async () => {
@@ -220,8 +224,10 @@ export const dailyReport = inngest.createFunction(
  * Demonstrates using step.sleep for delayed execution
  */
 export const welcomeSequence = inngest.createFunction(
-  { id: "welcome-sequence" },
-  { event: "app/user.signup" },
+  {
+    id: "welcome-sequence",
+    triggers: [{ event: "app/user.signup" }],
+  },
   async ({ event, step }) => {
     const { userId, email, name } = event.data;
 


### PR DESCRIPTION
## Summary
- Migrate inngest functions template from v3 3-arg `createFunction(config, trigger, handler)` to v4 2-arg `createFunction(config, handler)` with trigger inside config as `triggers` field
- Fix unused `req` parameter in oRPC context.ts template for fastify and self backends when `auth != better-auth` (prefix with `_`)
- Apply same unused param fix to tRPC context.ts template for `self+next` and `self+tanstack-start` backends
- Add Alisha-21-cloud to homepage contributors section for Polar/Convex PR #110

## Test plan
- [x] Scaffolded `next+nestjs+inngest` combo locally — `check-types` passes
- [x] Scaffolded `astro+fastify+orpc+auth=none` combo locally — `check-types` passes
- [x] All 151 job-queue + API tests pass
- [ ] CI smoke tests should no longer hit these type errors