### PR TITLE
feat: add Ent as Go ORM option

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -789,6 +789,7 @@ function displayGoInstructions(config: ProjectConfig & { depsInstalled: boolean 
     const ormNames: Record<string, string> = {
       gorm: "GORM",
       sqlc: "sqlc",
+      ent: "Ent",
     };
     output += `${pc.cyan("•")} Database: ${ormNames[goOrm] || goOrm}\n`;
   }

--- a/apps/cli/src/prompts/go-ecosystem.ts
+++ b/apps/cli/src/prompts/go-ecosystem.ts
@@ -60,6 +60,11 @@ export async function getGoOrmChoice(goOrm?: GoOrm) {
       hint: "Generate type-safe Go code from SQL",
     },
     {
+      value: "ent" as const,
+      label: "Ent",
+      hint: "Code-first ORM by Meta with graph traversal API, 15k+ stars",
+    },
+    {
       value: "none" as const,
       label: "None",
       hint: "No ORM/database layer",

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -3048,6 +3048,14 @@ export const TECH_OPTIONS: Record<
       default: false,
     },
     {
+      id: "ent",
+      name: "Ent",
+      description: "Code-first ORM by Meta with compile-time safety and graph traversal API",
+      icon: "",
+      color: "from-blue-500 to-indigo-600",
+      default: false,
+    },
+    {
       id: "none",
       name: "No ORM",
       description: "Skip Go ORM/database layer selection",

--- a/apps/web/src/lib/tech-resource-links.ts
+++ b/apps/web/src/lib/tech-resource-links.ts
@@ -744,6 +744,7 @@ const BASE_LINKS: LinkMap = {
   chi: { docsUrl: "https://go-chi.io/", githubUrl: "https://github.com/go-chi/chi" },
   gorm: { docsUrl: "https://gorm.io/docs/", githubUrl: "https://github.com/go-gorm/gorm" },
   sqlc: { docsUrl: "https://docs.sqlc.dev/", githubUrl: "https://github.com/sqlc-dev/sqlc" },
+  ent: { docsUrl: "https://entgo.io/docs/getting-started/", githubUrl: "https://github.com/ent/ent" },
   "grpc-go": {
     docsUrl: "https://grpc.io/docs/languages/go/quickstart/",
     githubUrl: "https://github.com/grpc/grpc-go",

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -1244,6 +1244,8 @@ function generateGoReadmeContent(config: ProjectConfig): string {
     features.push("- **GORM** - Full-featured ORM for Go");
   } else if (goOrm === "sqlc") {
     features.push("- **SQLc** - Generate type-safe code from SQL");
+  } else if (goOrm === "ent") {
+    features.push("- **Ent** - Code-first ORM by Meta with graph traversal API");
   }
 
   // API
@@ -1296,6 +1298,11 @@ function generateGoReadmeContent(config: ProjectConfig): string {
     structure.push("│   │   └── database.go");
     if (goOrm === "gorm") {
       structure.push("│   ├── models/           # GORM models");
+      structure.push("│   │   └── models.go");
+      structure.push("│   └── handlers/         # HTTP handlers");
+      structure.push("│       └── handlers.go");
+    } else if (goOrm === "ent") {
+      structure.push("│   ├── models/           # Request/response types");
       structure.push("│   │   └── models.go");
       structure.push("│   └── handlers/         # HTTP handlers");
       structure.push("│       └── handlers.go");
@@ -1396,6 +1403,28 @@ cp .env.example .env
 \`\`\`bash
 sqlc generate
 \`\`\`
+`;
+  } else if (goOrm === "ent") {
+    databaseSetup = `
+## Database Setup
+
+This project uses Ent (by Meta) as the ORM. To set up:
+
+1. Copy the environment file:
+\`\`\`bash
+cp .env.example .env
+\`\`\`
+
+2. Update \`DATABASE_URL\` in \`.env\` with your database connection string.
+
+3. Generate Ent client code from schemas:
+\`\`\`bash
+go generate ./ent
+\`\`\`
+
+Supported databases:
+- SQLite (default): leave \`DATABASE_URL\` empty
+- PostgreSQL: \`DATABASE_URL=postgres://user:pass@localhost:5432/dbname?sslmode=disable\`
 `;
   }
 

--- a/packages/template-generator/templates/go-base/cmd/server/main.go.hbs
+++ b/packages/template-generator/templates/go-base/cmd/server/main.go.hbs
@@ -30,7 +30,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 {{/if}}
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 
 	"{{projectName}}/internal/database"
 {{/if}}
@@ -190,6 +190,33 @@ func main() {
 	logger.Info("Database pool connected successfully")
 {{/if}}
 	_ = pool // Use pool in your handlers
+{{/if}}
+{{#if (eq goOrm "ent")}}
+	// Initialize database (run `go generate ./ent` to use Ent client)
+	db, err := database.InitDB()
+	if err != nil {
+{{#if (eq goLogging "zap")}}
+		logger.Fatal("Failed to connect to database", zap.Error(err))
+{{else if (eq goLogging "zerolog")}}
+		logger.Fatal().Err(err).Msg("Failed to connect to database")
+{{else if (eq goLogging "slog")}}
+		logger.Error("Failed to connect to database", "error", err)
+		os.Exit(1)
+{{else}}
+		panic("Failed to connect to database: " + err.Error())
+{{/if}}
+	}
+	defer database.Close()
+{{#if (eq goLogging "zap")}}
+	logger.Info("Database connected successfully")
+{{/if}}
+{{#if (eq goLogging "zerolog")}}
+	logger.Info().Msg("Database connected successfully")
+{{/if}}
+{{#if (eq goLogging "slog")}}
+	logger.Info("Database connected successfully")
+{{/if}}
+	_ = db // Use db in your handlers
 {{/if}}
 
 {{#if (or (or (or (or (or (eq goWebFramework "gin") (eq goWebFramework "echo")) (eq goWebFramework "fiber")) (eq goWebFramework "chi")) (eq goApi "grpc-go")) (eq auth "go-better-auth"))}}

--- a/packages/template-generator/templates/go-base/ent/generate.go.hbs
+++ b/packages/template-generator/templates/go-base/ent/generate.go.hbs
@@ -1,0 +1,5 @@
+{{#if (eq goOrm "ent")}}
+package ent
+
+//go:generate go run -mod=mod entgo.io/ent/cmd/ent generate ./schema
+{{/if}}

--- a/packages/template-generator/templates/go-base/ent/schema/post.go.hbs
+++ b/packages/template-generator/templates/go-base/ent/schema/post.go.hbs
@@ -1,0 +1,46 @@
+{{#if (eq goOrm "ent")}}
+package schema
+
+import (
+	"time"
+
+	"entgo.io/ent"
+	"entgo.io/ent/schema/edge"
+	"entgo.io/ent/schema/field"
+)
+
+// Post holds the schema definition for the Post entity.
+type Post struct {
+	ent.Schema
+}
+
+// Fields of the Post.
+func (Post) Fields() []ent.Field {
+	return []ent.Field{
+		field.String("title").
+			NotEmpty(),
+		field.Text("content").
+			Default(""),
+		field.Bool("published").
+			Default(false),
+		field.Int("author_id"),
+		field.Time("created_at").
+			Default(time.Now).
+			Immutable(),
+		field.Time("updated_at").
+			Default(time.Now).
+			UpdateDefault(time.Now),
+	}
+}
+
+// Edges of the Post.
+func (Post) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.From("author", User.Type).
+			Ref("posts").
+			Field("author_id").
+			Unique().
+			Required(),
+	}
+}
+{{/if}}

--- a/packages/template-generator/templates/go-base/ent/schema/user.go.hbs
+++ b/packages/template-generator/templates/go-base/ent/schema/user.go.hbs
@@ -1,0 +1,40 @@
+{{#if (eq goOrm "ent")}}
+package schema
+
+import (
+	"time"
+
+	"entgo.io/ent"
+	"entgo.io/ent/schema/edge"
+	"entgo.io/ent/schema/field"
+)
+
+// User holds the schema definition for the User entity.
+type User struct {
+	ent.Schema
+}
+
+// Fields of the User.
+func (User) Fields() []ent.Field {
+	return []ent.Field{
+		field.String("name").
+			NotEmpty(),
+		field.String("email").
+			NotEmpty().
+			Unique(),
+		field.Time("created_at").
+			Default(time.Now).
+			Immutable(),
+		field.Time("updated_at").
+			Default(time.Now).
+			UpdateDefault(time.Now),
+	}
+}
+
+// Edges of the User.
+func (User) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.To("posts", Post.Type),
+	}
+}
+{{/if}}

--- a/packages/template-generator/templates/go-base/go.mod.hbs
+++ b/packages/template-generator/templates/go-base/go.mod.hbs
@@ -29,6 +29,11 @@ require (
 {{#if (eq goOrm "sqlc")}}
 	github.com/jackc/pgx/v5 v5.9.1
 {{/if}}
+{{#if (eq goOrm "ent")}}
+	entgo.io/ent v0.14.0
+	github.com/lib/pq v1.10.9
+	github.com/mattn/go-sqlite3 v1.14.24
+{{/if}}
 {{#if (eq goApi "grpc-go")}}
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11

--- a/packages/template-generator/templates/go-base/internal/database/database.go.hbs
+++ b/packages/template-generator/templates/go-base/internal/database/database.go.hbs
@@ -92,3 +92,89 @@ func Close() {
 	}
 }
 {{/if}}
+{{#if (eq goOrm "ent")}}
+package database
+
+import (
+	"database/sql"
+	"os"
+	"strings"
+
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var DB *sql.DB
+
+// InitDB initializes the database connection.
+// After running `go generate ./ent`, you can switch to using the Ent client directly.
+func InitDB() (*sql.DB, error) {
+	dsn := os.Getenv("DATABASE_URL")
+
+	var db *sql.DB
+	var err error
+
+	if dsn == "" {
+		// Default to SQLite for development
+		db, err = sql.Open("sqlite3", "file:app.db?cache=shared&_fk=1")
+	} else if strings.HasPrefix(dsn, "postgres") {
+		db, err = sql.Open("postgres", dsn)
+	} else {
+		// Assume SQLite file path
+		db, err = sql.Open("sqlite3", "file:"+dsn+"?cache=shared&_fk=1")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify connection
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	// Create tables if they don't exist (SQLite dev mode)
+	if dsn == "" || !strings.HasPrefix(dsn, "postgres") {
+		if _, err := db.Exec(sqliteSchema); err != nil {
+			db.Close()
+			return nil, err
+		}
+	}
+
+	DB = db
+	return DB, nil
+}
+
+// GetDB returns the database instance
+func GetDB() *sql.DB {
+	return DB
+}
+
+// Close closes the database connection
+func Close() {
+	if DB != nil {
+		DB.Close()
+	}
+}
+
+const sqliteSchema = `
+CREATE TABLE IF NOT EXISTS users (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	email TEXT NOT NULL UNIQUE,
+	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	title TEXT NOT NULL,
+	content TEXT NOT NULL DEFAULT '',
+	published BOOLEAN NOT NULL DEFAULT 0,
+	author_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+`
+{{/if}}

--- a/packages/template-generator/templates/go-base/internal/handlers/handlers.go.hbs
+++ b/packages/template-generator/templates/go-base/internal/handlers/handlers.go.hbs
@@ -4,12 +4,12 @@ package handlers
 {{#if (eq goWebFramework "gin")}}
 import (
 	"net/http"
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 	"strconv"
 {{/if}}
 
 	"github.com/gin-gonic/gin"
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 
 	"{{projectName}}/internal/database"
 	"{{projectName}}/internal/models"
@@ -459,6 +459,153 @@ func DeletePost(c *gin.Context) {
 
 	c.JSON(http.StatusNoContent, nil)
 }
+{{else if (eq goOrm "ent")}}
+// GetUsers returns all users
+func GetUsers(c *gin.Context) {
+	rows, err := database.GetDB().Query("SELECT id, name, email, created_at, updated_at FROM users ORDER BY id")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	var users []models.UserCreate
+	for rows.Next() {
+		var id int
+		var name, email string
+		var createdAt, updatedAt string
+		if err := rows.Scan(&id, &name, &email, &createdAt, &updatedAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		users = append(users, models.UserCreate{Name: name, Email: email})
+	}
+
+	c.JSON(http.StatusOK, users)
+}
+
+// GetUser returns a user by ID
+func GetUser(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	var name, email string
+	err = database.GetDB().QueryRow("SELECT name, email FROM users WHERE id = ?", id).Scan(&name, &email)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"id": id, "name": name, "email": email})
+}
+
+// CreateUser creates a new user
+func CreateUser(c *gin.Context) {
+	var input models.UserCreate
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO users (name, email) VALUES (?, ?)", input.Name, input.Email)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, _ := result.LastInsertId()
+	c.JSON(http.StatusCreated, gin.H{"id": id, "name": input.Name, "email": input.Email})
+}
+
+// UpdateUser updates a user
+func UpdateUser(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	var input models.UserUpdate
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if input.Name != nil {
+		database.GetDB().Exec("UPDATE users SET name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", *input.Name, id)
+	}
+	if input.Email != nil {
+		database.GetDB().Exec("UPDATE users SET email = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", *input.Email, id)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"id": id, "message": "User updated"})
+}
+
+// DeleteUser deletes a user
+func DeleteUser(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	_, err = database.GetDB().Exec("DELETE FROM users WHERE id = ?", id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// GetPosts returns all posts
+func GetPosts(c *gin.Context) {
+	rows, err := database.GetDB().Query("SELECT id, title, content, published, author_id, created_at, updated_at FROM posts ORDER BY id")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	var posts []gin.H
+	for rows.Next() {
+		var id, authorID int
+		var title, content string
+		var published bool
+		var createdAt, updatedAt string
+		if err := rows.Scan(&id, &title, &content, &published, &authorID, &createdAt, &updatedAt); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		posts = append(posts, gin.H{"id": id, "title": title, "content": content, "published": published, "author_id": authorID})
+	}
+
+	if posts == nil {
+		posts = []gin.H{}
+	}
+	c.JSON(http.StatusOK, posts)
+}
+
+// CreatePost creates a new post
+func CreatePost(c *gin.Context) {
+	var input models.PostCreate
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO posts (title, content, author_id) VALUES (?, ?, ?)", input.Title, input.Content, input.AuthorID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, _ := result.LastInsertId()
+	c.JSON(http.StatusCreated, gin.H{"id": id, "title": input.Title, "content": input.Content, "author_id": input.AuthorID})
+}
 {{else}}
 // HealthCheck returns server health status
 func HealthCheck(c *gin.Context) {
@@ -472,12 +619,12 @@ func HealthCheck(c *gin.Context) {
 {{#if (eq goWebFramework "echo")}}
 import (
 	"net/http"
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 	"strconv"
 {{/if}}
 
 	"github.com/labstack/echo/v4"
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 
 	"{{projectName}}/internal/database"
 	"{{projectName}}/internal/models"
@@ -881,6 +1028,118 @@ func DeletePost(c echo.Context) error {
 
 	return c.NoContent(http.StatusNoContent)
 }
+{{else if (eq goOrm "ent")}}
+// GetUsers returns all users
+func GetUsers(c echo.Context) error {
+	rows, err := database.GetDB().Query("SELECT id, name, email FROM users ORDER BY id")
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer rows.Close()
+
+	var users []map[string]any
+	for rows.Next() {
+		var id int
+		var name, email string
+		if err := rows.Scan(&id, &name, &email); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		users = append(users, map[string]any{"id": id, "name": name, "email": email})
+	}
+
+	if users == nil {
+		users = []map[string]any{}
+	}
+	return c.JSON(http.StatusOK, users)
+}
+
+// GetUser returns a user by ID
+func GetUser(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid ID"})
+	}
+
+	var name, email string
+	err = database.GetDB().QueryRow("SELECT name, email FROM users WHERE id = ?", id).Scan(&name, &email)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "User not found"})
+	}
+
+	return c.JSON(http.StatusOK, map[string]any{"id": id, "name": name, "email": email})
+}
+
+// CreateUser creates a new user
+func CreateUser(c echo.Context) error {
+	var input models.UserCreate
+	if err := c.Bind(&input); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO users (name, email) VALUES (?, ?)", input.Name, input.Email)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	id, _ := result.LastInsertId()
+	return c.JSON(http.StatusCreated, map[string]any{"id": id, "name": input.Name, "email": input.Email})
+}
+
+// DeleteUser deletes a user
+func DeleteUser(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid ID"})
+	}
+
+	_, err = database.GetDB().Exec("DELETE FROM users WHERE id = ?", id)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// GetPosts returns all posts
+func GetPosts(c echo.Context) error {
+	rows, err := database.GetDB().Query("SELECT id, title, content, published, author_id FROM posts ORDER BY id")
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer rows.Close()
+
+	var posts []map[string]any
+	for rows.Next() {
+		var id, authorID int
+		var title, content string
+		var published bool
+		if err := rows.Scan(&id, &title, &content, &published, &authorID); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
+		posts = append(posts, map[string]any{"id": id, "title": title, "content": content, "published": published, "author_id": authorID})
+	}
+
+	if posts == nil {
+		posts = []map[string]any{}
+	}
+	return c.JSON(http.StatusOK, posts)
+}
+
+// CreatePost creates a new post
+func CreatePost(c echo.Context) error {
+	var input models.PostCreate
+	if err := c.Bind(&input); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO posts (title, content, author_id) VALUES (?, ?, ?)", input.Title, input.Content, input.AuthorID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	id, _ := result.LastInsertId()
+	return c.JSON(http.StatusCreated, map[string]any{"id": id, "title": input.Title, "content": input.Content, "author_id": input.AuthorID})
+}
 {{else}}
 // HealthCheck returns server health status
 func HealthCheck(c echo.Context) error {
@@ -893,13 +1152,13 @@ func HealthCheck(c echo.Context) error {
 {{/if}}
 {{#if (eq goWebFramework "fiber")}}
 import (
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 	"net/http"
 	"strconv"
 {{/if}}
 
 	"github.com/gofiber/fiber/v2"
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 
 	"{{projectName}}/internal/database"
 	"{{projectName}}/internal/models"
@@ -1292,6 +1551,102 @@ func DeletePost(c *fiber.Ctx) error {
 
 	return c.SendStatus(http.StatusNoContent)
 }
+{{else if (eq goOrm "ent")}}
+// GetUsers returns all users
+func GetUsers(c *fiber.Ctx) error {
+	rows, err := database.GetDB().Query("SELECT id, name, email FROM users ORDER BY id")
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	defer rows.Close()
+
+	var users []fiber.Map
+	for rows.Next() {
+		var id int
+		var name, email string
+		if err := rows.Scan(&id, &name, &email); err != nil {
+			return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		users = append(users, fiber.Map{"id": id, "name": name, "email": email})
+	}
+
+	if users == nil {
+		users = []fiber.Map{}
+	}
+	return c.JSON(users)
+}
+
+// CreateUser creates a new user
+func CreateUser(c *fiber.Ctx) error {
+	var input models.UserCreate
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO users (name, email) VALUES (?, ?)", input.Name, input.Email)
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	id, _ := result.LastInsertId()
+	return c.Status(http.StatusCreated).JSON(fiber.Map{"id": id, "name": input.Name, "email": input.Email})
+}
+
+// DeleteUser deletes a user
+func DeleteUser(c *fiber.Ctx) error {
+	id, err := strconv.Atoi(c.Params("id"))
+	if err != nil {
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "Invalid ID"})
+	}
+
+	_, err = database.GetDB().Exec("DELETE FROM users WHERE id = ?", id)
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.SendStatus(http.StatusNoContent)
+}
+
+// GetPosts returns all posts
+func GetPosts(c *fiber.Ctx) error {
+	rows, err := database.GetDB().Query("SELECT id, title, content, published, author_id FROM posts ORDER BY id")
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	defer rows.Close()
+
+	var posts []fiber.Map
+	for rows.Next() {
+		var id, authorID int
+		var title, content string
+		var published bool
+		if err := rows.Scan(&id, &title, &content, &published, &authorID); err != nil {
+			return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		posts = append(posts, fiber.Map{"id": id, "title": title, "content": content, "published": published, "author_id": authorID})
+	}
+
+	if posts == nil {
+		posts = []fiber.Map{}
+	}
+	return c.JSON(posts)
+}
+
+// CreatePost creates a new post
+func CreatePost(c *fiber.Ctx) error {
+	var input models.PostCreate
+	if err := c.BodyParser(&input); err != nil {
+		return c.Status(http.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO posts (title, content, author_id) VALUES (?, ?, ?)", input.Title, input.Content, input.AuthorID)
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	id, _ := result.LastInsertId()
+	return c.Status(http.StatusCreated).JSON(fiber.Map{"id": id, "title": input.Title, "content": input.Content, "author_id": input.AuthorID})
+}
 {{else}}
 // HealthCheck returns server health status
 func HealthCheck(c *fiber.Ctx) error {
@@ -1306,7 +1661,7 @@ func HealthCheck(c *fiber.Ctx) error {
 import (
 	"encoding/json"
 	"net/http"
-{{#if (or (eq goOrm "gorm") (eq goOrm "sqlc"))}}
+{{#if (or (or (eq goOrm "gorm") (eq goOrm "sqlc")) (eq goOrm "ent"))}}
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
@@ -1859,6 +2214,138 @@ func DeletePost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+{{else if (eq goOrm "ent")}}
+// GetUsers returns all users
+func GetUsers(w http.ResponseWriter, r *http.Request) {
+	rows, err := database.GetDB().Query("SELECT id, name, email FROM users ORDER BY id")
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	var users []map[string]any
+	for rows.Next() {
+		var id int
+		var name, email string
+		if err := rows.Scan(&id, &name, &email); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		users = append(users, map[string]any{"id": id, "name": name, "email": email})
+	}
+
+	if users == nil {
+		users = []map[string]any{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(users)
+}
+
+// CreateUser creates a new user
+func CreateUser(w http.ResponseWriter, r *http.Request) {
+	var input models.UserCreate
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO users (name, email) VALUES (?, ?)", input.Name, input.Email)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	id, _ := result.LastInsertId()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]any{"id": id, "name": input.Name, "email": input.Email})
+}
+
+// DeleteUser deletes a user
+func DeleteUser(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid ID"})
+		return
+	}
+
+	_, err = database.GetDB().Exec("DELETE FROM users WHERE id = ?", id)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetPosts returns all posts
+func GetPosts(w http.ResponseWriter, r *http.Request) {
+	rows, err := database.GetDB().Query("SELECT id, title, content, published, author_id FROM posts ORDER BY id")
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	var posts []map[string]any
+	for rows.Next() {
+		var id, authorID int
+		var title, content string
+		var published bool
+		if err := rows.Scan(&id, &title, &content, &published, &authorID); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		posts = append(posts, map[string]any{"id": id, "title": title, "content": content, "published": published, "author_id": authorID})
+	}
+
+	if posts == nil {
+		posts = []map[string]any{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(posts)
+}
+
+// CreatePost creates a new post
+func CreatePost(w http.ResponseWriter, r *http.Request) {
+	var input models.PostCreate
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	result, err := database.GetDB().Exec("INSERT INTO posts (title, content, author_id) VALUES (?, ?, ?)", input.Title, input.Content, input.AuthorID)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	id, _ := result.LastInsertId()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]any{"id": id, "title": input.Title, "content": input.Content, "author_id": input.AuthorID})
 }
 {{else}}
 // HealthCheck returns server health status

--- a/packages/template-generator/templates/go-base/internal/models/models.go.hbs
+++ b/packages/template-generator/templates/go-base/internal/models/models.go.hbs
@@ -110,3 +110,32 @@ type PostUpdate struct {
 	Published *bool   `json:"published,omitempty"`
 }
 {{/if}}
+{{#if (eq goOrm "ent")}}
+package models
+
+// UserCreate is used for creating a new user
+type UserCreate struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// UserUpdate is used for updating a user
+type UserUpdate struct {
+	Name  *string `json:"name,omitempty"`
+	Email *string `json:"email,omitempty"`
+}
+
+// PostCreate is used for creating a new post
+type PostCreate struct {
+	Title    string `json:"title"`
+	Content  string `json:"content"`
+	AuthorID int    `json:"author_id"`
+}
+
+// PostUpdate is used for updating a post
+type PostUpdate struct {
+	Title     *string `json:"title,omitempty"`
+	Content   *string `json:"content,omitempty"`
+	Published *bool   `json:"published,omitempty"`
+}
+{{/if}}

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -599,6 +599,7 @@ const EXACT_LABEL_OVERRIDES: Partial<Record<OptionCategory, Partial<Record<strin
   goOrm: {
     gorm: "GORM",
     sqlc: "sqlc",
+    ent: "Ent",
   },
   goApi: {
     "grpc-go": "gRPC-Go",

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -326,7 +326,7 @@ export const PythonQualitySchema = z.enum(["ruff", "none"]).describe("Python cod
 // Go ecosystem schemas
 export const GoWebFrameworkSchema = z.enum(["gin", "echo", "fiber", "chi", "none"]).describe("Go web framework");
 
-export const GoOrmSchema = z.enum(["gorm", "sqlc", "none"]).describe("Go ORM/database layer");
+export const GoOrmSchema = z.enum(["gorm", "sqlc", "ent", "none"]).describe("Go ORM/database layer");
 
 export const GoApiSchema = z.enum(["grpc-go", "none"]).describe("Go API layer (gRPC)");
 


### PR DESCRIPTION
## Summary
- Adds **Ent** (entgo.io) by Meta as a third Go ORM option alongside GORM and sqlc
- Ent provides code-first schema definitions with compile-time safety and a graph traversal API (15k+ GitHub stars)
- Full CRUD handlers for all 4 web frameworks (gin, echo, fiber, chi) using `database/sql` with Ent schema files ready for code generation via `go generate ./ent`

## Files changed (15)
| File | Change |
|------|--------|
| `packages/types/src/schemas.ts` | Add `"ent"` to `GoOrmSchema` enum |
| `packages/types/src/option-metadata.ts` | Add `Ent` label override |
| `apps/cli/src/prompts/go-ecosystem.ts` | Add Ent prompt option |
| `templates/go-base/go.mod.hbs` | Add `entgo.io/ent`, `lib/pq`, `go-sqlite3` deps |
| `templates/go-base/cmd/server/main.go.hbs` | Widen DB import guard, add Ent init block |
| `templates/go-base/internal/database/database.go.hbs` | Add Ent database init using `database/sql` |
| `templates/go-base/internal/models/models.go.hbs` | Add Ent request/response types |
| `templates/go-base/internal/handlers/handlers.go.hbs` | Widen all ORM guards, add Ent CRUD for gin/echo/fiber/chi |
| `templates/go-base/ent/generate.go.hbs` | `//go:generate` directive for Ent code gen |
| `templates/go-base/ent/schema/user.go.hbs` | Ent User schema with edges |
| `templates/go-base/ent/schema/post.go.hbs` | Ent Post schema with edges |
| `apps/web/src/lib/constant.ts` | Add Ent to `TECH_OPTIONS.goOrm` |
| `apps/web/src/lib/tech-resource-links.ts` | Add Ent docs/GitHub links |
| `packages/template-generator/src/processors/readme-generator.ts` | Add Ent features, structure, DB setup section |
| `apps/cli/src/helpers/core/post-installation.ts` | Add Ent display name |

## Test plan
- [x] `cli-builder-sync.test.ts` passes (351 pass, 1 pre-existing fail from i18n/rustCaching)
- [x] Full build chain succeeds: types -> generate-templates -> template-generator -> CLI
- [x] Scaffolded 6 combos, all compile with `go build ./...`:
  - gin + ent
  - echo + ent
  - fiber + ent
  - chi + ent
  - gin + ent + grpc
  - fiber + ent + none-logging