### PR TITLE
Show monthly npm downloads in navbar

### DIFF
--- a/apps/web/src/components/navbar-stats.tsx
+++ b/apps/web/src/components/navbar-stats.tsx
@@ -15,7 +15,7 @@ type NavbarStatsData = {
 };
 
 const REPO = "Marve10s/Better-Fullstack";
-const CACHE_KEY = "navbar-stats-cache-v1";
+const CACHE_KEY = "navbar-stats-cache-v2";
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 let memoryCache: { data: NavbarStatsData; timestamp: number } | null = null;
@@ -152,10 +152,10 @@ export function NavbarStats() {
         target="_blank"
         rel="noopener noreferrer"
         className="hidden items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground lg:flex"
-        title={`${stats.npm.downloads.toLocaleString()} downloads this week`}
+        title={`${stats.npm.downloads.toLocaleString()} downloads this month`}
       >
         <Download className="h-3.5 w-3.5" />
-        <span className="tabular-nums">{formatCompact(stats.npm.downloads)}/wk</span>
+        <span className="tabular-nums">{formatCompact(stats.npm.downloads)}/mo</span>
       </a>
     </>
   );

--- a/apps/web/src/routes/api/stats.ts
+++ b/apps/web/src/routes/api/stats.ts
@@ -44,7 +44,7 @@ async function fetchStatsFromSources(): Promise<StatsPayload> {
     }),
     fetch(`https://api.github.com/search/issues?q=repo:${REPO}+type:pr+state:open`, { headers }),
     fetch(`https://api.github.com/search/issues?q=repo:${REPO}+type:pr+is:merged`, { headers }),
-    fetch("https://api.npmjs.org/downloads/point/last-week/create-better-fullstack"),
+    fetch("https://api.npmjs.org/downloads/point/last-month/create-better-fullstack"),
   ]);
 
   const [repoData, openIssues, closedIssues, openPRs, mergedPRs, npmData] = await Promise.all([


### PR DESCRIPTION
## Summary
- Switch the header download counter from weekly to monthly for a broader usage signal
- Update the npm API call from `last-week` to `last-month` and relabel the UI from `/wk` to `/mo`
- Bump the `localStorage` cache key to `v2` so stale weekly values are invalidated on first load

## Test plan
- [ ] Load the site and confirm the navbar download pill shows `X/mo` with the monthly count
- [ ] Hover the pill and confirm the tooltip reads "N downloads this month"
- [ ] Inspect Network tab for `/api/stats` and confirm the upstream call is `https://api.npmjs.org/downloads/point/last-month/create-better-fullstack`
- [ ] Clear `localStorage` and reload to confirm the new `navbar-stats-cache-v2` key is written