### PR TITLE
chore(release): 2.0.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Scaffold production-ready fullstack apps in seconds. Pick your stack from 425 options — the CLI wires everything together.",
   "keywords": [
     "algolia",
@@ -127,8 +127,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@better-fullstack/template-generator": "workspace:*",
-    "@better-fullstack/types": "workspace:*",
+    "@better-fullstack/template-generator": "^2.0.3",
+    "@better-fullstack/types": "^2.0.3",
     "@clack/core": "^0.5.0",
     "@clack/prompts": "^1.5.1",
     "@orpc/server": "^1.14.6",

--- a/apps/web/src/lib/changelog.ts
+++ b/apps/web/src/lib/changelog.ts
@@ -19,10 +19,33 @@ const RELEASE_BASE_URL = "https://github.com/Marve10s/Better-Fullstack/releases/
 
 export const changelogReleases: ChangelogRelease[] = [
   {
+    version: "v2.0.3",
+    publishedAt: "2026-06-17T00:00:00Z",
+    displayDate: "June 17, 2026",
+    isLatest: true,
+    href: `${RELEASE_BASE_URL}/v2.0.3`,
+    title: "OpenAPI clients and Nx workspace tooling",
+    summary:
+      "This release adds OpenAPI API generation and Nx root tooling across the CLI, web builder, template generator, snapshots, and release checks. It also fixes the Vinext OpenAPI health check env key and makes Nx database scripts use explicit targets so db:* scripts work reliably.",
+    highlights: [
+      "Added OpenAPI as a first-class API option across CLI prompts, web builder state, compatibility metadata, generated templates, preview wiring, and snapshot coverage.",
+      "Added Nx workspace tooling as an addon/root-tooling path with generated workspace scripts, CLI/web parity, and matrix coverage.",
+      "Hardened Nx database scripts by emitting explicit targets for db:* commands, preserving package-script targets that contain colons.",
+      "Fixed Vinext OpenAPI clients to read env.VITE_SERVER_URL for health checks instead of the Next-only NEXT_PUBLIC_SERVER_URL.",
+      "Expanded release coverage with OpenAPI and Nx snapshots, package config regression tests, CLI addon tests, and strict smoke checks.",
+    ],
+    image: {
+      src: "https://images.unsplash.com/photo-1777711391050-7e0cefd4b33b?q=80&w=2340&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      alt: "Abstract colorful gradient artwork",
+      credit: "Unsplash",
+      creditHref:
+        "https://images.unsplash.com/photo-1777711391050-7e0cefd4b33b?q=80&w=2340&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    },
+  },
+  {
     version: "v2.0.2",
     publishedAt: "2026-06-12T00:00:00Z",
     displayDate: "June 12, 2026",
-    isLatest: true,
     href: `${RELEASE_BASE_URL}/v2.0.2`,
     title: "Agent benchmark, .NET ecosystem, and a 42% lighter install",
     summary:

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "1.6.3",
+  "version": "2.0.3",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -80,6 +80,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "workspace:*"
+    "create-better-fullstack": "^2.0.3"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "1.6.3",
+  "version": "2.0.3",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -62,7 +62,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "workspace:*",
+    "@better-fullstack/types": "^2.0.3",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "1.6.3",
+  "version": "2.0.3",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",


### PR DESCRIPTION
## Release v2.0.3

This PR bumps the published packages to 2.0.3.

### Packages
- create-better-fullstack
- create-bfs
- @better-fullstack/types
- @better-fullstack/template-generator
