### PR TITLE
[codex] fix vinext smoke user menu import

### DIFF
--- a/apps/cli/test/auth.test.ts
+++ b/apps/cli/test/auth.test.ts
@@ -301,6 +301,34 @@ describe("Authentication Configurations", () => {
         expectSuccess(result);
       });
     }
+
+    it("should scaffold better-auth + vinext without a missing user-menu import", async () => {
+      const result = await runTRPCTest({
+        projectName: "better-auth-vinext",
+        auth: "better-auth",
+        backend: "elysia",
+        runtime: "bun",
+        database: "postgres",
+        orm: "kysely",
+        api: "graphql-yoga",
+        frontend: ["vinext"],
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "docker",
+        webDeploy: "none",
+        serverDeploy: "none",
+        install: false,
+      });
+
+      expectSuccess(result);
+
+      const projectDir = result.projectDir;
+      const headerFile = await readFile(
+        join(projectDir, "apps/web/src/components/header.tsx"),
+        "utf-8",
+      );
+      expect(headerFile).not.toContain("./user-menu");
+    });
   });
 
   describe("Auth.js (NextAuth) Provider", () => {

--- a/packages/template-generator/templates/frontend/react/web-base/src/components/header.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/web-base/src/components/header.tsx.hbs
@@ -10,7 +10,7 @@ import { Link } from "@tanstack/react-router";
 import { ModeToggle } from "./mode-toggle";
 {{/unless}}
 {{#if (or
-  (and (ne auth "none") (ne auth "clerk") (ne backend "convex") (or (eq auth "better-auth") (includes frontend "next")))
+  (and (not (includes frontend "vinext")) (ne auth "none") (ne auth "clerk") (ne backend "convex") (or (eq auth "better-auth") (includes frontend "next")))
   (and (eq auth "clerk") (eq backend "self") (or (includes frontend "next") (includes frontend "tanstack-start")))
 )}}
 import UserMenu from "./user-menu";
@@ -68,7 +68,7 @@ export default function Header() {
           <ModeToggle />
           {{/unless}}
           {{#if (or
-            (and (ne auth "none") (ne auth "clerk") (ne backend "convex") (or (eq auth "better-auth") (includes frontend "next")))
+            (and (not (includes frontend "vinext")) (ne auth "none") (ne auth "clerk") (ne backend "convex") (or (eq auth "better-auth") (includes frontend "next")))
             (and (eq auth "clerk") (eq backend "self") (or (includes frontend "next") (includes frontend "tanstack-start")))
           )}}
           <UserMenu />


### PR DESCRIPTION
## Summary
- Prevent the shared React web-base header from importing `./user-menu` for Vinext stacks.
- Add regression coverage for Better Auth + Vinext scaffolds so the missing import does not come back.

## Root cause
Vinext shares the React web-base header, but the Better Auth user-menu templates are only emitted for the React frameworks that have matching auth web templates. A Vinext smoke combo could therefore render `<UserMenu />` without generating `apps/web/src/components/user-menu.tsx`.

## Validation
- `bun test apps/cli/test/auth.test.ts -t "missing user-menu"`
- Rebuilt `packages/template-generator` and `apps/cli` locally before validating generated output.
- Re-scaffolded the failing Vinext combo and confirmed `bun run build` passes.
- Pre-commit lint hook passed with existing warnings only.