### PR TITLE
[codex] expand template-generator coverage

### DIFF
--- a/packages/template-generator/test/processors/api-deps.test.ts
+++ b/packages/template-generator/test/processors/api-deps.test.ts
@@ -143,4 +143,151 @@ describe("processApiDeps", () => {
       "@tanstack/solid-router-devtools",
     ]);
   });
+
+  it("adds Garph dependencies across api, self-hosted web, and native packages", () => {
+    const vfs = createSeededVFS([
+      "apps/web/package.json",
+      "apps/native/package.json",
+      "packages/api/package.json",
+    ]);
+
+    processApiDeps(
+      vfs,
+      makeConfig({
+        api: "garph",
+        backend: "self",
+        frontend: ["next", "native-bare"],
+      }),
+    );
+
+    expectIncludesAll(getDeps(vfs, "packages/api/package.json").deps, [
+      "garph",
+      "graphql-yoga",
+      "graphql",
+      "next",
+    ]);
+    expectIncludesAll(getDeps(vfs, "apps/web/package.json").deps, [
+      "garph",
+      "graphql-yoga",
+      "graphql",
+      "@garph/gqty",
+      "gqty",
+      "@tanstack/react-query",
+    ]);
+    expect(getDeps(vfs, "apps/web/package.json").devDeps).toContain(
+      "@tanstack/react-query-devtools",
+    );
+    expectIncludesAll(getDeps(vfs, "apps/native/package.json").deps, [
+      "@garph/gqty",
+      "gqty",
+      "@tanstack/react-query",
+    ]);
+  });
+
+  it("adds GraphQL Yoga and backend-specific api package dependencies", () => {
+    const honoVfs = createSeededVFS([
+      "apps/web/package.json",
+      "apps/server/package.json",
+      "packages/api/package.json",
+    ]);
+    const elysiaVfs = createSeededVFS(["packages/api/package.json"]);
+
+    processApiDeps(
+      honoVfs,
+      makeConfig({
+        api: "graphql-yoga",
+        backend: "hono",
+        frontend: ["react-router"],
+      }),
+    );
+    processApiDeps(
+      elysiaVfs,
+      makeConfig({
+        api: "graphql-yoga",
+        backend: "elysia",
+        frontend: ["solid"],
+      }),
+    );
+
+    expectIncludesAll(getDeps(honoVfs, "packages/api/package.json").deps, [
+      "graphql-yoga",
+      "graphql",
+      "@pothos/core",
+      "hono",
+    ]);
+    expectIncludesAll(getDeps(honoVfs, "apps/server/package.json").deps, [
+      "graphql-yoga",
+      "graphql",
+      "@pothos/core",
+    ]);
+    expectIncludesAll(getDeps(honoVfs, "apps/web/package.json").deps, ["@tanstack/react-query"]);
+    expect(getDeps(honoVfs, "apps/web/package.json").devDeps).toContain(
+      "@tanstack/react-query-devtools",
+    );
+
+    expectIncludesAll(getDeps(elysiaVfs, "packages/api/package.json").deps, [
+      "graphql-yoga",
+      "graphql",
+      "@pothos/core",
+      "elysia",
+    ]);
+  });
+
+  it("adds oRPC client dependencies for nuxt, svelte, and solid-start frontends", () => {
+    const nuxtVfs = createSeededVFS(["apps/web/package.json"]);
+    const svelteVfs = createSeededVFS(["apps/web/package.json"]);
+    const solidStartVfs = createSeededVFS(["apps/web/package.json"]);
+
+    processApiDeps(
+      nuxtVfs,
+      makeConfig({
+        api: "orpc",
+        frontend: ["nuxt"],
+      }),
+    );
+    processApiDeps(
+      svelteVfs,
+      makeConfig({
+        api: "orpc",
+        frontend: ["svelte"],
+      }),
+    );
+    processApiDeps(
+      solidStartVfs,
+      makeConfig({
+        api: "orpc",
+        frontend: ["solid-start"],
+      }),
+    );
+
+    expectIncludesAll(getDeps(nuxtVfs, "apps/web/package.json").deps, [
+      "@tanstack/vue-query",
+      "@orpc/tanstack-query",
+      "@orpc/client",
+      "@orpc/server",
+    ]);
+    expect(getDeps(nuxtVfs, "apps/web/package.json").devDeps).toEqual([
+      "@tanstack/vue-query-devtools",
+    ]);
+
+    expectIncludesAll(getDeps(svelteVfs, "apps/web/package.json").deps, [
+      "@orpc/tanstack-query",
+      "@orpc/client",
+      "@orpc/server",
+      "@tanstack/svelte-query",
+    ]);
+    expect(getDeps(svelteVfs, "apps/web/package.json").devDeps).toEqual([
+      "@tanstack/svelte-query-devtools",
+    ]);
+
+    expectIncludesAll(getDeps(solidStartVfs, "apps/web/package.json").deps, [
+      "@orpc/tanstack-query",
+      "@orpc/client",
+      "@orpc/server",
+      "@tanstack/solid-query",
+    ]);
+    expect(getDeps(solidStartVfs, "apps/web/package.json").devDeps).toEqual([
+      "@tanstack/solid-router-devtools",
+    ]);
+  });
 });

--- a/packages/template-generator/test/processors/db-deps.test.ts
+++ b/packages/template-generator/test/processors/db-deps.test.ts
@@ -84,6 +84,61 @@ describe("processDatabaseDeps", () => {
     expect(getDeps(vfs, "apps/web/package.json").deps).toContain("@prisma/client");
   });
 
+  it("adds Prisma mysql, postgres, and d1 adapter branches", () => {
+    const planetscale = createSeededVFS(["packages/db/package.json"]);
+    const postgres = createSeededVFS(["packages/db/package.json", "apps/web/package.json"]);
+    const d1 = createSeededVFS(["packages/db/package.json", "apps/web/package.json"]);
+
+    processDatabaseDeps(
+      planetscale,
+      makeConfig({
+        orm: "prisma",
+        database: "mysql",
+        dbSetup: "planetscale",
+      }),
+    );
+    processDatabaseDeps(
+      postgres,
+      makeConfig({
+        orm: "prisma",
+        database: "postgres",
+        dbSetup: "none",
+      }),
+    );
+    processDatabaseDeps(
+      d1,
+      makeConfig({
+        orm: "prisma",
+        database: "sqlite",
+        dbSetup: "d1",
+      }),
+    );
+
+    expectIncludesAll(getDeps(planetscale, "packages/db/package.json").deps, [
+      "@prisma/client",
+      "@prisma/adapter-planetscale",
+      "@planetscale/database",
+    ]);
+    expect(getDeps(planetscale, "packages/db/package.json").deps).not.toContain(
+      "@prisma/adapter-mariadb",
+    );
+
+    expectIncludesAll(getDeps(postgres, "packages/db/package.json").deps, [
+      "@prisma/client",
+      "@prisma/adapter-pg",
+      "pg",
+    ]);
+    expect(getDeps(postgres, "packages/db/package.json").devDeps).toContain("@types/pg");
+    expect(getDeps(postgres, "apps/web/package.json").deps).toEqual(["@prisma/client"]);
+
+    expectIncludesAll(getDeps(d1, "packages/db/package.json").deps, [
+      "@prisma/client",
+      "@prisma/adapter-d1",
+    ]);
+    expect(getDeps(d1, "packages/db/package.json").deps).not.toContain("@prisma/adapter-libsql");
+    expect(getDeps(d1, "apps/web/package.json").deps).toEqual(["@prisma/client"]);
+  });
+
   it("adds Drizzle sqlite dependencies for db and web packages", () => {
     const vfs = createSeededVFS(["packages/db/package.json", "apps/web/package.json"]);
 
@@ -121,6 +176,40 @@ describe("processDatabaseDeps", () => {
     expect(db.deps).not.toContain("mysql2");
   });
 
+  it("adds Drizzle postgres dependencies for neon and node drivers", () => {
+    const neon = createSeededVFS(["packages/db/package.json"]);
+    const local = createSeededVFS(["packages/db/package.json"]);
+
+    processDatabaseDeps(
+      neon,
+      makeConfig({
+        orm: "drizzle",
+        database: "postgres",
+        dbSetup: "neon",
+      }),
+    );
+    processDatabaseDeps(
+      local,
+      makeConfig({
+        orm: "drizzle",
+        database: "postgres",
+        dbSetup: "none",
+      }),
+    );
+
+    expectIncludesAll(getDeps(neon, "packages/db/package.json").deps, [
+      "drizzle-orm",
+      "@neondatabase/serverless",
+    ]);
+    expect(getDeps(neon, "packages/db/package.json").devDeps).toEqual(["drizzle-kit"]);
+
+    expectIncludesAll(getDeps(local, "packages/db/package.json").deps, ["drizzle-orm", "pg"]);
+    expect(getDeps(local, "packages/db/package.json").devDeps).toEqual([
+      "@types/pg",
+      "drizzle-kit",
+    ]);
+  });
+
   it("adds TypeORM postgres dependencies and typing support", () => {
     const vfs = createSeededVFS(["packages/db/package.json"]);
 
@@ -138,6 +227,179 @@ describe("processDatabaseDeps", () => {
       "pg",
     ]);
     expect(getDeps(vfs, "packages/db/package.json").devDeps).toContain("@types/pg");
+  });
+
+  it("adds TypeORM, Kysely, MikroORM, and Sequelize driver branches for other databases", () => {
+    const typeormSqlite = createSeededVFS(["packages/db/package.json"]);
+    const kyselyMysql = createSeededVFS(["packages/db/package.json"]);
+    const mikroPostgres = createSeededVFS(["packages/db/package.json"]);
+    const sequelizeMysql = createSeededVFS(["packages/db/package.json"]);
+    const mongoose = createSeededVFS(["packages/db/package.json"]);
+
+    processDatabaseDeps(
+      typeormSqlite,
+      makeConfig({
+        orm: "typeorm",
+        database: "sqlite",
+      }),
+    );
+    processDatabaseDeps(
+      kyselyMysql,
+      makeConfig({
+        orm: "kysely",
+        database: "mysql",
+      }),
+    );
+    processDatabaseDeps(
+      mikroPostgres,
+      makeConfig({
+        orm: "mikroorm",
+        database: "postgres",
+      }),
+    );
+    processDatabaseDeps(
+      sequelizeMysql,
+      makeConfig({
+        orm: "sequelize",
+        database: "mysql",
+      }),
+    );
+    processDatabaseDeps(
+      mongoose,
+      makeConfig({
+        orm: "mongoose",
+        database: "mongodb",
+      }),
+    );
+
+    expectIncludesAll(getDeps(typeormSqlite, "packages/db/package.json").deps, [
+      "typeorm",
+      "reflect-metadata",
+      "better-sqlite3",
+    ]);
+    expect(getDeps(typeormSqlite, "packages/db/package.json").devDeps).toEqual([
+      "@types/better-sqlite3",
+    ]);
+
+    expectIncludesAll(getDeps(kyselyMysql, "packages/db/package.json").deps, [
+      "kysely",
+      "mysql2",
+    ]);
+    expect(getDeps(kyselyMysql, "packages/db/package.json").devDeps).toEqual([]);
+
+    expectIncludesAll(getDeps(mikroPostgres, "packages/db/package.json").deps, [
+      "@mikro-orm/core",
+      "@mikro-orm/postgresql",
+    ]);
+
+    expectIncludesAll(getDeps(sequelizeMysql, "packages/db/package.json").deps, [
+      "sequelize",
+      "sequelize-typescript",
+      "mysql2",
+    ]);
+
+    expect(getDeps(mongoose, "packages/db/package.json").deps).toEqual(["mongoose"]);
+  });
+
+  it("adds the remaining Kysely, MikroORM, Sequelize, and TypeORM database driver branches", () => {
+    const typeormMysql = createSeededVFS(["packages/db/package.json"]);
+    const kyselySqlite = createSeededVFS(["packages/db/package.json"]);
+    const kyselyPostgres = createSeededVFS(["packages/db/package.json"]);
+    const mikroSqlite = createSeededVFS(["packages/db/package.json"]);
+    const mikroMysql = createSeededVFS(["packages/db/package.json"]);
+    const sequelizeSqlite = createSeededVFS(["packages/db/package.json"]);
+    const sequelizePostgres = createSeededVFS(["packages/db/package.json"]);
+
+    processDatabaseDeps(
+      typeormMysql,
+      makeConfig({
+        orm: "typeorm",
+        database: "mysql",
+      }),
+    );
+    processDatabaseDeps(
+      kyselySqlite,
+      makeConfig({
+        orm: "kysely",
+        database: "sqlite",
+      }),
+    );
+    processDatabaseDeps(
+      kyselyPostgres,
+      makeConfig({
+        orm: "kysely",
+        database: "postgres",
+      }),
+    );
+    processDatabaseDeps(
+      mikroSqlite,
+      makeConfig({
+        orm: "mikroorm",
+        database: "sqlite",
+      }),
+    );
+    processDatabaseDeps(
+      mikroMysql,
+      makeConfig({
+        orm: "mikroorm",
+        database: "mysql",
+      }),
+    );
+    processDatabaseDeps(
+      sequelizeSqlite,
+      makeConfig({
+        orm: "sequelize",
+        database: "sqlite",
+      }),
+    );
+    processDatabaseDeps(
+      sequelizePostgres,
+      makeConfig({
+        orm: "sequelize",
+        database: "postgres",
+      }),
+    );
+
+    expectIncludesAll(getDeps(typeormMysql, "packages/db/package.json").deps, [
+      "typeorm",
+      "reflect-metadata",
+      "mysql2",
+    ]);
+
+    expectIncludesAll(getDeps(kyselySqlite, "packages/db/package.json").deps, [
+      "kysely",
+      "better-sqlite3",
+    ]);
+    expect(getDeps(kyselySqlite, "packages/db/package.json").devDeps).toEqual([
+      "@types/better-sqlite3",
+    ]);
+
+    expectIncludesAll(getDeps(kyselyPostgres, "packages/db/package.json").deps, [
+      "kysely",
+      "pg",
+    ]);
+    expect(getDeps(kyselyPostgres, "packages/db/package.json").devDeps).toEqual(["@types/pg"]);
+
+    expectIncludesAll(getDeps(mikroSqlite, "packages/db/package.json").deps, [
+      "@mikro-orm/core",
+      "@mikro-orm/better-sqlite",
+    ]);
+    expectIncludesAll(getDeps(mikroMysql, "packages/db/package.json").deps, [
+      "@mikro-orm/core",
+      "@mikro-orm/mysql",
+    ]);
+
+    expectIncludesAll(getDeps(sequelizeSqlite, "packages/db/package.json").deps, [
+      "sequelize",
+      "sequelize-typescript",
+      "sqlite3",
+    ]);
+    expectIncludesAll(getDeps(sequelizePostgres, "packages/db/package.json").deps, [
+      "sequelize",
+      "sequelize-typescript",
+      "pg",
+    ]);
+    expect(getDeps(sequelizePostgres, "packages/db/package.json").devDeps).toEqual(["@types/pg"]);
   });
 
   it("adds EdgeDB generator tooling", () => {

--- a/packages/template-generator/test/processors/env-vars.test.ts
+++ b/packages/template-generator/test/processors/env-vars.test.ts
@@ -180,4 +180,222 @@ describe("processEnvVariables", () => {
     expect(serverEnv.DATABASE_URL).toBe("http://127.0.0.1:8080");
     expect(webEnv.NEXT_PUBLIC_SANITY_API_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
+
+  it("writes self-hosted auth env vars for NextAuth, Stack Auth, and Supabase Auth", () => {
+    const nextauthVfs = createSeededVFS(["apps/web/package.json"]);
+    const stackAuthVfs = createSeededVFS(["apps/web/package.json"]);
+    const supabaseVfs = createSeededVFS(["apps/web/package.json"]);
+
+    processEnvVariables(
+      nextauthVfs,
+      makeConfig({
+        frontend: ["next"],
+        backend: "self",
+        auth: "nextauth",
+      }),
+    );
+    processEnvVariables(
+      stackAuthVfs,
+      makeConfig({
+        frontend: ["next"],
+        backend: "self",
+        auth: "stack-auth",
+      }),
+    );
+    processEnvVariables(
+      supabaseVfs,
+      makeConfig({
+        frontend: ["next"],
+        backend: "self",
+        auth: "supabase-auth",
+      }),
+    );
+
+    const nextauthEnv = getEnvVars(nextauthVfs, "apps/web/.env");
+    const stackEnv = getEnvVars(stackAuthVfs, "apps/web/.env");
+    const supabaseEnv = getEnvVars(supabaseVfs, "apps/web/.env");
+
+    expect(nextauthEnv.AUTH_SECRET).toMatch(/^[A-Za-z0-9]{32}$/);
+    expect(nextauthEnv.AUTH_TRUST_HOST).toBe("true");
+    expect(nextauthEnv.AUTH_GITHUB_ID).toBe("");
+    expect(nextauthEnv.AUTH_GOOGLE_SECRET).toBe("");
+
+    expect(stackEnv.NEXT_PUBLIC_STACK_PROJECT_ID).toBe("");
+    expect(stackEnv.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY).toBe("");
+    expect(stackEnv.STACK_SECRET_SERVER_KEY).toBe("");
+
+    expect(supabaseEnv.NEXT_PUBLIC_SUPABASE_URL).toBe("");
+    expect(supabaseEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("");
+    expect(supabaseEnv.SUPABASE_SERVICE_ROLE_KEY).toBe("");
+  });
+
+  it("writes Clerk env vars for convex Next.js and self-hosted TanStack Start", () => {
+    const convexNext = createSeededVFS(["apps/web/package.json"]);
+    const selfTanstackStart = createSeededVFS(["apps/web/package.json"]);
+
+    processEnvVariables(
+      convexNext,
+      makeConfig({
+        frontend: ["next"],
+        backend: "convex",
+        auth: "clerk",
+      }),
+    );
+    processEnvVariables(
+      selfTanstackStart,
+      makeConfig({
+        frontend: ["tanstack-start"],
+        backend: "self",
+        auth: "clerk",
+      }),
+    );
+
+    const convexEnv = getEnvVars(convexNext, "apps/web/.env");
+    const selfEnv = getEnvVars(selfTanstackStart, "apps/web/.env");
+
+    expect(convexEnv.NEXT_PUBLIC_CONVEX_URL).toBe("https://<YOUR_CONVEX_URL>");
+    expect(convexEnv.NEXT_PUBLIC_CLERK_FRONTEND_API_URL).toBe("");
+    expect(convexEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY).toBe("");
+    expect(convexEnv.CLERK_SECRET_KEY).toBe("");
+
+    expect(selfEnv.VITE_CLERK_PUBLISHABLE_KEY).toBe("");
+    expect(selfEnv.CLERK_SECRET_KEY).toBe("");
+    expect(selfEnv.VITE_SERVER_URL).toBeUndefined();
+  });
+
+  it("writes analytics and feature-flag env vars with framework-specific prefixes", () => {
+    const nextPlausible = createSeededVFS(["apps/web/package.json", "apps/server/package.json"]);
+    const nuxtGrowthbook = createSeededVFS(["apps/web/package.json", "apps/server/package.json"]);
+    const sveltePosthogUmami = createSeededVFS([
+      "apps/web/package.json",
+      "apps/server/package.json",
+    ]);
+
+    processEnvVariables(
+      nextPlausible,
+      makeConfig({
+        frontend: ["next"],
+        backend: "hono",
+        analytics: "plausible",
+      }),
+    );
+    processEnvVariables(
+      nuxtGrowthbook,
+      makeConfig({
+        frontend: ["nuxt"],
+        backend: "hono",
+        featureFlags: "growthbook",
+      }),
+    );
+    processEnvVariables(
+      sveltePosthogUmami,
+      makeConfig({
+        frontend: ["svelte"],
+        backend: "hono",
+        analytics: "umami",
+        featureFlags: "posthog",
+      }),
+    );
+
+    const nextEnv = getEnvVars(nextPlausible, "apps/web/.env");
+    const nuxtEnv = getEnvVars(nuxtGrowthbook, "apps/web/.env");
+    const svelteEnv = getEnvVars(sveltePosthogUmami, "apps/web/.env");
+
+    expect(nextEnv.NEXT_PUBLIC_PLAUSIBLE_DOMAIN).toBe("");
+    expect(nextEnv.NEXT_PUBLIC_PLAUSIBLE_API_HOST).toBe("https://plausible.io");
+
+    expect(nuxtEnv.NUXT_PUBLIC_GROWTHBOOK_API_HOST).toBe("https://cdn.growthbook.io");
+    expect(nuxtEnv.NUXT_PUBLIC_GROWTHBOOK_CLIENT_KEY).toBe("");
+
+    expect(svelteEnv.PUBLIC_UMAMI_WEBSITE_ID).toBe("");
+    expect(svelteEnv.PUBLIC_UMAMI_SCRIPT_URL).toBe("https://cloud.umami.is/script.js");
+    expect(svelteEnv.PUBLIC_POSTHOG_KEY).toBe("");
+    expect(svelteEnv.PUBLIC_POSTHOG_HOST).toBe("https://us.i.posthog.com");
+  });
+
+  it("writes server env vars for email, observability, queues, caching, search, and storage providers", () => {
+    const sentryTemporal = createSeededVFS(["apps/server/package.json"]);
+    const grafanaBullmq = createSeededVFS(["apps/server/package.json"]);
+    const otelInngest = createSeededVFS(["apps/server/package.json"]);
+
+    processEnvVariables(
+      sentryTemporal,
+      makeConfig({
+        frontend: ["react-router"],
+        backend: "hono",
+        email: "aws-ses",
+        observability: "sentry",
+        jobQueue: "temporal",
+        caching: "upstash-redis",
+        search: "elasticsearch",
+        fileStorage: "r2",
+      }),
+    );
+    processEnvVariables(
+      grafanaBullmq,
+      makeConfig({
+        frontend: ["react-router"],
+        backend: "hono",
+        email: "nodemailer",
+        observability: "grafana",
+        jobQueue: "bullmq",
+        search: "typesense",
+        fileStorage: "s3",
+      }),
+    );
+    processEnvVariables(
+      otelInngest,
+      makeConfig({
+        frontend: ["react-router"],
+        backend: "hono",
+        email: "mailgun",
+        observability: "opentelemetry",
+        jobQueue: "inngest",
+        search: "algolia",
+      }),
+    );
+
+    const sentryEnv = getEnvVars(sentryTemporal, "apps/server/.env");
+    const grafanaEnv = getEnvVars(grafanaBullmq, "apps/server/.env");
+    const otelEnv = getEnvVars(otelInngest, "apps/server/.env");
+
+    expect(sentryEnv.AWS_REGION).toBe("us-east-1");
+    expect(sentryEnv.SENTRY_DSN).toBe("");
+    expect(sentryEnv.TEMPORAL_ADDRESS).toBe("localhost:7233");
+    expect(sentryEnv.UPSTASH_REDIS_REST_URL).toBe("");
+    expect(sentryEnv.ELASTICSEARCH_NODE).toBe("http://localhost:9200");
+    expect(sentryEnv.R2_BUCKET_NAME).toBe("");
+
+    expect(grafanaEnv.SMTP_HOST).toBe("smtp.ethereal.email");
+    expect(grafanaEnv.METRICS_PORT).toBe("9090");
+    expect(grafanaEnv.REDIS_HOST).toBe("localhost");
+    expect(grafanaEnv.TYPESENSE_PORT).toBe("8108");
+    expect(grafanaEnv.AWS_S3_BUCKET_NAME).toBe("");
+
+    expect(otelEnv.MAILGUN_API_KEY).toBe("");
+    expect(otelEnv.OTEL_SERVICE_NAME).toBe("");
+    expect(otelEnv.INNGEST_EVENT_KEY).toBe("");
+    expect(otelEnv.ALGOLIA_APP_ID).toBe("");
+  });
+
+  it("writes the Discord Chat SDK example env vars for Nuxt self-backend projects", () => {
+    const vfs = createSeededVFS(["apps/web/package.json"]);
+
+    processEnvVariables(
+      vfs,
+      makeConfig({
+        backend: "self",
+        frontend: ["nuxt"],
+        examples: ["chat-sdk"],
+      }),
+    );
+
+    const env = getEnvVars(vfs, "apps/web/.env");
+
+    expect(env.DISCORD_BOT_TOKEN).toBe("");
+    expect(env.DISCORD_PUBLIC_KEY).toBe("");
+    expect(env.DISCORD_APPLICATION_ID).toBe("");
+    expect(env.ANTHROPIC_API_KEY).toBe("");
+    expect(env.NUXT_PUBLIC_SITE_URL).toBe("http://localhost:3000");
+  });
 });

--- a/packages/template-generator/test/processors/file-upload-deps.test.ts
+++ b/packages/template-generator/test/processors/file-upload-deps.test.ts
@@ -69,6 +69,52 @@ describe("processFileUploadDeps", () => {
     expect(getDeps(astroBaseVfs, "apps/web/package.json").deps).toEqual(["uploadthing"]);
   });
 
+  it("adds UploadThing vue and solid adapters for supported web integrations", () => {
+    const nuxtVfs = createSeededVFS(["apps/web/package.json"]);
+    const astroVueVfs = createSeededVFS(["apps/web/package.json"]);
+    const astroSolidVfs = createSeededVFS(["apps/web/package.json"]);
+
+    processFileUploadDeps(
+      nuxtVfs,
+      makeConfig({
+        fileUpload: "uploadthing",
+        backend: "self",
+        frontend: ["nuxt"],
+      }),
+    );
+    processFileUploadDeps(
+      astroVueVfs,
+      makeConfig({
+        fileUpload: "uploadthing",
+        backend: "self",
+        frontend: ["astro"],
+        astroIntegration: "vue",
+      }),
+    );
+    processFileUploadDeps(
+      astroSolidVfs,
+      makeConfig({
+        fileUpload: "uploadthing",
+        backend: "self",
+        frontend: ["astro"],
+        astroIntegration: "solid",
+      }),
+    );
+
+    expectIncludesAll(getDeps(nuxtVfs, "apps/web/package.json").deps, [
+      "uploadthing",
+      "@uploadthing/nuxt",
+    ]);
+    expectIncludesAll(getDeps(astroVueVfs, "apps/web/package.json").deps, [
+      "uploadthing",
+      "@uploadthing/vue",
+    ]);
+    expectIncludesAll(getDeps(astroSolidVfs, "apps/web/package.json").deps, [
+      "uploadthing",
+      "@uploadthing/solid",
+    ]);
+  });
+
   it("adds FilePond framework adapters or vanilla plugins depending on frontend", () => {
     const svelteVfs = createSeededVFS(["apps/web/package.json"]);
     const astroVfs = createSeededVFS(["apps/web/package.json"]);
@@ -115,6 +161,36 @@ describe("processFileUploadDeps", () => {
       "filepond-plugin-file-validate-size",
       "filepond-plugin-file-validate-type",
       "filepond-plugin-image-preview",
+    ]);
+  });
+
+  it("adds FilePond vue adapters for Nuxt and Astro Vue integrations", () => {
+    const nuxtVfs = createSeededVFS(["apps/web/package.json"]);
+    const astroVueVfs = createSeededVFS(["apps/web/package.json"]);
+
+    processFileUploadDeps(
+      nuxtVfs,
+      makeConfig({
+        fileUpload: "filepond",
+        frontend: ["nuxt"],
+      }),
+    );
+    processFileUploadDeps(
+      astroVueVfs,
+      makeConfig({
+        fileUpload: "filepond",
+        frontend: ["astro"],
+        astroIntegration: "vue",
+      }),
+    );
+
+    expectIncludesAll(getDeps(nuxtVfs, "apps/web/package.json").deps, [
+      "filepond",
+      "vue-filepond",
+    ]);
+    expectIncludesAll(getDeps(astroVueVfs, "apps/web/package.json").deps, [
+      "filepond",
+      "vue-filepond",
     ]);
   });
 
@@ -166,6 +242,36 @@ describe("processFileUploadDeps", () => {
       "@uppy/progress-bar",
       "@uppy/tus",
       "@uppy/xhr-upload",
+    ]);
+  });
+
+  it("adds Uppy vue and react adapters for Nuxt and Astro integrations", () => {
+    const nuxtVfs = createSeededVFS(["apps/web/package.json"]);
+    const astroReactVfs = createSeededVFS(["apps/web/package.json"]);
+
+    processFileUploadDeps(
+      nuxtVfs,
+      makeConfig({
+        fileUpload: "uppy",
+        frontend: ["nuxt"],
+      }),
+    );
+    processFileUploadDeps(
+      astroReactVfs,
+      makeConfig({
+        fileUpload: "uppy",
+        frontend: ["astro"],
+        astroIntegration: "react",
+      }),
+    );
+
+    expectIncludesAll(getDeps(nuxtVfs, "apps/web/package.json").deps, [
+      "@uppy/core",
+      "@uppy/vue",
+    ]);
+    expectIncludesAll(getDeps(astroReactVfs, "apps/web/package.json").deps, [
+      "@uppy/core",
+      "@uppy/react",
     ]);
   });
 

--- a/packages/template-generator/test/template-handlers/auth.test.ts
+++ b/packages/template-generator/test/template-handlers/auth.test.ts
@@ -77,4 +77,180 @@ describe("processAuthTemplates", () => {
     expect(vfs.fileExists("apps/web/login.tsx")).toBe(true);
     expect(vfs.fileExists("packages/db/schema.prisma")).toBe(true);
   });
+
+  it("routes Stack Auth, Supabase Auth, and Auth0 special-case Next.js templates", async () => {
+    const stackTemplates = makeTemplates({
+      "auth/stack-auth/fullstack/next/handler.ts.hbs": "fullstack",
+      "auth/stack-auth/web/react/next/page.tsx.hbs": "web",
+    });
+    const supabaseTemplates = makeTemplates({
+      "auth/supabase-auth/fullstack/next/middleware.ts.hbs": "fullstack",
+      "auth/supabase-auth/web/react/next/login.tsx.hbs": "web",
+    });
+    const auth0Templates = makeTemplates({
+      "auth/auth0/fullstack/next/api.ts.hbs": "fullstack",
+      "auth/auth0/web/react/next/button.tsx.hbs": "web",
+    });
+    const stackVfs = new VirtualFileSystem();
+    const supabaseVfs = new VirtualFileSystem();
+    const auth0Vfs = new VirtualFileSystem();
+
+    await processAuthTemplates(
+      stackVfs,
+      stackTemplates,
+      makeConfig({
+        auth: "stack-auth",
+        backend: "self",
+        frontend: ["next"],
+      }),
+    );
+    await processAuthTemplates(
+      supabaseVfs,
+      supabaseTemplates,
+      makeConfig({
+        auth: "supabase-auth",
+        backend: "self",
+        frontend: ["next"],
+      }),
+    );
+    await processAuthTemplates(
+      auth0Vfs,
+      auth0Templates,
+      makeConfig({
+        auth: "auth0",
+        backend: "self",
+        frontend: ["next"],
+      }),
+    );
+
+    expect(stackVfs.fileExists("apps/web/handler.ts")).toBe(true);
+    expect(stackVfs.fileExists("apps/web/page.tsx")).toBe(true);
+    expect(supabaseVfs.fileExists("apps/web/middleware.ts")).toBe(true);
+    expect(supabaseVfs.fileExists("apps/web/login.tsx")).toBe(true);
+    expect(auth0Vfs.fileExists("apps/web/api.ts")).toBe(true);
+    expect(auth0Vfs.fileExists("apps/web/button.tsx")).toBe(true);
+  });
+
+  it("routes standard Clerk templates for server, React fullstack, db, and native variants", async () => {
+    const templates = makeTemplates({
+      "auth/clerk/server/base/server.ts.hbs": "server",
+      "auth/clerk/server/db/drizzle/sqlite/schema.ts.hbs": "db",
+      "auth/clerk/web/react/base/provider.tsx.hbs": "base",
+      "auth/clerk/web/react/tanstack-start/page.tsx.hbs": "web",
+      "auth/clerk/fullstack/tanstack-start/middleware.ts.hbs": "fullstack",
+      "auth/clerk/native/base/session.tsx.hbs": "native-base",
+      "auth/clerk/native/unistyles/app.tsx.hbs": "native",
+    });
+    const vfs = new VirtualFileSystem();
+
+    await processAuthTemplates(
+      vfs,
+      templates,
+      makeConfig({
+        auth: "clerk",
+        backend: "self",
+        frontend: ["tanstack-start", "native-unistyles"],
+        orm: "drizzle",
+        database: "sqlite",
+      }),
+    );
+
+    expect(vfs.fileExists("packages/auth/server.ts")).toBe(true);
+    expect(vfs.fileExists("packages/db/schema.ts")).toBe(true);
+    expect(vfs.fileExists("apps/web/provider.tsx")).toBe(true);
+    expect(vfs.fileExists("apps/web/page.tsx")).toBe(true);
+    expect(vfs.fileExists("apps/web/middleware.ts")).toBe(true);
+    expect(vfs.fileExists("apps/native/session.tsx")).toBe(true);
+    expect(vfs.fileExists("apps/native/app.tsx")).toBe(true);
+  });
+
+  it("routes Better Auth templates for svelte, solid-start, and nuxt variants", async () => {
+    const svelteTemplates = makeTemplates({
+      "auth/better-auth/server/base/server.ts.hbs": "server",
+      "auth/better-auth/server/db/prisma/sqlite/schema.prisma.hbs": "db",
+      "auth/better-auth/web/svelte/hooks.server.ts.hbs": "web",
+      "auth/better-auth/fullstack/svelte/page.server.ts.hbs": "fullstack",
+    });
+    const solidStartTemplates = makeTemplates({
+      "auth/better-auth/server/base/auth.ts.hbs": "server",
+      "auth/better-auth/web/solid-start/route.tsx.hbs": "web",
+      "auth/better-auth/fullstack/solid-start/server.ts.hbs": "fullstack",
+    });
+    const nuxtTemplates = makeTemplates({
+      "auth/better-auth/server/base/server.ts.hbs": "server",
+      "auth/better-auth/web/nuxt/plugin.ts.hbs": "web",
+    });
+    const svelteVfs = new VirtualFileSystem();
+    const solidStartVfs = new VirtualFileSystem();
+    const nuxtVfs = new VirtualFileSystem();
+
+    await processAuthTemplates(
+      svelteVfs,
+      svelteTemplates,
+      makeConfig({
+        auth: "better-auth",
+        backend: "self",
+        frontend: ["svelte"],
+        orm: "prisma",
+        database: "sqlite",
+      }),
+    );
+    await processAuthTemplates(
+      solidStartVfs,
+      solidStartTemplates,
+      makeConfig({
+        auth: "better-auth",
+        backend: "self",
+        frontend: ["solid-start"],
+      }),
+    );
+    await processAuthTemplates(
+      nuxtVfs,
+      nuxtTemplates,
+      makeConfig({
+        auth: "better-auth",
+        backend: "hono",
+        frontend: ["nuxt"],
+      }),
+    );
+
+    expect(svelteVfs.fileExists("packages/auth/server.ts")).toBe(true);
+    expect(svelteVfs.fileExists("packages/db/schema.prisma")).toBe(true);
+    expect(svelteVfs.fileExists("apps/web/hooks.server.ts")).toBe(true);
+    expect(svelteVfs.fileExists("apps/web/page.server.ts")).toBe(true);
+
+    expect(solidStartVfs.fileExists("packages/auth/auth.ts")).toBe(true);
+    expect(solidStartVfs.fileExists("apps/web/route.tsx")).toBe(true);
+    expect(solidStartVfs.fileExists("apps/web/server.ts")).toBe(true);
+
+    expect(nuxtVfs.fileExists("packages/auth/server.ts")).toBe(true);
+    expect(nuxtVfs.fileExists("apps/web/plugin.ts")).toBe(true);
+  });
+
+  it("routes convex Better Auth templates for Next.js and native uniwind projects", async () => {
+    const templates = makeTemplates({
+      "auth/better-auth/convex/backend/auth.ts.hbs": "backend",
+      "auth/better-auth/convex/web/react/base/provider.tsx.hbs": "base",
+      "auth/better-auth/convex/web/react/next/page.tsx.hbs": "web",
+      "auth/better-auth/convex/native/base/session.tsx.hbs": "native-base",
+      "auth/better-auth/convex/native/uniwind/app.tsx.hbs": "native",
+    });
+    const vfs = new VirtualFileSystem();
+
+    await processAuthTemplates(
+      vfs,
+      templates,
+      makeConfig({
+        auth: "better-auth",
+        backend: "convex",
+        frontend: ["next", "native-uniwind"],
+      }),
+    );
+
+    expect(vfs.fileExists("packages/backend/auth.ts")).toBe(true);
+    expect(vfs.fileExists("apps/web/provider.tsx")).toBe(true);
+    expect(vfs.fileExists("apps/web/page.tsx")).toBe(true);
+    expect(vfs.fileExists("apps/native/session.tsx")).toBe(true);
+    expect(vfs.fileExists("apps/native/app.tsx")).toBe(true);
+  });
 });


### PR DESCRIPTION
## What changed
- add another tranche of focused `packages/template-generator` tests in the highest-yield low-coverage files
- expand coverage for `db-deps`, `api-deps`, `file-upload-deps`, `env-vars`, and `template-handlers/auth`
- keep the follow-up scoped to tests only so it stacks cleanly on the first PR

## Coverage impact
Package-local Bun coverage moved from `87.28%` to `89.67%` line coverage overall.

Notable source-file improvements from the follow-up pass:
- `src/processors/db-deps.ts`: `52.75%` -> `99.26%`
- `src/template-handlers/auth.ts`: `47.04%` -> `97.39%`
- `src/processors/api-deps.ts`: `64.09%` -> `86.35%`
- `src/processors/file-upload-deps.ts`: `66.54%` -> `80.31%`
- `src/processors/env-vars.ts`: `76.27%` -> `84.46%`

The remaining all-files gap is still partially dragged down by Bun counting executed `packages/types/dist` files in the aggregate report.

## Why
The first PR put the test harness and core package coverage in place. This follow-up pushes deeper into the branchy processor and handler code paths that were still under-covered.

## Validation
- `~/.bun/bin/bun test --coverage` (package-local)
- `~/.bun/bin/bun run test --filter=@better-fullstack/template-generator`
