### PR TITLE
fix: unblock smoke tests for ruler addon and go sqlc+jwt combo

### DIFF
--- a/apps/cli/src/helpers/addons/ruler-setup.ts
+++ b/apps/cli/src/helpers/addons/ruler-setup.ts
@@ -8,6 +8,7 @@ import type { ProjectConfig } from "../../types";
 
 import { exitCancelled } from "../../utils/errors";
 import { getPackageExecutionArgs, getPackageExecutionCommand } from "../../utils/package-runner";
+import { canPromptInteractively } from "../../utils/prompt-environment";
 
 export async function setupRuler(config: ProjectConfig) {
   const { packageManager, projectDir } = config;
@@ -58,16 +59,24 @@ export async function setupRuler(config: ProjectConfig) {
       zed: { label: "Zed" },
     } as const;
 
-    const selectedEditors = await autocompleteMultiselect({
-      message: "Select AI assistants for Ruler",
-      options: Object.entries(EDITORS).map(([key, v]) => ({
-        value: key,
-        label: v.label,
-      })),
-      required: false,
-    });
+    let selectedEditors: string[] = [];
 
-    if (isCancel(selectedEditors)) return exitCancelled("Operation cancelled");
+    if (canPromptInteractively()) {
+      const prompted = await autocompleteMultiselect({
+        message: "Select AI assistants for Ruler",
+        options: Object.entries(EDITORS).map(([key, v]) => ({
+          value: key,
+          label: v.label,
+        })),
+        required: false,
+      });
+
+      if (isCancel(prompted)) return exitCancelled("Operation cancelled");
+
+      selectedEditors = [...prompted];
+    } else {
+      log.info("Skipping AI assistant selection (non-interactive mode).");
+    }
 
     if (selectedEditors.length === 0) {
       log.info("No AI assistants selected. To apply rules later, run:");

--- a/packages/template-generator/templates/go-base/cmd/server/main.go.hbs
+++ b/packages/template-generator/templates/go-base/cmd/server/main.go.hbs
@@ -1,7 +1,7 @@
 package main
 
 import (
-{{#if (or (or (or (or (or (eq goWebFramework "gin") (eq goWebFramework "echo")) (eq goWebFramework "fiber")) (eq goWebFramework "chi")) (eq goApi "grpc-go")) (or (or (eq auth "go-better-auth") (ne goAuth "none")) (ne goLogging "none")))}}
+{{#if (or (or (or (or (or (eq goWebFramework "gin") (eq goWebFramework "echo")) (eq goWebFramework "fiber")) (eq goWebFramework "chi")) (eq goApi "grpc-go")) (or (eq auth "go-better-auth") (ne goLogging "none")))}}
 	"os"
 {{/if}}
 {{#if (or (or (or (eq goWebFramework "gin") (eq goWebFramework "echo")) (eq goWebFramework "chi")) (and (eq auth "go-better-auth") (not (eq goWebFramework "fiber"))))}}


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs surfaced by the PR #164 smoke test run (`Results: 12 passed, 2 failed out of 14`). Neither is caused by the dependency bump in #164 — both reproduce on main.

### 1. Ruler addon hangs non-interactive scaffold

**Combo:** `typescript-tanstack-start-convex-tailwind-daisyui-...` with `--addons ruler`

`setupRuler()` unconditionally called `autocompleteMultiselect` ("Select AI assistants for Ruler"). In smoke runs (non-TTY stdin, CI=true) the prompt never resolves and the scaffold exits early, so `bts.jsonc` is never written and the smoke verifier reports `missingExpectedFiles: bts.jsonc`.

**Fix:** gate the prompt with `canPromptInteractively()` (the same pattern used by `mcp-setup.ts`, `ultracite-setup.ts`, and every db provider). Non-interactive path falls through to the existing "no editors selected" branch that logs the manual-apply command and returns cleanly.

### 2. Go `"os" imported and not used` for sqlc + jwt + no logging

**Combo:** `--ecosystem go --go-web-framework none --go-orm sqlc --go-api none --go-cli bubbletea --go-logging none --go-auth jwt`

The `"os"` import conditional in `go-base/cmd/server/main.go.hbs` included `(ne goAuth "none")`, but none of the `os.*` usages in the template are gated on `goAuth`. Every usage is behind a web framework, `goApi=grpc-go`, `auth=go-better-auth`, or `goLogging != "none"`.

**Fix:** drop `(ne goAuth "none")` from the `os` import guard. `go build ./...` and `go vet ./...` now pass on the repro.

## Test plan

- [x] Rebuild template-generator + CLI, rescaffold the failing ruler combo with `CI=true` → project created, `bts.jsonc` written.
- [x] Rescaffold the failing Go combo, run `go mod tidy && go build ./... && go vet ./...` → all clean, no unused-import error.
- [x] `bun run --filter=create-better-fullstack check-types` → exit 0.
- [ ] CI smoke test passes on this PR.

Once merged, retrigger PR #164 smoke to confirm the dependency bump is green.