### PR TITLE
fix(ci): pin Bun in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,10 @@ jobs:
         if: steps.check-version.outputs.exists == 'false'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Bun 1.3.13 regressed `bun publish` against npm in this workflow.
+          # Keep the last known-good release version pinned until upstream is
+          # verified and we intentionally bump it.
+          bun-version: 1.3.12
 
       - name: Cache Dependencies
         if: steps.check-version.outputs.exists == 'false'
@@ -208,4 +211,3 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### GitHub Release" >> $GITHUB_STEP_SUMMARY
           echo "[v$VERSION](https://github.com/${{ github.repository }}/releases/tag/v$VERSION)" >> $GITHUB_STEP_SUMMARY
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ See `docs/guidelines/` for deeper reference on these topics:
 - Surprise worth remembering: TanStack Start route generation in `apps/web` only reads ignore settings from `tanstackStart({ router: ... })` in `apps/web/vite.config.ts`, not from top-level plugin options. Any `createFileRoute` scratch/design file left in `apps/web/src/routes` will be pulled into `routeTree.gen.ts` and build output unless it matches `routeFileIgnorePrefix`/`routeFileIgnorePattern`.
 - Surprise worth remembering: `packages/template-generator/tsconfig.json` includes only `src/**/*`, so tests added under `packages/template-generator/test/` are not covered by the package's normal TypeScript check unless you add a dedicated test tsconfig or expand the include set.
 - Surprise worth remembering: ecosystem additions can still miss `apps/web/src/lib/stack-search-schema.ts`, which used to hardcode the web URL `ecosystem` enum separately from `@better-fullstack/types`. When adding or renaming ecosystems, keep that parser on the shared `EcosystemSchema` so pre-commit `apps/web` typecheck does not fail after the main stack wiring looks complete.
+- Surprise worth remembering: `.github/workflows/release.yaml` broke when `setup-bun@v2` floated from Bun 1.3.12 to 1.3.13. The release job's `bun publish` steps started failing on npm with a misleading 404 for `@better-fullstack/*` packages even though the same workflow had just published successfully on 1.3.12. Keep the release workflow pinned to a known-good Bun version and treat Bun bumps there as release-sensitive changes.
 
 ## Bun
 


### PR DESCRIPTION
## Summary
- pin `.github/workflows/release.yaml` to Bun `1.3.12` instead of floating to `latest`
- document the release publish regression in `AGENTS.md`

## Why
- release `1.6.1` failed at `Publish types to NPM`
- the last successful release used Bun `1.3.12`, while the failed run picked up Bun `1.3.13` from `setup-bun@v2` with `bun-version: latest`
- the workflow and secret wiring were otherwise unchanged, so the safest immediate fix is to pin the known-good release Bun version

## Validation
- parsed `.github/workflows/release.yaml` locally with Ruby `YAML.load_file`
- pre-commit lint hook passed
