### PR TITLE
Add Better Fullstack agent skill

### DIFF
--- a/.agents/skills/better-fullstack/SKILL.md
+++ b/.agents/skills/better-fullstack/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: better-fullstack
+description: Scaffold, plan, or extend Better Fullstack projects with the generator, CLI, or MCP server. Use when a user asks to create, generate, or scaffold a fullstack starter; choose a Better Fullstack stack; add Better Fullstack addons; compare agent scaffolding paths; or avoid hand-authoring boilerplate project files.
+---
+
+# Better Fullstack
+
+Use Better Fullstack CLI as the source of truth for starter generation. Do not hand-write a full starter when the generator can produce it.
+
+## Choose The Path
+
+Use the CLI by default. The benchmarked best framing is: map the stack, dry-run the CLI, then run the same non-interactive command for real.
+
+Use MCP only when the user explicitly asks for MCP, when CLI access is unavailable, or when the request needs structured schema lookup beyond what a concise CLI command can safely express. If using MCP, start with `bfs_get_guidance`, then use schema, compatibility, plan, and create/add tools in that order.
+
+If the prompt provides a local CLI path, use that. Otherwise use the package runner available in the environment, such as `bunx create-better-fullstack@latest` or `npx -y create-better-fullstack@latest`.
+
+## Default CLI Workflow
+
+1. Map the user's stack into Better Fullstack graph parts and flat flags.
+2. Build one non-interactive command.
+3. Run it with `--dry-run`.
+4. If the dry run succeeds, run the same command without `--dry-run`.
+5. If the CLI rejects a combination, adjust to the closest valid Better Fullstack stack and report the adjustment.
+
+## CLI Rules
+
+- Create exactly the requested project directory, using a relative project name.
+- Prefer `create <project-name> --part ...` for explicit or multi-ecosystem stacks.
+- Pass `--no-install --no-git` for agent-driven scaffolding unless the user explicitly asks for side effects.
+- Pass `--package-manager bun` when the user or project expects Bun.
+- Pass `--ai-docs agents-md` for reusable projects, or `--ai-docs none` for benchmarks and throwaway scaffolds.
+- Use `none` explicitly for categories the user wants disabled.
+- Do not start a dev server.
+
+## Mapping Hints
+
+- React + Vite: `frontend:typescript:react-vite`
+- Hono: `backend:typescript:hono`
+- Bun runtime: `backend.runtime:typescript:bun`
+- SQLite: `database:universal:sqlite`
+- Drizzle: `backend.orm:typescript:drizzle`
+- tRPC: `backend.api:typescript:trpc`
+- Tailwind: `frontend.css:typescript:tailwind`
+- DaisyUI: `frontend.ui:typescript:daisyui`
+- Pino: `backend.logging:typescript:pino`
+- Biome: `codeQuality:universal:biome`
+
+## Graph Part Examples
+
+Use graph parts as `category:ecosystem:option`.
+
+```bash
+bunx create-better-fullstack@latest my-app \
+  --part frontend:typescript:react-vite \
+  --part backend:typescript:hono \
+  --part database:universal:sqlite \
+  --part backend.runtime:typescript:bun \
+  --part backend.api:typescript:trpc \
+  --part backend.orm:typescript:drizzle \
+  --part frontend.css:typescript:tailwind \
+  --part frontend.ui:typescript:daisyui \
+  --part backend.logging:typescript:pino \
+  --part codeQuality:universal:biome \
+  --forms none \
+  --validation none \
+  --ai-docs none \
+  --package-manager bun \
+  --no-install \
+  --no-git
+```
+
+```bash
+bunx create-better-fullstack@latest api-app \
+  --part backend:python:fastapi \
+  --part database:universal:postgres \
+  --part backend.orm:python:sqlmodel \
+  --part backend.validation:python:pydantic \
+  --part backend.auth:python:jwt \
+  --part codeQuality:python:ruff \
+  --ai-docs agents-md \
+  --no-install \
+  --no-git
+```
+
+## Existing Projects
+
+For a generated project with `bts.jsonc`, use the Better Fullstack `add` command or MCP add tools. Addons are arrays, for example:
+
+```bash
+bunx create-better-fullstack@latest add --project-dir ./my-app --addons biome turborepo --no-install
+```
+
+## Final Response
+
+Report the command or tool path used, any compatibility adjustments, the project directory, and the next install/test/run commands. Do not claim dependencies are installed when `--no-install` or MCP creation skipped them.

--- a/.agents/skills/better-fullstack/agents/openai.yaml
+++ b/.agents/skills/better-fullstack/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Better Fullstack"
+  short_description: "Scaffold Better Fullstack projects"
+  default_prompt: "Use $better-fullstack to scaffold a fullstack project with the requested stack."

--- a/apps/web/content/docs/ai/mcp.mdx
+++ b/apps/web/content/docs/ai/mcp.mdx
@@ -7,6 +7,8 @@ The Better Fullstack MCP server lets agents scaffold projects through structured
 
 This page describes the Better Fullstack MCP server. The generated-project `mcp` addon is separate: it writes MCP client/server configuration into a scaffolded app and may run external setup commands.
 
+For a lighter CLI-driven agent workflow, install the [Better Fullstack agent skill](/docs/ai/skills/). The skill and MCP server both use the same generator; the skill is optimized for fast flag-based scaffolding, while MCP is optimized for structured tool calls.
+
 ## Setup
 
 Launch the server with the package manager you use:

--- a/apps/web/content/docs/ai/meta.json
+++ b/apps/web/content/docs/ai/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "AI Agents",
   "defaultOpen": true,
-  "pages": ["overview", "mcp", "mcp-tools"]
+  "pages": ["overview", "skills", "mcp", "mcp-tools"]
 }

--- a/apps/web/content/docs/ai/overview.mdx
+++ b/apps/web/content/docs/ai/overview.mdx
@@ -3,15 +3,16 @@ title: AI Agents
 description: How AI coding agents should use Better Fullstack safely and reliably.
 ---
 
-Better Fullstack supports two AI workflows:
+Better Fullstack supports three AI workflows:
 
 - Generate project-local instruction files with `--ai-docs`.
+- Install the Better Fullstack agent skill so coding agents use the CLI instead of hand-writing starter files.
 - Let an AI coding agent use the Better Fullstack MCP server for schema lookup, compatibility checks, dry-runs, and project creation.
 
 ## Preferred workflow
 
 1. Choose the target ecosystem: `typescript`, `react-native`, `rust`, `python`, `go`, `java`, or `elixir`.
-2. Fetch schema options from MCP or the CLI reference.
+2. Use the Better Fullstack agent skill, MCP server, or explicit CLI reference.
 3. Validate compatibility before scaffolding.
 4. Dry-run to inspect the file tree.
 5. Scaffold with dependency installation disabled when an agent is driving the flow.
@@ -60,6 +61,12 @@ npm create better-fullstack@latest my-app -- \
 <Callout kind="info" title="CLI rules for agents">
 `--yes` accepts defaults and is incompatible with core stack flags. Explicit flags skip only the categories they cover. Pass `none` for optional categories you want disabled.
 </Callout>
+
+## Agent skill workflow
+
+The Better Fullstack agent skill lives in this repository and teaches supported agents to use the CLI with the benchmarked fast workflow: map the stack, run a dry-run, scaffold without install or Git side effects, then report follow-up commands.
+
+See the [agent skill setup guide](/docs/ai/skills/) for Codex, Claude Code, Cursor, GitHub Copilot, and Gemini CLI install commands.
 
 ## AI provider options
 

--- a/apps/web/content/docs/ai/skills.mdx
+++ b/apps/web/content/docs/ai/skills.mdx
@@ -1,0 +1,60 @@
+---
+title: Agent Skill
+description: Install the Better Fullstack agent skill for fast CLI-driven scaffolding in Codex, Claude Code, Cursor, and other agents.
+---
+
+The Better Fullstack agent skill teaches coding agents to use the CLI instead of hand-writing starter projects. It maps the requested stack to graph parts, runs a dry-run first, scaffolds with dependency installation disabled, and reports the exact follow-up commands.
+
+Use this when your agent supports skills and you want the fastest path from a prompt to a generated Better Fullstack project. Use the [MCP server](/docs/ai/mcp/) when you want structured schema lookup and tool-call planning instead.
+
+## Install
+
+The skill lives in this repository at `.agents/skills/better-fullstack`. Because the repo also contains other internal skills, install only `better-fullstack`.
+
+Install for Codex:
+
+<PMTabs
+  npm="npx skills@latest add Marve10s/Better-Fullstack --skill better-fullstack --agent codex --global --yes"
+  pnpm="pnpm dlx skills@latest add Marve10s/Better-Fullstack --skill better-fullstack --agent codex --global --yes"
+  bun="bunx skills@latest add Marve10s/Better-Fullstack --skill better-fullstack --agent codex --global --yes"
+  yarn="yarn dlx skills@latest add Marve10s/Better-Fullstack --skill better-fullstack --agent codex --global --yes"
+/>
+
+Install for several common agents:
+
+```bash
+bunx skills@latest add Marve10s/Better-Fullstack \
+  --skill better-fullstack \
+  --agent codex claude-code cursor github-copilot gemini-cli \
+  --global \
+  --yes
+```
+
+For a project-local install, omit `--global` from the same command. Project installs are useful when a team wants the skill version recorded with the repository.
+
+## Use
+
+Invoke the skill explicitly:
+
+```text
+Use $better-fullstack to create a React + Vite app with Hono, SQLite, Drizzle, tRPC, Tailwind, DaisyUI, Pino, Vitest, and Biome.
+```
+
+Or ask naturally. Agents that support implicit skill matching can choose the skill when the request is about scaffolding, planning, or extending a Better Fullstack project.
+
+## What The Skill Does
+
+1. Maps the requested stack into Better Fullstack graph parts and CLI flags.
+2. Runs a non-interactive CLI dry-run.
+3. Runs the same command without `--dry-run` when the plan succeeds.
+4. Uses `--no-install` and `--no-git` unless you explicitly ask for those side effects.
+5. Reports the command used, any compatibility adjustment, and next install/test/run commands.
+
+## Skill vs MCP
+
+| Path | Best for |
+| --- | --- |
+| Agent skill | Fast CLI-driven scaffolding when the stack can be expressed as flags or graph parts. |
+| MCP server | Structured schema lookup, compatibility checks, dry-run planning, and existing-project mutation through tool calls. |
+
+Both paths use the same Better Fullstack generator. The skill is the lighter route; MCP is the more structured route.

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -45,6 +45,7 @@ You can keep that stack, start from a template, or switch ecosystems entirely.
 | CLI wizard | You want prompts and sensible defaults. |
 | Stack Builder | You want to explore compatible combinations before scaffolding. |
 | Explicit flags | You want repeatable output in scripts, docs, or issue reports. |
+| Agent Skill | You want a coding agent to use the CLI workflow without hand-writing starter files. |
 | MCP server | You want an AI coding agent to inspect the schema, validate compatibility, and dry-run safely. |
 
 ## Generated project context

--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -33,6 +33,7 @@ export function generateLlmsTxt({
       "/docs/reference/compatibility",
       "/docs/reference/options",
       "/docs/ai/overview",
+      "/docs/ai/skills",
       "/docs/ai/mcp",
       "/docs/ai/mcp-tools",
       "/docs/ecosystems/typescript",

--- a/apps/web/test/docs-navigation.test.ts
+++ b/apps/web/test/docs-navigation.test.ts
@@ -32,6 +32,7 @@ describe("docs navigation", () => {
     expect(ecosystemsMeta.pages).toContain("multi-ecosystem");
     expect(referenceMeta.pages).toContain("compatibility");
     expect(optionsMeta.pages).toContain("elixir");
+    expect(aiMeta.pages).toContain("skills");
     expect(aiMeta.pages).toContain("mcp-tools");
   });
 
@@ -45,6 +46,7 @@ describe("docs navigation", () => {
     await expectDocPage("cli/history.mdx");
     await expectDocPage("cli/mcp.mdx");
     await expectDocPage("ecosystems/multi-ecosystem.mdx");
+    await expectDocPage("ai/skills.mdx");
     await expectDocPage("ai/mcp-tools.mdx");
   });
 });


### PR DESCRIPTION
## Summary

- Add the Better Fullstack agent skill under `.agents/skills/better-fullstack`.
- Add install and usage docs, then link them from the AI docs, MCP page, docs index, and generated LLMs page list.
- Cover the new docs page in navigation tests.

## Validation

- `git diff --cached --check`
- Ruby skill/docs sanity check
- Temporary project-local skill install copied exactly one `better-fullstack` skill
- Pre-commit lint passed with existing warnings
- `bun test apps/web/test/docs-navigation.test.ts` currently fails before assertions with `EMFILE` while reading unrelated repo files
