### PR TITLE
chore: save local WIP changes

### DIFF
--- a/.github/workflows/deps-check.yaml
+++ b/.github/workflows/deps-check.yaml
@@ -278,4 +278,5 @@ jobs:
         with:
           name: major-deps-smoke-results
           path: testing/.smoke-output/
+          include-hidden-files: true
           retention-days: 7

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -127,6 +127,7 @@ jobs:
         with:
           name: smoke-strict-results
           path: testing/.smoke-output/
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -180,5 +180,6 @@ jobs:
         with:
           name: smoke-results
           path: testing/.smoke-output/
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/template-matrix.yaml
+++ b/.github/workflows/template-matrix.yaml
@@ -84,4 +84,5 @@ jobs:
         with:
           name: smoke-results-${{ matrix.preset }}
           path: testing/.smoke-output/${{ matrix.preset }}
+          include-hidden-files: true
           if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,15 +17,6 @@ See `docs/guidelines/` for deeper reference on these topics:
 - `template-output-and-validation.md` - template conditional logic, generated output validation, sync test discipline, and framework-specific constraints
 - `adding-new-tool-options/` - **read this subfolder when adding any new library, tool, or category** to any ecosystem (TypeScript, Rust, Go, Python). Covers every file that must be touched, with worked examples, template handler reference, test patterns, and routing gotchas (Convex skips, self-backend, frontend array detection, processor ordering)
 
-## Git Remotes and Pull Requests
-
-This is a fork. There are two remotes:
-
-- `origin` → `Marve10s/Better-Fullstack` (our fork — **always create PRs here**)
-- `upstream` → `AmanVarshney01/create-better-t-stack` (the upstream project — never push PRs here)
-
-When creating pull requests, always target `--repo Marve10s/Better-Fullstack`. Do not let `gh pr create` default to the upstream repo.
-
 ## Workflow
 
 - Never start the dev server (`turbo dev`, `bun run dev`, `vite dev`, etc.) unless explicitly asked to.

--- a/apps/web/src/components/home/footer.tsx
+++ b/apps/web/src/components/home/footer.tsx
@@ -30,21 +30,8 @@ export default function Footer() {
           </Link>
         </div>
 
-        {/* Fork info */}
-        <p className="mt-8 text-center text-xs text-muted-foreground">
-          Forked from{" "}
-          <a
-            href="https://github.com/better-t-stack/create-better-t-stack"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-foreground underline-offset-4 hover:underline"
-          >
-            create-better-t-stack
-          </a>
-        </p>
-
         {/* Copyright */}
-        <p className="mt-2 text-center text-xs text-muted-foreground">
+        <p className="mt-8 text-center text-xs text-muted-foreground">
           {new Date().getFullYear()} Better Fullstack · Built by{" "}
           <a
             href="https://elkamali.dev"

--- a/apps/web/src/routes/new.tsx
+++ b/apps/web/src/routes/new.tsx
@@ -58,14 +58,31 @@ export const Route = createFileRoute("/new")({
   component: StackBuilderPage,
 });
 
+function BuilderLoadingState() {
+  return (
+    <div className="flex h-[calc(100vh-64px)] w-full flex-col items-center justify-center bg-background">
+      <div className="flex flex-col items-center gap-6">
+        <div className="relative flex h-12 w-12 items-center justify-center">
+          <div className="absolute h-full w-full animate-spin rounded-full border-2 border-muted border-t-primary" />
+          <div className="h-2 w-2 rounded-full bg-primary" />
+        </div>
+        <div className="flex flex-col items-center gap-1.5">
+          <h3 className="font-mono text-sm font-medium tracking-tight text-foreground">
+            Loading Builder
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Preparing your workspace...
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function StackBuilderPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex h-[calc(100vh-64px)] items-center justify-center">Loading...</div>
-      }
-    >
-      <div className="grid h-[calc(100vh-64px)] w-full flex-1 grid-cols-1 overflow-hidden">
+    <Suspense fallback={<BuilderLoadingState />}>
+      <div className="flex h-[calc(100vh-64px)] w-full flex-1 flex-col overflow-hidden bg-background">
         <StackBuilder />
       </div>
     </Suspense>

--- a/docs/plans/planned/java-ecosystem-implementation-plan.md
+++ b/docs/plans/planned/java-ecosystem-implementation-plan.md
@@ -1,0 +1,410 @@
+# Java Ecosystem Expansion
+
+Requested in GitHub issue #119. This plan replaces the earlier Java wishlist with an implementation plan aligned to the repo's "new ecosystem" workflow in `docs/guidelines/adding-new-tool-options/README.md` Scenario C.
+
+Goal: ship Java as the fifth language ecosystem with a stable MVP first, then expand once generator, CLI, MCP, and web-builder parity are proven.
+
+---
+
+## MVP Scope
+
+Phase 1 ships these six Java categories only:
+
+- `javaWebFramework`: `spring-boot`, `quarkus`, `micronaut`, `none`
+- `javaOrm`: `spring-data-jpa`, `jooq`, `none`
+- `javaAuth`: `spring-security`, `none`
+- `javaBuildSystem`: `maven`, `gradle`
+- `javaLogging`: `logback`, `log4j2`, `none`
+- `javaTesting`: `junit5`, `none`
+
+Deliberately out of MVP:
+
+- `mybatis`
+- `keycloak`
+- `spring-graphql`
+- `grpc-java`
+- `openapi-generator`
+- `mockito`
+- `testcontainers`
+- task queues / messaging
+- observability
+
+These are phase-2+ additions because they add infra assumptions, code generation workflows, or materially more template branching than the base ecosystem needs.
+
+---
+
+## Design Decisions
+
+### Defaults
+
+- Default web framework: `spring-boot`
+- Default ORM: `spring-data-jpa`
+- Default auth: `none`
+- Default build system: `maven`
+- Default logging: `logback`
+- Default testing: `junit5`
+
+Rationale:
+
+- Spring Boot + Maven + JPA is the most broadly expected baseline.
+- `spring-security` should stay opt-in because it changes application structure and config more than logging or testing.
+- `junit5` is the normal default for Java projects and keeps generated output closer to "real project" expectations than omitting tests.
+
+### Template Strategy
+
+Use a Go-style monolithic Java handler:
+
+- `packages/template-generator/templates/java-base/`
+- `packages/template-generator/src/template-handlers/java-base.ts`
+
+Handler rules:
+
+- boolean flags for framework/build/auth/orm/testing/logging combinations
+- explicit path skips for mutually exclusive files
+- empty-file skip for fully conditional templates
+
+This is the safest pattern because Java will mix shared source layout with framework-specific entrypoints and config files.
+
+### Project Shape
+
+Base template structure should follow standard Java conventions:
+
+```text
+packages/template-generator/templates/java-base/
+  pom.xml.hbs
+  build.gradle.kts.hbs
+  settings.gradle.kts.hbs
+  src/main/java/com/example/
+    Application.java.hbs
+    controller/GreetingController.java.hbs
+    config/SecurityConfig.java.hbs
+    repository/...
+    model/...
+  src/main/resources/
+    application.yml.hbs
+    logback-spring.xml.hbs
+    log4j2.xml.hbs
+  src/test/java/com/example/
+    ApplicationTest.java.hbs
+  .gitignore
+```
+
+Notes:
+
+- Maven and Gradle manifests are mutually exclusive.
+- Logging config files should be mutually exclusive.
+- Security files should only emit when auth is enabled.
+- JPA and jOOQ should not share repository/data-access templates.
+
+---
+
+## Compatibility Rules
+
+These rules need to exist before UI and CLI exposure so the system cannot compose invalid Java stacks.
+
+### Hard constraints
+
+- `javaBuildSystem` cannot be `none`
+- `spring-security` only works with `spring-boot`
+- `logback` and `log4j2` are mutually exclusive scalar choices in `javaLogging`
+- `spring-data-jpa` and `jooq` are mutually exclusive scalar choices in `javaOrm`
+
+### Expected compatibility posture
+
+- `spring-data-jpa` should work with `spring-boot`, `quarkus`, and `micronaut` only if the template layer can emit valid project wiring for each framework
+- `jooq` should work with all three frameworks only if the template layer emits consistent config and repository wiring
+- `logback` should be valid across all Java frameworks
+- `log4j2` should be valid across all Java frameworks only if manifests and config files are correctly swapped
+- `junit5` should be valid across all Java frameworks and both build systems
+
+If a combination is not implemented in templates, it must be blocked in `packages/types/src/compatibility.ts` rather than silently generating partial output.
+
+### Auto-adjustment policy
+
+Avoid silent rewrites for Java MVP. Prefer:
+
+- explicit disabled reasons in builder/CLI
+- hard blocks in compatibility analysis
+
+The only acceptable auto-fill is assigning defaults when the user omitted a Java category entirely.
+
+---
+
+## Implementation Phases
+
+## Phase 1: Schema and Type Foundation
+
+Add Java as a first-class ecosystem and define all six categories.
+
+Files:
+
+- `packages/types/src/schemas.ts`
+- `packages/types/src/types.ts`
+- `packages/types/src/option-metadata.ts`
+- `packages/types/src/compatibility.ts`
+
+Work:
+
+- add `"java"` to `EcosystemSchema`
+- create `JavaWebFrameworkSchema`, `JavaOrmSchema`, `JavaAuthSchema`, `JavaBuildSystemSchema`, `JavaLoggingSchema`, `JavaTestingSchema`
+- wire all Java fields through `CreateInputSchema`, `ProjectConfigSchema`, and `BetterTStackConfigSchema`
+- export inferred Java types and `*_VALUES`
+- add label overrides and category metadata
+- add category display names and disabled-reason logic
+
+Exit criteria:
+
+- Type layer builds cleanly
+- Java categories appear in all schema surfaces
+- compatibility logic rejects unsupported combinations instead of allowing partial generation
+
+## Phase 2: Generator Skeleton and Java Base Templates
+
+Create the Java template tree and the generator entrypoint.
+
+Files:
+
+- `packages/template-generator/templates/java-base/`
+- `packages/template-generator/src/template-handlers/java-base.ts`
+- `packages/template-generator/src/template-handlers/index.ts`
+- `packages/template-generator/src/generator.ts`
+- `packages/template-generator/src/processors/readme-generator.ts`
+- `packages/template-generator/src/processors/ai-docs-generator.ts`
+
+Work:
+
+- create Java base handler using Go-style boolean and skip rules
+- add ecosystem dispatch in generator
+- emit framework-specific entrypoints for Spring Boot, Quarkus, and Micronaut
+- emit build-specific manifests for Maven and Gradle
+- emit ORM-specific data-access templates for JPA and jOOQ
+- emit optional security config for Spring Boot only
+- emit optional test scaffold for JUnit 5
+- wire README generation with Java framework/build descriptions
+- wire AI docs generation with Java run/dev/test commands
+
+Exit criteria:
+
+- generator can produce a complete Java project for each supported MVP combination
+- incompatible files are skipped cleanly
+- no empty or broken files remain in generated output
+
+## Phase 3: CLI, MCP, and Config Serialization
+
+Expose Java throughout the CLI and machine-facing config surfaces.
+
+Files:
+
+- `apps/cli/src/prompts/java-ecosystem.ts`
+- `apps/cli/src/prompts/config-prompts.ts`
+- `apps/cli/src/index.ts`
+- `apps/cli/src/mcp.ts`
+- `apps/cli/src/utils/bts-config.ts`
+- `apps/cli/src/constants.ts`
+- `apps/cli/src/helpers/core/command-handlers.ts`
+- `apps/cli/src/utils/generate-reproducible-command.ts`
+- `apps/cli/src/helpers/core/post-installation.ts`
+
+Work:
+
+- add Java prompts and defaults
+- register all Java CLI flags
+- wire Java categories into MCP schema maps and project-config builders
+- persist Java fields in `bts.jsonc`
+- include Java fields in reproducible command generation
+- add post-install instructions for JDK and Maven/Gradle usage
+
+Exit criteria:
+
+- CLI can create Java projects interactively and non-interactively
+- MCP can plan and create Java projects with the same fields
+- generated commands round-trip correctly
+
+## Phase 4: Web Builder and URL State
+
+Expose Java in the builder with parity to CLI behavior.
+
+Files:
+
+- `apps/web/src/lib/constant.ts`
+- `apps/web/src/lib/tech-icons.ts`
+- `apps/web/src/lib/tech-resource-links.ts`
+- `apps/web/src/lib/preview-config.ts`
+- `apps/web/src/lib/stack-defaults.ts`
+- `apps/web/src/lib/stack-url-keys.ts`
+- `apps/web/src/lib/stack-url-state.ts`
+- `apps/web/src/lib/stack-utils.ts`
+
+Work:
+
+- add `java` ecosystem option
+- add all six Java categories to `TECH_OPTIONS` and `ECOSYSTEM_CATEGORIES`
+- assign icons and resource links
+- map `StackState` to Java config fields
+- add URL serialization keys for each Java category
+- add Java command generation order
+
+Exit criteria:
+
+- builder can select Java and all MVP categories
+- URL state round-trips correctly
+- generated web command matches CLI naming
+
+## Phase 5: Verification and Release Guard
+
+Prove parity across type layer, generator, CLI, and web builder before expansion.
+
+Files:
+
+- `apps/cli/test/java-ecosystem.test.ts`
+- `apps/cli/test/template-snapshots.test.ts`
+- `apps/cli/test/generate-reproducible-command.test.ts`
+- `apps/cli/test/add-history-commands.test.ts`
+- `testing/lib/generate-combos/options.ts`
+- `testing/lib/presets.ts`
+
+Work:
+
+- add focused Java generation tests
+- add representative Java snapshot configs
+- update command/history tests for Java flags
+- add Java defaults to smoke-combo generation
+
+Exit criteria:
+
+- Java generation tests pass
+- snapshots are stable
+- release lane passes with Java included
+
+---
+
+## Required File Surface
+
+This is the minimum expected change surface for Java MVP, based on Scenario C.
+
+### Types and compatibility
+
+- `packages/types/src/schemas.ts`
+- `packages/types/src/types.ts`
+- `packages/types/src/option-metadata.ts`
+- `packages/types/src/compatibility.ts`
+
+### Template generator
+
+- `packages/template-generator/templates/java-base/`
+- `packages/template-generator/src/template-handlers/java-base.ts`
+- `packages/template-generator/src/template-handlers/index.ts`
+- `packages/template-generator/src/generator.ts`
+- `packages/template-generator/src/processors/readme-generator.ts`
+- `packages/template-generator/src/processors/ai-docs-generator.ts`
+
+### CLI and MCP
+
+- `apps/cli/src/prompts/java-ecosystem.ts`
+- `apps/cli/src/prompts/config-prompts.ts`
+- `apps/cli/src/index.ts`
+- `apps/cli/src/mcp.ts`
+- `apps/cli/src/utils/bts-config.ts`
+- `apps/cli/src/constants.ts`
+- `apps/cli/src/helpers/core/command-handlers.ts`
+- `apps/cli/src/utils/generate-reproducible-command.ts`
+- `apps/cli/src/helpers/core/post-installation.ts`
+
+### Web builder
+
+- `apps/web/src/lib/constant.ts`
+- `apps/web/src/lib/tech-icons.ts`
+- `apps/web/src/lib/tech-resource-links.ts`
+- `apps/web/src/lib/preview-config.ts`
+- `apps/web/src/lib/stack-defaults.ts`
+- `apps/web/src/lib/stack-url-keys.ts`
+- `apps/web/src/lib/stack-url-state.ts`
+- `apps/web/src/lib/stack-utils.ts`
+
+### Tests and smoke coverage
+
+- `apps/cli/test/java-ecosystem.test.ts`
+- `apps/cli/test/template-snapshots.test.ts`
+- `apps/cli/test/generate-reproducible-command.test.ts`
+- `apps/cli/test/add-history-commands.test.ts`
+- `testing/lib/generate-combos/options.ts`
+- `testing/lib/presets.ts`
+
+Note: `apps/cli/test/cli-builder-sync.test.ts` should auto-detect schema additions, but remember that it reads built `packages/types/dist`. Rebuild `packages/types` before trusting parity failures or passes after schema changes.
+
+---
+
+## Verification Plan
+
+After implementation, run the smallest meaningful proof set first:
+
+1. package-local type/generator tests for touched areas
+2. `packages/types` build after schema changes
+3. focused CLI Java tests
+4. snapshot coverage for representative Java combinations
+
+For release-sensitive Java ecosystem work, run from repo root:
+
+```bash
+~/.bun/bin/bun run test:release
+```
+
+This is required before considering Java MVP complete because the change touches schema parity, builder wiring, generator output, and preview config.
+
+---
+
+## Suggested Snapshot Matrix
+
+At minimum, snapshots should cover:
+
+1. `spring-boot` + `maven` + `spring-data-jpa` + `logback` + `junit5`
+2. `spring-boot` + `gradle` + `jooq` + `spring-security` + `log4j2`
+3. `quarkus` + `maven` + `spring-data-jpa` + `logback` + `junit5`
+4. `micronaut` + `gradle` + `jooq` + `none` auth + `logback`
+
+That matrix exercises:
+
+- all three frameworks
+- both build systems
+- both ORMs
+- both logging options
+- auth on and off
+- testing on and off
+
+---
+
+## Phase 2 Expansion Candidates
+
+Only start these after Java MVP is stable in release tests:
+
+1. `mockito`
+2. `testcontainers`
+3. `mybatis`
+4. `spring-graphql`
+5. `grpc-java`
+6. `openapi-generator`
+7. `keycloak`
+8. messaging / task queue category
+9. observability category
+
+Order principle:
+
+- first add features that stay inside project code and manifests
+- then add features requiring external services or code generation
+- last add categories that multiply compatibility branches across every framework
+
+---
+
+## Definition of Done
+
+Java MVP is complete when all of the following are true:
+
+- Java is selectable in CLI, MCP, and web builder
+- all six MVP categories round-trip through config and URL state
+- generator emits complete Java projects for supported combinations
+- unsupported combinations are blocked with explicit reasons
+- reproducible command output includes Java flags
+- representative Java snapshots pass
+- `test:release` passes
+
+Anything short of that is partial wiring, not a shipped ecosystem.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:web": "turbo test --filter=web",
     "test:release": "bun run --cwd packages/types build && bun run --cwd packages/template-generator build && bun test apps/cli/test/template-snapshots.test.ts && bun test apps/cli/test/cli-builder-sync.test.ts && bun test apps/web/test/preview-config.test.ts && bun test apps/cli/test/generate-reproducible-command.test.ts && bun test apps/cli/test/add-history-commands.test.ts && bun run --cwd apps/web validate:tech-links",
     "check": "oxfmt . && oxlint .",
-    "prepare": "lefthook install",
+    "prepare": "sh scripts/install-hooks.sh",
     "release": "bun run scripts/release.ts",
     "bump": "bun run scripts/bump-version.ts",
     "canary": "bun run scripts/canary-release.ts",

--- a/packages/template-generator/templates/backend/server/fets/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/fets/src/index.ts.hbs
@@ -1,4 +1,6 @@
+{{#if (or (or (eq runtime "node") (eq runtime "bun")) (and (includes examples "ai") (eq runtime "workers")))}}
 import { env } from "@{{projectName}}/env/server";
+{{/if}}
 {{#if (eq api "orpc")}}
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins";
@@ -16,7 +18,7 @@ import { appRouter } from "@{{projectName}}/api/routers/index";
 {{#if (eq auth "better-auth")}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
-import { createRouter, Response } from "fets";
+import { createRouter, Response, type Router } from "fets";
 {{#if (and (includes examples "ai") (or (eq runtime "bun") (eq runtime "node")))}}
 import { streamText, convertToModelMessages, wrapLanguageModel } from "ai";
 import { google } from "@ai-sdk/google";
@@ -43,7 +45,7 @@ const toNativeRequest = async (request: Request): Promise<Request> => {
 };
 {{/if}}
 
-const router = createRouter({
+const router: Router<any, any, any> = createRouter({
 	openAPI: {
 		info: {
 			title: "{{projectName}} API",

--- a/packages/template-generator/templates/rust-base/crates/cli/Cargo.toml.hbs
+++ b/packages/template-generator/templates/rust-base/crates/cli/Cargo.toml.hbs
@@ -18,7 +18,12 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Error handling
+{{#if (eq rustErrorHandling "anyhow-thiserror")}}
 anyhow.workspace = true
+{{else if (eq rustErrorHandling "eyre")}}
+eyre.workspace = true
+color-eyre.workspace = true
+{{/if}}
 
 # Logging
 tracing.workspace = true

--- a/packages/template-generator/templates/rust-base/crates/cli/src/main.rs.hbs
+++ b/packages/template-generator/templates/rust-base/crates/cli/src/main.rs.hbs
@@ -1,4 +1,8 @@
+{{#if (eq rustErrorHandling "anyhow-thiserror")}}
 use anyhow::Result;
+{{else if (eq rustErrorHandling "eyre")}}
+use eyre::Result;
+{{/if}}
 use clap::{Parser, Subcommand};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -82,9 +86,14 @@ enum GenerateComponent {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> {{#if (or (eq rustErrorHandling "anyhow-thiserror") (eq rustErrorHandling "eyre"))}}Result<()>{{else}}Result<(), Box<dyn std::error::Error>>{{/if}} {
     // Load environment variables
     dotenvy::dotenv().ok();
+{{#if (eq rustErrorHandling "eyre")}}
+
+    // Install color-eyre error handler
+    color_eyre::install()?;
+{{/if}}
 
     let cli = Cli::parse();
 

--- a/packages/template-generator/templates/rust-base/crates/server/src/grpc.rs.hbs
+++ b/packages/template-generator/templates/rust-base/crates/server/src/grpc.rs.hbs
@@ -16,7 +16,13 @@ impl Greeter for GreeterService {
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
         let name = request.into_inner().name;
+{{#if (eq rustLogging "tracing")}}
         tracing::info!("Received gRPC request: SayHello from '{}'", name);
+{{else if (eq rustLogging "env-logger")}}
+        log::info!("Received gRPC request: SayHello from '{}'", name);
+{{else}}
+        println!("Received gRPC request: SayHello from '{}'", name);
+{{/if}}
 
         let reply = HelloReply {
             message: format!("Hello, {}!", name),
@@ -33,7 +39,13 @@ impl Greeter for GreeterService {
         request: Request<HelloRequest>,
     ) -> Result<Response<Self::SayHelloStreamStream>, Status> {
         let name = request.into_inner().name;
+{{#if (eq rustLogging "tracing")}}
         tracing::info!("Received gRPC streaming request: SayHelloStream from '{}'", name);
+{{else if (eq rustLogging "env-logger")}}
+        log::info!("Received gRPC streaming request: SayHelloStream from '{}'", name);
+{{else}}
+        println!("Received gRPC streaming request: SayHelloStream from '{}'", name);
+{{/if}}
 
         let (tx, rx) = tokio::sync::mpsc::channel(4);
 

--- a/packages/template-generator/templates/rust-base/crates/tui/Cargo.toml.hbs
+++ b/packages/template-generator/templates/rust-base/crates/tui/Cargo.toml.hbs
@@ -19,7 +19,12 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Error handling
+{{#if (eq rustErrorHandling "anyhow-thiserror")}}
 anyhow.workspace = true
+{{else if (eq rustErrorHandling "eyre")}}
+eyre.workspace = true
+color-eyre.workspace = true
+{{/if}}
 
 # Logging
 tracing.workspace = true

--- a/packages/template-generator/templates/rust-base/crates/tui/src/main.rs.hbs
+++ b/packages/template-generator/templates/rust-base/crates/tui/src/main.rs.hbs
@@ -1,7 +1,11 @@
 use std::io;
 use std::time::Duration;
 
+{{#if (eq rustErrorHandling "anyhow-thiserror")}}
 use anyhow::Result;
+{{else if (eq rustErrorHandling "eyre")}}
+use eyre::Result;
+{{/if}}
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,
@@ -112,9 +116,14 @@ impl App {
     }
 }
 
-fn main() -> Result<()> {
+fn main() -> {{#if (or (eq rustErrorHandling "anyhow-thiserror") (eq rustErrorHandling "eyre"))}}Result<()>{{else}}Result<(), Box<dyn std::error::Error>>{{/if}} {
     // Load environment variables
     dotenvy::dotenv().ok();
+{{#if (eq rustErrorHandling "eyre")}}
+
+    // Install color-eyre error handler
+    color_eyre::install()?;
+{{/if}}
 
     // Initialize tracing to a file (can't use terminal while TUI is running)
     let file_appender = tracing_appender::rolling::daily("logs", "tui.log");

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+if ! command -v git >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! command -v lefthook >/dev/null 2>&1; then
+  exit 0
+fi
+
+hooks_path="$(git config --local --get core.hooksPath 2>/dev/null || true)"
+default_hooks_path="$(git rev-parse --git-path hooks 2>/dev/null || true)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+
+if [ "$hooks_path" = "/dev/null" ]; then
+  printf '%s\n' "Skipping lefthook install because core.hooksPath is disabled."
+  exit 0
+fi
+
+if [ -n "$hooks_path" ]; then
+  case "$hooks_path" in
+    "$default_hooks_path"|".git/hooks"|"$repo_root/.git/hooks")
+      exec lefthook install --reset-hooks-path
+      ;;
+    *)
+      printf '%s\n' "Skipping lefthook install because core.hooksPath is managed locally at '$hooks_path'."
+      exit 0
+      ;;
+  esac
+fi
+
+exec lefthook install

--- a/tech-social-blueprints.md
+++ b/tech-social-blueprints.md
@@ -1,0 +1,439 @@
+# Tech social blueprints
+
+Notes:
+
+`X` shows an official handle when I could verify one from an official site, repo, or a direct X result.
+
+`daily.dev` is not a canonical account system, so I listed a topic/article/feed URL when I found one.
+
+If a handle or page was not confirmed, I left it as `not confirmed` instead of guessing.
+
+## TypeScript
+
+Vercel
+
+Scaffold a production-ready project with Vercel deployment built in — framework-specific `vercel.json` and env vars already wired.
+No setup. Just code.
+
+`pnpm create better-fullstack@latest`
+
+@vercel #webdev #devtools
+
+X: [@vercel](https://x.com/vercel)
+
+daily.dev: [Vercel feed](https://app.daily.dev/sources/vercel/best-of/2026/03)
+
+---
+
+GraphQL Yoga
+
+Better Fullstack now ships GraphQL Yoga — a spec-compliant GraphQL server that runs everywhere: Node, edge, serverless.
+No config. Just queries.
+
+`pnpm create better-fullstack@latest`
+
+@TheGuildDev #graphql #typescript
+
+X: [@TheGuildDev](https://x.com/TheGuildDev)
+
+daily.dev: [GraphQL Yoga tag](https://app.daily.dev/tags/graphql-yoga)
+
+---
+
+Elasticsearch
+
+Full-text search, aggregations, and relevance scoring — scaffolded from day one.
+Better Fullstack now includes Elasticsearch.
+
+`pnpm create better-fullstack@latest`
+
+@elastic #elasticsearch #devtools
+
+X: [@elastic](https://x.com/elastic)
+
+daily.dev: [Elasticsearch stack page](https://recruiter.daily.dev/stacks/elasticsearch/)
+
+---
+
+Algolia
+
+Hosted search with millisecond response times — no infra to manage.
+Better Fullstack now includes Algolia.
+
+`pnpm create better-fullstack@latest`
+
+@algolia #algolia #typescript
+
+X: [@algolia](https://x.com/algolia)
+
+daily.dev: [Algolia feed](https://app.daily.dev/sources/algolia)
+
+---
+
+i18next
+
+Ship multilingual apps faster. Better Fullstack now scaffolds i18next — the most widely adopted i18n framework in JS, with translation namespaces and runtime detection ready to go.
+
+`pnpm create better-fullstack@latest`
+
+#i18n #typescript
+
+X: not confirmed
+
+daily.dev: [i18next tag](https://app.daily.dev/tags/i18next)
+
+---
+
+next-intl
+
+App Router i18n without the boilerplate. Better Fullstack now scaffolds next-intl — type-safe messages, locale routing, and RSC support all configured.
+
+`pnpm create better-fullstack@latest`
+
+@jamannnnnn #nextjs #i18n
+
+X: [@jamannnnnn](https://x.com/jamannnnnn) (creator, Jan Amann — no dedicated library account)
+
+daily.dev: [next-intl tag](https://app.daily.dev/tags/next-intl)
+
+## Python
+
+Flask
+
+The classic Python web framework, now a first-class Better Fullstack option. Minimal, explicit, and out of your way.
+
+`pnpm create better-fullstack@latest`
+
+@PalletsTeam #python #flask
+
+X: [@PalletsTeam](https://x.com/PalletsTeam)
+
+daily.dev: [Flask tag](https://app.daily.dev/tags/flask)
+
+---
+
+Litestar
+
+FastAPI alternative with batteries included — validation, DI, OpenAPI, and more out of the box.
+Better Fullstack now supports Litestar.
+
+`pnpm create better-fullstack@latest`
+
+@LitestarAPI #python #asgi
+
+X: [@LitestarAPI](https://x.com/LitestarAPI)
+
+daily.dev: [Litestar tag](https://app.daily.dev/tags/litestar)
+
+---
+
+Tortoise ORM
+
+Django-style async models for your Python API. Better Fullstack now scaffolds Tortoise ORM — define once, query asynchronously.
+
+`pnpm create better-fullstack@latest`
+
+#python #asyncio #orm
+
+X: not confirmed
+
+daily.dev: [Tortoise ORM tag](https://app.daily.dev/tags/tortoise-orm)
+
+---
+
+Strawberry
+
+Type annotation-driven GraphQL for Python. Better Fullstack now scaffolds Strawberry — schema, resolvers, and type safety from the start.
+
+`pnpm create better-fullstack@latest`
+
+@strawberry_gql #graphql #python
+
+X: [@strawberry_gql](https://x.com/strawberry_gql)
+
+daily.dev: [Strawberry GraphQL tag](https://app.daily.dev/tags/strawberry-graphql)
+
+---
+
+Authlib
+
+OAuth 2.0 and OIDC for Python, handled properly. Better Fullstack now scaffolds Authlib — authorization code flow, token endpoints, and resource servers ready.
+
+`pnpm create better-fullstack@latest`
+
+@authlib #python #oauth
+
+X: [@authlib](https://x.com/authlib)
+
+daily.dev: [Authlib tag](https://app.daily.dev/tags/authlib)
+
+---
+
+JWT (python-jose)
+
+Stateless auth for your Python API — no sessions, no cookies, just tokens. Better Fullstack now scaffolds JWT auth with python-jose.
+
+`pnpm create better-fullstack@latest`
+
+#python #jwt #auth
+
+X: not confirmed
+
+daily.dev: not confirmed
+
+## Go
+
+Fiber
+
+Express-inspired API framework for Go — same ergonomics, real performance.
+Better Fullstack now supports Fiber.
+
+`pnpm create better-fullstack@latest`
+
+@Go_Fiber #golang #fiber
+
+X: [@Go_Fiber](https://x.com/go_fiber)
+
+daily.dev: [Fiber tag](https://app.daily.dev/tags/fiber)
+
+---
+
+Chi
+
+Lightweight, stdlib-compatible routing for Go. Zero dependencies, full flexibility.
+Better Fullstack now supports Chi.
+
+`pnpm create better-fullstack@latest`
+
+#golang #chi #webdev
+
+X: not confirmed
+
+daily.dev: [Chi tag](https://app.daily.dev/tags/chi)
+
+---
+
+Ent
+
+Generated Go code. Type-safe queries. Schema-as-code. Better Fullstack now supports Ent ORM — define your entities once, get the full DB layer for free.
+
+`pnpm create better-fullstack@latest`
+
+@entgo_io #golang #ent
+
+X: [@entgo_io](https://x.com/entgo_io)
+
+daily.dev: [Ent tag](https://app.daily.dev/tags/ent)
+
+---
+
+Casbin
+
+ACL, RBAC, ABAC — all in one policy engine for Go. Better Fullstack now scaffolds Casbin so you never hardcode authorization again.
+
+`pnpm create better-fullstack@latest`
+
+@casbinHQ #golang #authz
+
+X: [@casbinHQ](https://x.com/casbinhq)
+
+daily.dev: [Casbin tag](https://app.daily.dev/tags/casbin)
+
+---
+
+JWT
+
+Token-based auth for your Go API — no sessions needed. Better Fullstack now scaffolds JWT authentication so you start secured from day one.
+
+`pnpm create better-fullstack@latest`
+
+#golang #jwt #auth
+
+X: not confirmed
+
+daily.dev: not confirmed
+
+---
+
+zerolog
+
+The fastest structured logger in Go — zero allocation, JSON output, zero config. Better Fullstack now ships zerolog in every Go project.
+
+`pnpm create better-fullstack@latest`
+
+#golang #zerolog #logging
+
+X: not confirmed
+
+daily.dev: [zerolog tag](https://app.daily.dev/tags/zerolog)
+
+---
+
+slog
+
+Structured logging landed in the Go standard library in 1.21. Better Fullstack now sets it up for you out of the box.
+
+`pnpm create better-fullstack@latest`
+
+#golang #slog #logging
+
+X: not confirmed (standard library package, no dedicated account)
+
+daily.dev: [slog tag](https://app.daily.dev/tags/slog)
+
+## Rust
+
+Rocket
+
+Boilerplate-free web apps in Rust. Better Fullstack now scaffolds Rocket — macros, type-safe routing, and request guards wired from the start.
+
+`pnpm create better-fullstack@latest`
+
+#rust #rocket #webdev
+
+X: not confirmed
+
+daily.dev: not confirmed (general "rocket" tag is mixed with aerospace content)
+
+---
+
+Diesel
+
+Compile-time query validation for Rust. Better Fullstack now scaffolds Diesel — if it compiles, your SQL is correct.
+
+`pnpm create better-fullstack@latest`
+
+#rust #diesel #orm
+
+X: not confirmed
+
+daily.dev: [Diesel tag](https://app.daily.dev/tags/diesel)
+
+---
+
+tracing
+
+Structured, async-aware diagnostics for Rust — span context included. Better Fullstack now scaffolds tracing so your services are observable from day one.
+
+`pnpm create better-fullstack@latest`
+
+#rust #tracing #observability
+
+X: not confirmed
+
+daily.dev: not confirmed (general "tracing" tag is not Rust-specific)
+
+---
+
+env-logger
+
+Control logging with a single env var. Better Fullstack now includes env-logger for Rust — set RUST_LOG and get filtered output instantly.
+
+`pnpm create better-fullstack@latest`
+
+#rust #logging
+
+X: not confirmed
+
+daily.dev: not confirmed
+
+---
+
+anyhow + thiserror
+
+anyhow for propagation. thiserror for definition. The error handling duo every Rust app needs. Better Fullstack now scaffolds both together.
+
+`pnpm create better-fullstack@latest`
+
+#rust #errorhandling
+
+X: not confirmed
+
+daily.dev: not confirmed
+
+---
+
+eyre + color-eyre
+
+Error reports that are actually readable. Better Fullstack now scaffolds eyre and color-eyre — stack traces with context, colored output, and zero noise.
+
+`pnpm create better-fullstack@latest`
+
+#rust #errors
+
+X: not confirmed
+
+daily.dev: not confirmed
+
+---
+
+moka
+
+High-performance in-memory caching for Rust — concurrent, async-ready, and feature-rich. Better Fullstack now scaffolds moka so your app is fast from the first request.
+
+`pnpm create better-fullstack@latest`
+
+#rust #caching
+
+X: not confirmed
+
+daily.dev: not confirmed (daily.dev "moka" tag is mixed with non-tech content)
+
+---
+
+redis
+
+Redis caching for your Rust backend, scaffolded and configured. Better Fullstack now includes the redis crate — async connection pool and key-value ops ready to go.
+
+`pnpm create better-fullstack@latest`
+
+@Redisinc #rust #redis
+
+X: [@Redisinc](https://x.com/Redisinc)
+
+daily.dev: not confirmed
+
+## Other
+
+Tauri
+
+Electron is 100MB+ of Chromium. Tauri is ~4MB of native webview.
+Better Fullstack now scaffolds Tauri desktop apps — backend in Rust, frontend in anything.
+
+`pnpm create better-fullstack@latest`
+
+@TauriApps #tauri #rust #desktop
+
+X: [@TauriApps](https://x.com/TauriApps)
+
+daily.dev: [Tauri tag](https://app.daily.dev/tags/tauri)
+
+## References
+
+[Vercel X profile](https://x.com/vercel)
+
+[Elastic home page](https://www.elastic.co/)
+
+[Authlib GitHub repository](https://github.com/authlib/authlib)
+
+[Pallets contact page](https://palletsprojects.com/contact)
+
+[Ent documentation](https://entgo.io/docs/writing-docs)
+
+[Redis X profile](https://x.com/Redisinc)
+
+[Tauri X post](https://x.com/TauriApps/status/1819029384851861962)
+
+[TheGuildDev X profile](https://x.com/TheGuildDev) — GraphQL Yoga maintainer
+
+[Algolia X profile](https://x.com/algolia)
+
+[LitestarAPI X profile](https://x.com/LitestarAPI)
+
+[Strawberry GraphQL X profile](https://x.com/strawberry_gql)
+
+[Go Fiber X profile](https://x.com/go_fiber)
+
+[CasbinHQ X profile](https://x.com/casbinhq)
+
+[Jan Amann X profile](https://x.com/jamannnnnn) — next-intl creator


### PR DESCRIPTION
## Summary
- save current local working tree changes into a branch and PR
- include workflow, web, template, docs, and script updates currently present locally
- preserve the Java implementation plan draft in docs/plans/planned

## Notes
- This is a mixed WIP PR created to avoid losing local-only changes
- Pre-commit lint ran during commit and reported warnings, but no blocking errors
- Further cleanup/splitting is still needed before merge

## Included files
- GitHub workflow updates
- web route/component edits
- template generator Rust and backend template changes
- docs/plans/planned/java-ecosystem-implementation-plan.md
- scripts/install-hooks.sh
- tech-social-blueprints.md