### PR TITLE
feat(python): add tortoise-orm to Python ORM category

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -900,6 +900,7 @@ function displayPythonInstructions(config: ProjectConfig & { depsInstalled: bool
     const ormNames: Record<string, string> = {
       sqlalchemy: "SQLAlchemy",
       sqlmodel: "SQLModel",
+      "tortoise-orm": "Tortoise ORM",
     };
     output += `${pc.cyan("•")} ORM: ${ormNames[pythonOrm] || pythonOrm}\n`;
   }

--- a/apps/cli/src/prompts/python-ecosystem.ts
+++ b/apps/cli/src/prompts/python-ecosystem.ts
@@ -69,6 +69,11 @@ export async function getPythonOrmChoice(pythonOrm?: PythonOrm) {
       hint: "SQL databases in Python with Pydantic and SQLAlchemy",
     },
     {
+      value: "tortoise-orm" as const,
+      label: "Tortoise ORM",
+      hint: "Async-first ORM with Django-like API",
+    },
+    {
       value: "none" as const,
       label: "None",
       hint: "No ORM/database layer",

--- a/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
+++ b/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
@@ -13704,6 +13704,23 @@ exports[`Template Snapshots - Python Ecosystem Python File Structure Snapshots f
 ]
 `;
 
+exports[`Template Snapshots - Python Ecosystem Python File Structure Snapshots file structure: fastapi-tortoise-orm 1`] = `
+[
+  ".env.example",
+  "CLAUDE.md",
+  "README.md",
+  "pyproject.toml",
+  "src/app/__init__.py",
+  "src/app/crud.py",
+  "src/app/database.py",
+  "src/app/main.py",
+  "src/app/models.py",
+  "tests/__init__.py",
+  "tests/test_database.py",
+  "tests/test_main.py",
+]
+`;
+
 exports[`Template Snapshots - Python Ecosystem Python Key File Content Snapshots key files: fastapi-sqlalchemy-celery 1`] = `
 {
   "fileCount": 21,
@@ -14133,6 +14150,84 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/0
     {
       "content": "[exists]",
       "path": "tests/__init__.py",
+    },
+    {
+      "content": "[exists]",
+      "path": "tests/test_main.py",
+    },
+  ],
+}
+`;
+
+exports[`Template Snapshots - Python Ecosystem Python Key File Content Snapshots key files: fastapi-tortoise-orm 1`] = `
+{
+  "fileCount": 13,
+  "files": [
+    {
+      "content": 
+"# Environment Configuration
+# Copy this file to .env and update the values
+
+# Application
+DEBUG=true
+HOST=0.0.0.0
+PORT=8000
+
+# Database (if using SQLAlchemy/SQLModel)
+DATABASE_URL=sqlite:///./app.db
+
+# OpenAI (if using AI frameworks)
+OPENAI_API_KEY=your-openai-api-key
+
+# Anthropic (if using Anthropic SDK)
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Celery (if using task queue)
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+"
+,
+      "path": ".env.example",
+    },
+    {
+      "content": "[exists]",
+      "path": "CLAUDE.md",
+    },
+    {
+      "content": "[exists]",
+      "path": "pyproject.toml",
+    },
+    {
+      "content": "[exists]",
+      "path": "README.md",
+    },
+    {
+      "content": "[exists]",
+      "path": "src/app/__init__.py",
+    },
+    {
+      "content": "[exists]",
+      "path": "src/app/crud.py",
+    },
+    {
+      "content": "[exists]",
+      "path": "src/app/database.py",
+    },
+    {
+      "content": "[exists]",
+      "path": "src/app/main.py",
+    },
+    {
+      "content": "[exists]",
+      "path": "src/app/models.py",
+    },
+    {
+      "content": "[exists]",
+      "path": "tests/__init__.py",
+    },
+    {
+      "content": "[exists]",
+      "path": "tests/test_database.py",
     },
     {
       "content": "[exists]",

--- a/apps/cli/test/python-language.test.ts
+++ b/apps/cli/test/python-language.test.ts
@@ -85,6 +85,7 @@ describe("Python Language Support", () => {
     it("should have python ORM options", () => {
       expect(PYTHON_ORMS).toContain("sqlalchemy");
       expect(PYTHON_ORMS).toContain("sqlmodel");
+      expect(PYTHON_ORMS).toContain("tortoise-orm");
       expect(PYTHON_ORMS).toContain("none");
     });
 
@@ -922,6 +923,192 @@ describe("Python Language Support", () => {
       expect(hasFile(root, "src/app/crud.py")).toBe(false);
       expect(hasFile(root, "alembic.ini")).toBe(false);
       expect(hasFile(root, "migrations/env.py")).toBe(false);
+    });
+  });
+
+  describe("Tortoise ORM", () => {
+    it("should include Tortoise ORM dependencies in pyproject.toml", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-deps",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      const pyprojectContent = getFileContent(root, "pyproject.toml");
+      expect(pyprojectContent).toBeDefined();
+      expect(pyprojectContent).toContain("tortoise-orm");
+      expect(pyprojectContent).toContain("aerich");
+    });
+
+    it("should create Tortoise ORM database module", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-database",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      expect(hasFile(root, "src/app/database.py")).toBe(true);
+      const databaseContent = getFileContent(root, "src/app/database.py");
+      expect(databaseContent).toBeDefined();
+      expect(databaseContent).toContain("from tortoise import Tortoise");
+      expect(databaseContent).toContain("TORTOISE_ORM");
+      expect(databaseContent).toContain("init_db");
+      expect(databaseContent).toContain("close_db");
+    });
+
+    it("should create Tortoise ORM models module", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-models",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      expect(hasFile(root, "src/app/models.py")).toBe(true);
+      const modelsContent = getFileContent(root, "src/app/models.py");
+      expect(modelsContent).toBeDefined();
+      expect(modelsContent).toContain("from tortoise import fields, models");
+      expect(modelsContent).toContain("class User(models.Model)");
+      expect(modelsContent).toContain("class Post(models.Model)");
+    });
+
+    it("should create Tortoise ORM CRUD module", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-crud",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      expect(hasFile(root, "src/app/crud.py")).toBe(true);
+      const crudContent = getFileContent(root, "src/app/crud.py");
+      expect(crudContent).toBeDefined();
+      expect(crudContent).toContain("from app.models import Post, User");
+      expect(crudContent).toContain("async def get_user");
+      expect(crudContent).toContain("async def create_user");
+      expect(crudContent).toContain("async def get_post");
+      expect(crudContent).toContain("async def create_post");
+    });
+
+    it("should create database test file", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-tests",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      expect(hasFile(root, "tests/test_database.py")).toBe(true);
+      const testContent = getFileContent(root, "tests/test_database.py");
+      expect(testContent).toBeDefined();
+      expect(testContent).toContain("from app.models import Post, User");
+      expect(testContent).toContain("from app import crud");
+    });
+
+    it("should integrate Tortoise ORM with FastAPI endpoints", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-fastapi",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      const mainContent = getFileContent(root, "src/app/main.py");
+      expect(mainContent).toBeDefined();
+      expect(mainContent).toContain("from app import crud");
+      expect(mainContent).toContain("from app.database import close_db, init_db");
+      expect(mainContent).toContain("await init_db()");
+      expect(mainContent).toContain("await close_db()");
+      expect(mainContent).toContain("/users");
+      expect(mainContent).toContain("/posts");
+    });
+
+    it("should generate README with Tortoise ORM instructions", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-readme",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      const readmeContent = getFileContent(root, "README.md");
+      expect(readmeContent).toBeDefined();
+      expect(readmeContent).toContain("Tortoise ORM");
+      expect(readmeContent).toContain("Aerich");
+    });
+
+    it("should NOT use Alembic with Tortoise ORM", async () => {
+      const result = await createVirtual({
+        projectName: "python-tortoise-migrations",
+        ecosystem: "python",
+        pythonWebFramework: "fastapi",
+        pythonOrm: "tortoise-orm",
+        pythonValidation: "none",
+        pythonAi: [],
+        pythonTaskQueue: "none",
+        pythonQuality: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+
+      // Alembic should not be present with Tortoise ORM (uses aerich instead)
+      expect(hasFile(root, "alembic.ini")).toBe(false);
+      expect(hasFile(root, "migrations/env.py")).toBe(false);
+
+      const pyprojectContent = getFileContent(root, "pyproject.toml");
+      expect(pyprojectContent).not.toContain("alembic");
     });
   });
 

--- a/apps/cli/test/template-snapshots.test.ts
+++ b/apps/cli/test/template-snapshots.test.ts
@@ -559,6 +559,19 @@ describe("Template Snapshots - Python Ecosystem", () => {
         pythonQuality: "ruff" as const,
       },
     },
+    {
+      name: "fastapi-tortoise-orm",
+      config: {
+        ecosystem: "python" as const,
+        pythonWebFramework: "fastapi" as const,
+        pythonOrm: "tortoise-orm" as const,
+        pythonValidation: "none" as const,
+        pythonAi: [] as const,
+        pythonTaskQueue: "none" as const,
+        pythonGraphql: "none" as const,
+        pythonQuality: "none" as const,
+      },
+    },
   ];
 
   describe("Python File Structure Snapshots", () => {

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -2901,6 +2901,14 @@ export const TECH_OPTIONS: Record<
       default: false,
     },
     {
+      id: "tortoise-orm",
+      name: "Tortoise ORM",
+      description: "Async-first Python ORM with Django-like API, inspired by Django ORM",
+      icon: "",
+      color: "from-green-500 to-emerald-600",
+      default: false,
+    },
+    {
       id: "none",
       name: "No ORM",
       description: "Skip Python ORM selection",

--- a/apps/web/src/lib/tech-resource-links.ts
+++ b/apps/web/src/lib/tech-resource-links.ts
@@ -743,6 +743,10 @@ const BASE_LINKS: LinkMap = {
     docsUrl: "https://sqlmodel.tiangolo.com/",
     githubUrl: "https://github.com/fastapi/sqlmodel",
   },
+  "tortoise-orm": {
+    docsUrl: "https://tortoise.github.io/",
+    githubUrl: "https://github.com/tortoise/tortoise-orm",
+  },
   pydantic: {
     docsUrl: "https://docs.pydantic.dev/",
     githubUrl: "https://github.com/pydantic/pydantic",

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -989,6 +989,9 @@ function generatePythonReadmeContent(config: ProjectConfig): string {
   } else if (pythonOrm === "sqlmodel") {
     features.push("- **SQLModel** - SQL databases with Pydantic and SQLAlchemy");
     features.push("- **Alembic** - Database migrations");
+  } else if (pythonOrm === "tortoise-orm") {
+    features.push("- **Tortoise ORM** - Async-first Python ORM with Django-like API");
+    features.push("- **Aerich** - Database migrations for Tortoise ORM");
   }
 
   // Validation
@@ -1069,6 +1072,13 @@ function generatePythonReadmeContent(config: ProjectConfig): string {
     structure.push("│       └── crud.py       # CRUD operations");
   }
 
+  // Add Tortoise ORM files
+  if (pythonOrm === "tortoise-orm") {
+    structure.push("│       ├── database.py   # Database configuration");
+    structure.push("│       ├── models.py     # Tortoise ORM models");
+    structure.push("│       └── crud.py       # CRUD operations");
+  }
+
   // Add standalone Pydantic schemas (no ORM)
   if (pythonOrm === "none" && pythonValidation === "pydantic") {
     structure.push("│       └── schemas.py    # Pydantic validation schemas");
@@ -1114,7 +1124,7 @@ function generatePythonReadmeContent(config: ProjectConfig): string {
   structure.push("│   ├── __init__.py");
   structure.push("│   └── test_main.py      # Test suite");
 
-  if (pythonOrm === "sqlalchemy" || pythonOrm === "sqlmodel") {
+  if (pythonOrm === "sqlalchemy" || pythonOrm === "sqlmodel" || pythonOrm === "tortoise-orm") {
     structure.push("│   └── test_database.py  # Database tests");
   }
 
@@ -1148,6 +1158,14 @@ function generatePythonReadmeContent(config: ProjectConfig): string {
 - \`uv run alembic revision --autogenerate -m "description"\`: Generate migration
 - \`uv run alembic upgrade head\`: Apply migrations
 - \`uv run alembic downgrade -1\`: Rollback last migration`;
+  }
+
+  if (pythonOrm === "tortoise-orm") {
+    scripts += `
+- \`uv run aerich init -t app.database.TORTOISE_ORM\`: Initialize Aerich
+- \`uv run aerich init-db\`: Create initial migration
+- \`uv run aerich migrate\`: Generate migration
+- \`uv run aerich upgrade\`: Apply migrations`;
   }
 
   return `# ${projectName}

--- a/packages/template-generator/templates/python-base/pyproject.toml.hbs
+++ b/packages/template-generator/templates/python-base/pyproject.toml.hbs
@@ -34,6 +34,10 @@ dependencies = [
     "sqlmodel>=0.0.38",
     "alembic>=1.14.0",
 {{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+    "tortoise-orm[aiosqlite]>=0.25.0",
+    "aerich>=0.8.0",
+{{/if}}
 {{#if (eq pythonValidation "pydantic")}}
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",

--- a/packages/template-generator/templates/python-base/src/app/crud.py.hbs
+++ b/packages/template-generator/templates/python-base/src/app/crud.py.hbs
@@ -287,4 +287,101 @@ def delete_post(db: Session, post_id: int) -> bool:
     db.commit()
     return True
 {{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+"""CRUD operations for Tortoise ORM models."""
+
+from app.models import Post, User
+
+
+# User CRUD operations
+async def get_user(user_id: int) -> User | None:
+    """Get a user by ID."""
+    return await User.filter(id=user_id).first()
+
+
+async def get_user_by_email(email: str) -> User | None:
+    """Get a user by email."""
+    return await User.filter(email=email).first()
+
+
+async def get_users(skip: int = 0, limit: int = 100) -> list[User]:
+    """Get a list of users with pagination."""
+    return await User.all().offset(skip).limit(limit)
+
+
+async def create_user(email: str, name: str | None = None) -> User:
+    """Create a new user."""
+    return await User.create(email=email, name=name)
+
+
+async def update_user(user_id: int, email: str | None = None, name: str | None = None) -> User | None:
+    """Update a user."""
+    user = await get_user(user_id)
+    if user is None:
+        return None
+
+    if email is not None:
+        user.email = email
+    if name is not None:
+        user.name = name
+
+    await user.save()
+    return user
+
+
+async def delete_user(user_id: int) -> bool:
+    """Delete a user."""
+    user = await get_user(user_id)
+    if user is None:
+        return False
+
+    await user.delete()
+    return True
+
+
+# Post CRUD operations
+async def get_post(post_id: int) -> Post | None:
+    """Get a post by ID."""
+    return await Post.filter(id=post_id).first()
+
+
+async def get_posts(skip: int = 0, limit: int = 100) -> list[Post]:
+    """Get a list of posts with pagination."""
+    return await Post.all().offset(skip).limit(limit)
+
+
+async def get_posts_by_author(author_id: int) -> list[Post]:
+    """Get all posts by an author."""
+    return await Post.filter(author_id=author_id).all()
+
+
+async def create_post(title: str, author_id: int, content: str | None = None) -> Post:
+    """Create a new post."""
+    return await Post.create(title=title, content=content, author_id=author_id)
+
+
+async def update_post(post_id: int, title: str | None = None, content: str | None = None) -> Post | None:
+    """Update a post."""
+    post = await get_post(post_id)
+    if post is None:
+        return None
+
+    if title is not None:
+        post.title = title
+    if content is not None:
+        post.content = content
+
+    await post.save()
+    return post
+
+
+async def delete_post(post_id: int) -> bool:
+    """Delete a post."""
+    post = await get_post(post_id)
+    if post is None:
+        return False
+
+    await post.delete()
+    return True
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/python-base/src/app/database.py.hbs
+++ b/packages/template-generator/templates/python-base/src/app/database.py.hbs
@@ -62,4 +62,34 @@ def init_db() -> None:
 
     SQLModel.metadata.create_all(engine)
 {{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+"""Database configuration for Tortoise ORM."""
+
+import os
+
+from tortoise import Tortoise
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite://app.db")
+
+TORTOISE_ORM = {
+    "connections": {"default": DATABASE_URL},
+    "apps": {
+        "models": {
+            "models": ["app.models", "aerich.models"],
+            "default_connection": "default",
+        },
+    },
+}
+
+
+async def init_db() -> None:
+    """Initialize Tortoise ORM."""
+    await Tortoise.init(config=TORTOISE_ORM)
+    await Tortoise.generate_schemas()
+
+
+async def close_db() -> None:
+    """Close Tortoise ORM connections."""
+    await Tortoise.close_connections()
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/python-base/src/app/main.py.hbs
+++ b/packages/template-generator/templates/python-base/src/app/main.py.hbs
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 {{#if (eq pythonWebFramework "fastapi")}}
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI{{#if (or (eq pythonOrm "sqlalchemy") (eq pythonOrm "sqlmodel"))}}, Depends, HTTPException{{/if}}{{#if (and (eq pythonOrm "none") (or (eq pythonValidation "pydantic") (ne pythonAuth "none")))}}, HTTPException{{/if}}
+from fastapi import FastAPI{{#if (or (eq pythonOrm "sqlalchemy") (eq pythonOrm "sqlmodel"))}}, Depends, HTTPException{{/if}}{{#if (eq pythonOrm "tortoise-orm")}}, HTTPException{{/if}}{{#if (and (eq pythonOrm "none") (or (eq pythonValidation "pydantic") (ne pythonAuth "none")))}}, HTTPException{{/if}}
 from fastapi.middleware.cors import CORSMiddleware
 {{#if (eq pythonValidation "pydantic")}}
 from app.settings import get_settings
@@ -37,6 +37,10 @@ from app.models import (
     UserResponse,
     UserUpdate,
 )
+{{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+from app import crud
+from app.database import close_db, init_db
 {{/if}}
 {{#if (includes pythonAi "langchain")}}
 from fastapi.responses import StreamingResponse
@@ -168,7 +172,15 @@ async def lifespan(app: FastAPI):
     # Initialize database tables on startup
     init_db()
 {{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+    # Initialize Tortoise ORM on startup
+    await init_db()
+{{/if}}
     yield
+{{#if (eq pythonOrm "tortoise-orm")}}
+    # Close Tortoise ORM connections on shutdown
+    await close_db()
+{{/if}}
 
 
 {{#if (eq pythonValidation "pydantic")}}
@@ -909,6 +921,92 @@ async def update_post(post_id: int, post: PostUpdate, db: Session = Depends(get_
 async def delete_post(post_id: int, db: Session = Depends(get_db)):
     """Delete a post."""
     if not crud.delete_post(db, post_id):
+        raise HTTPException(status_code=404, detail="Post not found")
+{{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+
+# User endpoints
+@app.post("/users", status_code=201)
+async def create_user(email: str, name: str | None = None):
+    """Create a new user."""
+    existing = await crud.get_user_by_email(email)
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = await crud.create_user(email=email, name=name)
+    return {"id": user.id, "email": user.email, "name": user.name}
+
+
+@app.get("/users")
+async def list_users(skip: int = 0, limit: int = 100):
+    """List all users."""
+    users = await crud.get_users(skip=skip, limit=limit)
+    return [{"id": u.id, "email": u.email, "name": u.name} for u in users]
+
+
+@app.get("/users/{user_id}")
+async def get_user(user_id: int):
+    """Get a user by ID."""
+    user = await crud.get_user(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"id": user.id, "email": user.email, "name": user.name}
+
+
+@app.patch("/users/{user_id}")
+async def update_user(user_id: int, email: str | None = None, name: str | None = None):
+    """Update a user."""
+    updated = await crud.update_user(user_id, email=email, name=name)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"id": updated.id, "email": updated.email, "name": updated.name}
+
+
+@app.delete("/users/{user_id}", status_code=204)
+async def delete_user(user_id: int):
+    """Delete a user."""
+    if not await crud.delete_user(user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+
+
+# Post endpoints
+@app.post("/posts", status_code=201)
+async def create_post(title: str, author_id: int, content: str | None = None):
+    """Create a new post."""
+    if await crud.get_user(author_id) is None:
+        raise HTTPException(status_code=400, detail="Author not found")
+    post = await crud.create_post(title=title, author_id=author_id, content=content)
+    return {"id": post.id, "title": post.title, "content": post.content, "author_id": post.author_id}
+
+
+@app.get("/posts")
+async def list_posts(skip: int = 0, limit: int = 100):
+    """List all posts."""
+    posts = await crud.get_posts(skip=skip, limit=limit)
+    return [{"id": p.id, "title": p.title, "content": p.content, "author_id": p.author_id} for p in posts]
+
+
+@app.get("/posts/{post_id}")
+async def get_post(post_id: int):
+    """Get a post by ID."""
+    post = await crud.get_post(post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return {"id": post.id, "title": post.title, "content": post.content, "author_id": post.author_id}
+
+
+@app.patch("/posts/{post_id}")
+async def update_post(post_id: int, title: str | None = None, content: str | None = None):
+    """Update a post."""
+    updated = await crud.update_post(post_id, title=title, content=content)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return {"id": updated.id, "title": updated.title, "content": updated.content, "author_id": updated.author_id}
+
+
+@app.delete("/posts/{post_id}", status_code=204)
+async def delete_post(post_id: int):
+    """Delete a post."""
+    if not await crud.delete_post(post_id):
         raise HTTPException(status_code=404, detail="Post not found")
 {{/if}}
 

--- a/packages/template-generator/templates/python-base/src/app/models.py.hbs
+++ b/packages/template-generator/templates/python-base/src/app/models.py.hbs
@@ -142,4 +142,42 @@ class PostResponse(PostBase):
     created_at: datetime
     updated_at: datetime
 {{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+"""Tortoise ORM models."""
+
+from tortoise import fields, models
+
+
+class User(models.Model):
+    """User model."""
+
+    id = fields.IntField(primary_key=True)
+    email = fields.CharField(max_length=255, unique=True, index=True)
+    name = fields.CharField(max_length=255, null=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
+    updated_at = fields.DatetimeField(auto_now=True)
+
+    class Meta:
+        table = "users"
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, email={self.email})>"
+
+
+class Post(models.Model):
+    """Post model - example model for reference."""
+
+    id = fields.IntField(primary_key=True)
+    title = fields.CharField(max_length=255)
+    content = fields.TextField(null=True)
+    author_id = fields.IntField(index=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
+    updated_at = fields.DatetimeField(auto_now=True)
+
+    class Meta:
+        table = "posts"
+
+    def __repr__(self) -> str:
+        return f"<Post(id={self.id}, title={self.title})>"
+{{/if}}
 {{/if}}

--- a/packages/template-generator/templates/python-base/src/app/settings.py.hbs
+++ b/packages/template-generator/templates/python-base/src/app/settings.py.hbs
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     api_prefix: str = "/api"
     api_version: str = "v1"
 
-{{#if (or (eq pythonOrm "sqlalchemy") (eq pythonOrm "sqlmodel"))}}
+{{#if (or (eq pythonOrm "sqlalchemy") (eq pythonOrm "sqlmodel") (eq pythonOrm "tortoise-orm"))}}
     # Database settings
     database_url: str = "sqlite:///./app.db"
 {{/if}}

--- a/packages/template-generator/templates/python-base/tests/test_database.py.hbs
+++ b/packages/template-generator/templates/python-base/tests/test_database.py.hbs
@@ -535,4 +535,161 @@ class TestPostCrud:
         assert result is True
         assert crud.get_post(db_session, post.id) is None
 {{/if}}
+{{#if (eq pythonOrm "tortoise-orm")}}
+"""Tests for Tortoise ORM models and CRUD operations."""
+
+import pytest
+from tortoise.contrib.test import finalizer, initializer
+
+from app import crud
+from app.models import Post, User
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initialize_tests():
+    """Initialize Tortoise ORM for testing."""
+    initializer(["app.models"], db_url="sqlite://:memory:")
+    yield
+    finalizer()
+
+
+@pytest.fixture(autouse=True)
+async def cleanup():
+    """Clean up database between tests."""
+    yield
+    await User.all().delete()
+    await Post.all().delete()
+
+
+class TestUserModel:
+    """Tests for User model."""
+
+    async def test_create_user(self):
+        """Test creating a user."""
+        user = await User.create(email="test@example.com", name="Test User")
+
+        assert user.id is not None
+        assert user.email == "test@example.com"
+        assert user.name == "Test User"
+        assert user.created_at is not None
+        assert user.updated_at is not None
+
+    async def test_user_repr(self):
+        """Test User string representation."""
+        user = await User.create(email="repr@example.com")
+        assert "repr@example.com" in repr(user)
+
+
+class TestPostModel:
+    """Tests for Post model."""
+
+    async def test_create_post(self):
+        """Test creating a post."""
+        user = await User.create(email="author@example.com")
+        post = await Post.create(title="Test Post", content="Test content", author_id=user.id)
+
+        assert post.id is not None
+        assert post.title == "Test Post"
+        assert post.content == "Test content"
+        assert post.author_id == user.id
+        assert post.created_at is not None
+        assert post.updated_at is not None
+
+    async def test_post_repr(self):
+        """Test Post string representation."""
+        post = await Post.create(title="Test Title", author_id=1)
+        assert "Test Title" in repr(post)
+
+
+class TestUserCrud:
+    """Tests for User CRUD operations."""
+
+    async def test_create_user(self):
+        """Test creating a user via CRUD."""
+        user = await crud.create_user(email="crud@example.com", name="CRUD User")
+
+        assert user.id is not None
+        assert user.email == "crud@example.com"
+        assert user.name == "CRUD User"
+
+    async def test_get_user(self):
+        """Test getting a user by ID."""
+        user = await User.create(email="get@example.com")
+        result = await crud.get_user(user.id)
+        assert result is not None
+        assert result.email == "get@example.com"
+
+    async def test_get_user_not_found(self):
+        """Test getting a non-existent user."""
+        result = await crud.get_user(999)
+        assert result is None
+
+    async def test_get_user_by_email(self):
+        """Test getting a user by email."""
+        user = await User.create(email="email@example.com")
+        result = await crud.get_user_by_email("email@example.com")
+        assert result is not None
+        assert result.id == user.id
+
+    async def test_get_users(self):
+        """Test listing users with pagination."""
+        for i in range(5):
+            await User.create(email=f"user{i}@example.com")
+
+        users = await crud.get_users()
+        assert len(users) == 5
+
+        users = await crud.get_users(limit=2)
+        assert len(users) == 2
+
+    async def test_delete_user(self):
+        """Test deleting a user."""
+        user = await User.create(email="delete@example.com")
+        result = await crud.delete_user(user.id)
+        assert result is True
+        assert await crud.get_user(user.id) is None
+
+    async def test_delete_user_not_found(self):
+        """Test deleting a non-existent user."""
+        result = await crud.delete_user(999)
+        assert result is False
+
+
+class TestPostCrud:
+    """Tests for Post CRUD operations."""
+
+    async def test_create_post(self):
+        """Test creating a post via CRUD."""
+        user = await User.create(email="postauthor@example.com")
+        post = await crud.create_post(title="CRUD Post", author_id=user.id, content="Content")
+
+        assert post.id is not None
+        assert post.title == "CRUD Post"
+        assert post.author_id == user.id
+
+    async def test_get_post(self):
+        """Test getting a post by ID."""
+        post = await Post.create(title="Get Post", author_id=1)
+        result = await crud.get_post(post.id)
+        assert result is not None
+        assert result.title == "Get Post"
+
+    async def test_get_posts(self):
+        """Test listing posts with pagination."""
+        for i in range(5):
+            await Post.create(title=f"Post {i}", author_id=1)
+
+        posts = await crud.get_posts()
+        assert len(posts) == 5
+
+        posts = await crud.get_posts(limit=2)
+        assert len(posts) == 2
+
+    async def test_delete_post(self):
+        """Test deleting a post."""
+        post = await Post.create(title="Delete Post", author_id=1)
+        result = await crud.delete_post(post.id)
+        assert result is True
+        assert await crud.get_post(post.id) is None
+{{/if}}
 {{/if}}

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -586,6 +586,7 @@ const EXACT_LABEL_OVERRIDES: Partial<Record<OptionCategory, Partial<Record<strin
   pythonOrm: {
     sqlalchemy: "SQLAlchemy",
     sqlmodel: "SQLModel",
+    "tortoise-orm": "Tortoise ORM",
   },
   pythonValidation: {
     pydantic: "Pydantic",

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -312,7 +312,7 @@ export const PythonWebFrameworkSchema = z
   .describe("Python web framework");
 
 export const PythonOrmSchema = z
-  .enum(["sqlalchemy", "sqlmodel", "none"])
+  .enum(["sqlalchemy", "sqlmodel", "tortoise-orm", "none"])
   .describe("Python ORM/database layer");
 
 export const PythonValidationSchema = z


### PR DESCRIPTION
## Summary
- Adds `tortoise-orm` as a new option in `PythonOrmSchema` alongside `sqlalchemy` and `sqlmodel`
- Tortoise ORM is an async-first Python ORM with a Django-like API, using `aerich` for migrations (not alembic)
- Full template support: database.py, models.py, crud.py, test_database.py, and FastAPI endpoint integration
- All 4 web framework combos verified: fastapi+tortoise, flask+tortoise, litestar+tortoise, django+tortoise

## Files changed (17 files, Scenario A non-TS checklist)
1. `packages/types/src/schemas.ts` -- add `"tortoise-orm"` to PythonOrmSchema enum
2. `packages/types/src/option-metadata.ts` -- add label override `"Tortoise ORM"`
3. `packages/template-generator/templates/python-base/pyproject.toml.hbs` -- tortoise-orm + aerich deps
4. `packages/template-generator/templates/python-base/src/app/database.py.hbs` -- Tortoise init/close
5. `packages/template-generator/templates/python-base/src/app/models.py.hbs` -- Tortoise models (User, Post)
6. `packages/template-generator/templates/python-base/src/app/crud.py.hbs` -- async CRUD operations
7. `packages/template-generator/templates/python-base/src/app/main.py.hbs` -- FastAPI lifespan + routes
8. `packages/template-generator/templates/python-base/src/app/settings.py.hbs` -- widen database_url gate
9. `packages/template-generator/templates/python-base/tests/test_database.py.hbs` -- Tortoise test suite
10. `apps/cli/src/prompts/python-ecosystem.ts` -- CLI prompt option
11. `apps/web/src/lib/constant.ts` -- web builder entry
12. `apps/web/src/lib/tech-resource-links.ts` -- docs/github links
13. `packages/template-generator/src/processors/readme-generator.ts` -- README features + structure + scripts
14. `apps/cli/src/helpers/core/post-installation.ts` -- post-install display name
15. `apps/cli/test/python-language.test.ts` -- 9 new tests for Tortoise ORM
16. `apps/cli/test/template-snapshots.test.ts` -- snapshot combo
17. `apps/cli/test/__snapshots__/template-snapshots.test.ts.snap` -- snapshot data

## Test plan
- [x] `bun test apps/cli/test/cli-builder-sync.test.ts` -- 361 pass, 0 fail
- [x] `bun test apps/cli/test/python-language.test.ts` -- 120 pass, 0 fail
- [x] `bun test apps/cli/test/template-snapshots.test.ts -u` -- 68 pass, 0 fail
- [x] Scaffold fastapi+tortoise -- `python3 -m compileall` passes
- [x] Scaffold flask+tortoise -- `python3 -m compileall` passes
- [x] Scaffold litestar+tortoise -- `python3 -m compileall` passes
- [x] Scaffold django+tortoise -- `python3 -m compileall` passes
- [x] `bun run --cwd apps/web validate:tech-links` -- no errors