### PR TITLE
fix: repair main CI smoke and perf checks

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -71,6 +71,12 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/apps/web/scripts/check-performance-budget.mjs
+++ b/apps/web/scripts/check-performance-budget.mjs
@@ -52,7 +52,9 @@ async function getFileSize(filePath) {
 }
 
 function findAsset(entries, patterns) {
-  return entries.find((entry) => patterns.some((pattern) => pattern.test(entry.file)));
+  return [...entries]
+    .sort((a, b) => a.file.localeCompare(b.file))
+    .find((entry) => patterns.some((pattern) => pattern.test(entry.file)));
 }
 
 async function collectMetrics() {
@@ -105,6 +107,11 @@ async function collectMetrics() {
       totalJsGzip,
     },
     largestJsChunk: largestJs.file,
+    trackedAssets: {
+      mainJs: mainJs.file,
+      mainCss: mainCss.file,
+      stackBuilderJs: stackBuilderJs.file,
+    },
     topJsChunksByGzip: [...jsSizes]
       .sort((a, b) => b.gzip - a.gzip)
       .slice(0, 10)
@@ -207,6 +214,7 @@ async function checkAgainstBaseline(current) {
     ...rows,
     "",
     `Largest JS chunk: \`${current.largestJsChunk}\` (${formatBytes(current.metrics.largestJsGzip)} gzip)`,
+    `Tracked assets: main JS \`${current.trackedAssets?.mainJs ?? "unknown"}\`, main CSS \`${current.trackedAssets?.mainCss ?? "unknown"}\`, stack builder JS \`${current.trackedAssets?.stackBuilderJs ?? "unknown"}\``,
     "",
   ];
 

--- a/packages/template-generator/templates/cms/tinacms/web/react/tina/config.ts.hbs
+++ b/packages/template-generator/templates/cms/tinacms/web/react/tina/config.ts.hbs
@@ -1,5 +1,9 @@
 import { defineConfig } from "tinacms";
 
+const viteEnv = (import.meta as ImportMeta & {
+  env?: Record<string, string | undefined>;
+}).env ?? {};
+
 const branch =
   process.env.GITHUB_REF_NAME ||
   process.env.VERCEL_GIT_COMMIT_REF ||
@@ -7,7 +11,7 @@ const branch =
 
 export default defineConfig({
   branch,
-  clientId: import.meta.env.VITE_TINA_CLIENT_ID || "local",
+  clientId: viteEnv.VITE_TINA_CLIENT_ID || process.env.VITE_TINA_CLIENT_ID || "local",
   token: process.env.TINA_TOKEN || "local",
 
   build: {


### PR DESCRIPTION
## Summary
- set Java 21 in the smoke workflow so Java Maven scaffolds compile with the expected release target
- guard TinaCMS React config against missing import.meta.env during TanStack Start/server-side builds
- make the web performance budget asset lookup deterministic and report the tracked asset names

## Verification
- ~/.bun/bin/bun run build:web
- ~/.bun/bin/bun run --cwd apps/web perf:check
- ~/.bun/bin/bun test apps/cli/test/cms.test.ts -t "tinacms with TanStack Router"
- generated a TanStack Start + NestJS + Garph + TypeORM + TinaCMS repro app, ran ~/.bun/bin/bun install, then ~/.bun/bin/bun run build
- pre-commit lint completed with existing warnings and no errors