### PR TITLE
Fix scaffold correctness/trust bugs + add check-types to generated packages

### DIFF
--- a/apps/cli/src/helpers/core/add-handler.ts
+++ b/apps/cli/src/helpers/core/add-handler.ts
@@ -15,8 +15,8 @@ import type { AddInput, Addons, ProjectConfig } from "../../types";
 import { getDefaultConfig } from "../../constants";
 import { getAddonsToAdd } from "../../prompts/addons";
 import { readBtsConfig, updateBtsConfig } from "../../utils/bts-config";
-import { applyDependencyVersionChannel } from "../../utils/dependency-version-channel";
 import { isSilent, runWithContextAsync } from "../../utils/context";
+import { applyDependencyVersionChannel } from "../../utils/dependency-version-channel";
 import { CLIError, UserCancelledError } from "../../utils/errors";
 import { renderTitle } from "../../utils/render-title";
 import { setupAddons } from "../addons/addons-setup";
@@ -189,11 +189,13 @@ async function addHandlerInternal(input: AddInput): Promise<AddResult> {
 
   await updateBtsConfig(projectDir, configUpdates);
 
+  let addonInstallFailed = false;
   if (input.install) {
-    await installDependencies({
+    const installResult = await installDependencies({
       projectDir,
       packageManager: config.packageManager,
     });
+    addonInstallFailed = !installResult.success;
   }
 
   if (!isSilent()) {
@@ -201,10 +203,16 @@ async function addHandlerInternal(input: AddInput): Promise<AddResult> {
     for (const warning of setupWarnings) {
       log.warn(pc.yellow(warning));
     }
+    const installCmd =
+      config.packageManager === "npm" ? "npm install" : `${config.packageManager} install`;
     if (!input.install) {
-      const installCmd =
-        config.packageManager === "npm" ? "npm install" : `${config.packageManager} install`;
       log.info(pc.yellow(`Run '${installCmd}' to install new dependencies.`));
+    } else if (addonInstallFailed) {
+      log.warn(
+        pc.yellow(
+          `Dependency installation failed. Run '${installCmd}' after resolving the error above.`,
+        ),
+      );
     }
     outro(pc.magenta("Addons added successfully!"));
   }

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -397,9 +397,8 @@ export async function createProjectHandler(
       }
 
       if (input.dryRun) {
-        const { generateVirtualProject, EMBEDDED_TEMPLATES } = await import(
-          "@better-fullstack/template-generator"
-        );
+        const { generateVirtualProject, EMBEDDED_TEMPLATES } =
+          await import("@better-fullstack/template-generator");
         const result = await generateVirtualProject({
           config,
           templates: EMBEDDED_TEMPLATES,
@@ -470,9 +469,10 @@ export async function createProjectHandler(
         };
       }
 
-      await createProject(config, {
+      const createResult = await createProject(config, {
         manualDb: cliInput.manualDb ?? input.manualDb,
       });
+      const setupFailures = createResult?.setupFailures ?? [];
 
       if (cliInput.verify ?? input.verify) {
         await runGeneratedChecks(config);
@@ -503,9 +503,26 @@ export async function createProjectHandler(
       const elapsedTimeMs = Date.now() - startTime;
       if (!isSilent()) {
         const elapsedTimeInSeconds = (elapsedTimeMs / 1000).toFixed(2);
-        outro(
-          pc.magenta(`Project created successfully in ${pc.bold(elapsedTimeInSeconds)} seconds!`),
-        );
+        if (setupFailures.length > 0) {
+          const stepList = setupFailures.map((f) => f.step).join(", ");
+          const installCmd =
+            config.packageManager === "npm" ? "npm install" : `${config.packageManager} install`;
+          log.warn(
+            pc.yellow(
+              `Project files were scaffolded in ${config.relativePath}, but ${setupFailures.length} setup step(s) did not complete: ${stepList}.\n` +
+                `Review the errors above, then finish setup manually (for example, run '${installCmd}' inside the project).`,
+            ),
+          );
+          outro(
+            pc.yellow(
+              `Project created with ${setupFailures.length} unfinished setup step(s) in ${pc.bold(elapsedTimeInSeconds)}s.`,
+            ),
+          );
+        } else {
+          outro(
+            pc.magenta(`Project created successfully in ${pc.bold(elapsedTimeInSeconds)} seconds!`),
+          );
+        }
       }
 
       return {
@@ -516,6 +533,7 @@ export async function createProjectHandler(
         elapsedTimeMs,
         projectDirectory: config.projectDir,
         relativePath: config.relativePath,
+        setupFailures,
       };
     } catch (error) {
       if (error instanceof UserCancelledError) {

--- a/apps/cli/src/helpers/core/create-project.ts
+++ b/apps/cli/src/helpers/core/create-project.ts
@@ -7,8 +7,8 @@ import path from "node:path";
 import type { ProjectConfig } from "../../types";
 
 import { writeBtsConfig } from "../../utils/bts-config";
-import { applyDependencyVersionChannel } from "../../utils/dependency-version-channel";
 import { isSilent } from "../../utils/context";
+import { applyDependencyVersionChannel } from "../../utils/dependency-version-channel";
 import { exitWithError } from "../../utils/errors";
 import { formatProject } from "../../utils/file-formatter";
 import { setupAddons } from "../addons/addons-setup";
@@ -22,6 +22,7 @@ import {
   runUvSync,
   runGoModTidy,
   runMixCompile,
+  type SetupStepResult,
 } from "./install-dependencies";
 import { displayPostInstallInstructions } from "./post-installation";
 
@@ -32,6 +33,13 @@ export interface CreateProjectOptions {
 export async function createProject(options: ProjectConfig, cliInput: CreateProjectOptions = {}) {
   const projectDir = options.projectDir;
   const isConvex = options.backend === "convex";
+  const setupFailures: SetupStepResult[] = [];
+
+  // Track whether the target directory already had user content before we
+  // started writing. If it did (merge mode), we must never delete it on
+  // failure; if it was empty/new, we own everything in it and can roll back.
+  const dirHadContentBefore =
+    (await fs.pathExists(projectDir)) && (await fs.readdir(projectDir)).length > 0;
 
   try {
     await fs.ensureDir(projectDir);
@@ -58,7 +66,8 @@ export async function createProject(options: ProjectConfig, cliInput: CreateProj
     await ensurePackageManagerProjectFiles(projectDir, options.packageManager);
 
     if (!isConvex && options.database !== "none") {
-      await setupDatabase(options, cliInput);
+      const dbResult = await setupDatabase(options, cliInput);
+      if (dbResult && !dbResult.success) setupFailures.push(dbResult);
     }
 
     if (options.addons.length > 0 && options.addons[0] !== "none") {
@@ -78,42 +87,43 @@ export async function createProject(options: ProjectConfig, cliInput: CreateProj
       options.install &&
       (options.ecosystem === "typescript" || options.ecosystem === "react-native")
     ) {
-      await installDependencies({
+      const result = await installDependencies({
         projectDir,
         packageManager: options.packageManager,
       });
+      if (!result.success) setupFailures.push(result);
     }
 
     // Run cargo build for Rust projects
     if (options.install && options.ecosystem === "rust") {
-      await runCargoBuild({ projectDir });
+      const result = await runCargoBuild({ projectDir });
+      if (!result.success) setupFailures.push(result);
     }
 
     // Run uv sync for Python projects
     if (options.install && options.ecosystem === "python") {
-      await runUvSync({ projectDir });
+      const result = await runUvSync({ projectDir });
+      if (!result.success) setupFailures.push(result);
     }
 
     // Run go mod tidy for Go projects
     if (options.install && options.ecosystem === "go") {
-      await runGoModTidy({ projectDir });
+      const result = await runGoModTidy({ projectDir });
+      if (!result.success) setupFailures.push(result);
     }
 
     // Run wrapper-based verification for Java projects
-    if (
-      options.install &&
-      options.ecosystem === "java" &&
-      options.javaBuildTool !== "none"
-    ) {
-      if (options.javaBuildTool === "gradle") {
-        await runGradleTests({ projectDir });
-      } else {
-        await runMavenTests({ projectDir });
-      }
+    if (options.install && options.ecosystem === "java" && options.javaBuildTool !== "none") {
+      const result =
+        options.javaBuildTool === "gradle"
+          ? await runGradleTests({ projectDir })
+          : await runMavenTests({ projectDir });
+      if (!result.success) setupFailures.push(result);
     }
 
     if (options.install && options.ecosystem === "elixir") {
-      await runMixCompile({ projectDir });
+      const result = await runMixCompile({ projectDir });
+      if (!result.success) setupFailures.push(result);
     }
 
     await initializeGit(projectDir, options.git);
@@ -125,8 +135,9 @@ export async function createProject(options: ProjectConfig, cliInput: CreateProj
       });
     }
 
-    return projectDir;
+    return { projectDir, setupFailures };
   } catch (error) {
+    await rollbackPartialProject(projectDir, dirHadContentBefore);
     if (error instanceof Error) {
       if (!isSilent()) console.error(error.stack);
       exitWithError(`Error during project creation: ${error.message}`);
@@ -134,6 +145,38 @@ export async function createProject(options: ProjectConfig, cliInput: CreateProj
       if (!isSilent()) console.error(error);
       exitWithError(`An unexpected error occurred: ${String(error)}`);
     }
+  }
+}
+
+/**
+ * Remove a half-written project directory after a fatal scaffolding error so the
+ * user is not left with a broken, partially generated project. Only removes
+ * directories we created ourselves (empty/new before scaffolding) — never one
+ * that already had user content (merge mode). Set BTS_KEEP_FAILED_OUTPUT=1 to
+ * keep the partial output for debugging template failures.
+ */
+async function rollbackPartialProject(
+  projectDir: string,
+  dirHadContentBefore: boolean,
+): Promise<void> {
+  if (dirHadContentBefore || process.env.BTS_KEEP_FAILED_OUTPUT) {
+    if (!isSilent() && dirHadContentBefore) {
+      log.warn(
+        `Left partially created files in ${projectDir} (directory already existed). Review and clean up manually.`,
+      );
+    }
+    return;
+  }
+
+  try {
+    await fs.remove(projectDir);
+    if (!isSilent()) {
+      log.warn(
+        `Cleaned up partially created project at ${projectDir}. Set BTS_KEEP_FAILED_OUTPUT=1 to keep it for debugging.`,
+      );
+    }
+  } catch {
+    // Best-effort cleanup; surface nothing if removal itself fails.
   }
 }
 

--- a/apps/cli/src/helpers/core/db-setup.ts
+++ b/apps/cli/src/helpers/core/db-setup.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import pc from "picocolors";
 
 import type { ProjectConfig } from "../../types";
+import type { SetupStepResult } from "./install-dependencies";
 
 import { setupCloudflareD1 } from "../database-providers/d1-setup";
 import { setupDockerCompose } from "../database-providers/docker-compose-setup";
@@ -21,7 +22,10 @@ import { setupSupabase } from "../database-providers/supabase-setup";
 import { setupTurso } from "../database-providers/turso-setup";
 import { setupUpstash } from "../database-providers/upstash-setup";
 
-export async function setupDatabase(config: ProjectConfig, cliInput?: { manualDb?: boolean }) {
+export async function setupDatabase(
+  config: ProjectConfig,
+  cliInput?: { manualDb?: boolean },
+): Promise<SetupStepResult | null> {
   const { database, dbSetup, backend, projectDir } = config;
 
   if (backend === "convex" || database === "none") {
@@ -32,12 +36,12 @@ export async function setupDatabase(config: ProjectConfig, cliInput?: { manualDb
         await fs.remove(serverDbDir);
       }
     }
-    return;
+    return null;
   }
 
   const dbPackageDir = path.join(projectDir, "packages/db");
   if (!(await fs.pathExists(dbPackageDir))) {
-    return;
+    return null;
   }
 
   try {
@@ -65,9 +69,11 @@ export async function setupDatabase(config: ProjectConfig, cliInput?: { manualDb
     } else if (database === "redis" && dbSetup === "upstash") {
       await setupUpstash(config, cliInput);
     }
+
+    return { step: "Database setup", success: true };
   } catch (error) {
-    if (error instanceof Error) {
-      consola.error(pc.red(error.message));
-    }
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    consola.error(pc.red(errorMessage));
+    return { step: "Database setup", success: false, errorMessage };
   }
 }

--- a/apps/cli/src/helpers/core/install-dependencies.ts
+++ b/apps/cli/src/helpers/core/install-dependencies.ts
@@ -5,7 +5,27 @@ import pc from "picocolors";
 
 import type { Addons, PackageManager } from "../../types";
 
-export function getInstallEnvironment(packageManager: PackageManager): NodeJS.ProcessEnv | undefined {
+/**
+ * Result of a post-scaffold setup step (dependency install, native build, db setup).
+ * Steps still log their own errors, but no longer swallow failure silently — callers
+ * collect these so the CLI reports an accurate final status instead of always
+ * printing "Project created successfully" on top of a broken install.
+ */
+export interface SetupStepResult {
+  /** Human-readable step name, e.g. "Install dependencies". */
+  step: string;
+  success: boolean;
+  /** Present when success is false. */
+  errorMessage?: string;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function getInstallEnvironment(
+  packageManager: PackageManager,
+): NodeJS.ProcessEnv | undefined {
   if (packageManager === "yarn") {
     return {
       // Fresh generated workspaces need to create yarn.lock on first install.
@@ -37,8 +57,9 @@ export async function installDependencies({
   projectDir: string;
   packageManager: PackageManager;
   addons?: Addons[];
-}) {
+}): Promise<SetupStepResult> {
   const s = spinner();
+  const step = "Install dependencies";
 
   try {
     s.start(`Running ${packageManager} install...`);
@@ -54,16 +75,22 @@ export async function installDependencies({
     })`${packageManager} ${installArgs}`;
 
     s.stop("Dependencies installed successfully");
+    return { step, success: true };
   } catch (error) {
     s.stop(pc.red("Failed to install dependencies"));
-    if (error instanceof Error) {
-      consola.error(pc.red(`Installation error: ${error.message}`));
-    }
+    const errorMessage = toErrorMessage(error);
+    consola.error(pc.red(`Installation error: ${errorMessage}`));
+    return { step, success: false, errorMessage };
   }
 }
 
-export async function runCargoBuild({ projectDir }: { projectDir: string }) {
+export async function runCargoBuild({
+  projectDir,
+}: {
+  projectDir: string;
+}): Promise<SetupStepResult> {
   const s = spinner();
+  const step = "Cargo build";
 
   try {
     s.start("Running cargo build...");
@@ -74,16 +101,18 @@ export async function runCargoBuild({ projectDir }: { projectDir: string }) {
     })`cargo build`;
 
     s.stop("Cargo build completed");
+    return { step, success: true };
   } catch (error) {
     s.stop(pc.red("Cargo build failed"));
-    if (error instanceof Error) {
-      consola.error(pc.red(`Cargo build error: ${error.message}`));
-    }
+    const errorMessage = toErrorMessage(error);
+    consola.error(pc.red(`Cargo build error: ${errorMessage}`));
+    return { step, success: false, errorMessage };
   }
 }
 
-export async function runUvSync({ projectDir }: { projectDir: string }) {
+export async function runUvSync({ projectDir }: { projectDir: string }): Promise<SetupStepResult> {
   const s = spinner();
+  const step = "uv sync (Python dependencies)";
 
   try {
     s.start("Running uv sync...");
@@ -94,16 +123,22 @@ export async function runUvSync({ projectDir }: { projectDir: string }) {
     })`uv sync`;
 
     s.stop("Python dependencies installed successfully");
+    return { step, success: true };
   } catch (error) {
     s.stop(pc.red("uv sync failed"));
-    if (error instanceof Error) {
-      consola.error(pc.red(`uv sync error: ${error.message}`));
-    }
+    const errorMessage = toErrorMessage(error);
+    consola.error(pc.red(`uv sync error: ${errorMessage}`));
+    return { step, success: false, errorMessage };
   }
 }
 
-export async function runGoModTidy({ projectDir }: { projectDir: string }) {
+export async function runGoModTidy({
+  projectDir,
+}: {
+  projectDir: string;
+}): Promise<SetupStepResult> {
   const s = spinner();
+  const step = "go mod tidy";
 
   try {
     s.start("Running go mod tidy...");
@@ -114,17 +149,23 @@ export async function runGoModTidy({ projectDir }: { projectDir: string }) {
     })`go mod tidy`;
 
     s.stop("Go dependencies installed successfully");
+    return { step, success: true };
   } catch (error) {
     s.stop(pc.red("go mod tidy failed"));
-    if (error instanceof Error) {
-      consola.error(pc.red(`go mod tidy error: ${error.message}`));
-    }
+    const errorMessage = toErrorMessage(error);
+    consola.error(pc.red(`go mod tidy error: ${errorMessage}`));
+    return { step, success: false, errorMessage };
   }
 }
 
-export async function runMavenTests({ projectDir }: { projectDir: string }) {
+export async function runMavenTests({
+  projectDir,
+}: {
+  projectDir: string;
+}): Promise<SetupStepResult> {
   const s = spinner();
   const mvnw = process.platform === "win32" ? "mvnw.cmd" : "./mvnw";
+  const step = "Maven tests";
 
   try {
     s.start("Running Maven tests...");
@@ -135,17 +176,23 @@ export async function runMavenTests({ projectDir }: { projectDir: string }) {
     })`${mvnw} test`;
 
     s.stop("Maven tests completed");
+    return { step, success: true };
   } catch (error) {
     s.stop(pc.red("Maven tests failed"));
-    if (error instanceof Error) {
-      consola.error(pc.red(`Maven test error: ${error.message}`));
-    }
+    const errorMessage = toErrorMessage(error);
+    consola.error(pc.red(`Maven test error: ${errorMessage}`));
+    return { step, success: false, errorMessage };
   }
 }
 
-export async function runGradleTests({ projectDir }: { projectDir: string }) {
+export async function runGradleTests({
+  projectDir,
+}: {
+  projectDir: string;
+}): Promise<SetupStepResult> {
   const s = spinner();
   const gradlew = process.platform === "win32" ? "gradlew.bat" : "./gradlew";
+  const step = "Gradle tests";
 
   try {
     s.start("Running Gradle tests...");
@@ -156,16 +203,22 @@ export async function runGradleTests({ projectDir }: { projectDir: string }) {
     })`${gradlew} test`;
 
     s.stop("Gradle tests completed");
+    return { step, success: true };
   } catch (error) {
     s.stop(pc.red("Gradle tests failed"));
-    if (error instanceof Error) {
-      consola.error(pc.red(`Gradle test error: ${error.message}`));
-    }
+    const errorMessage = toErrorMessage(error);
+    consola.error(pc.red(`Gradle test error: ${errorMessage}`));
+    return { step, success: false, errorMessage };
   }
 }
 
-export async function runMixCompile({ projectDir }: { projectDir: string }) {
+export async function runMixCompile({
+  projectDir,
+}: {
+  projectDir: string;
+}): Promise<SetupStepResult> {
   const s = spinner();
+  const step = "mix deps.get / compile";
 
   try {
     s.start("Running mix deps.get and mix compile...");
@@ -181,10 +234,11 @@ export async function runMixCompile({ projectDir }: { projectDir: string }) {
     })`mix compile`;
 
     s.stop("Elixir dependencies installed and project compiled");
+    return { step, success: true };
   } catch (error) {
     s.stop(pc.red("mix compile failed"));
-    if (error instanceof Error) {
-      consola.error(pc.red(`Mix error: ${error.message}`));
-    }
+    const errorMessage = toErrorMessage(error);
+    consola.error(pc.red(`Mix error: ${errorMessage}`));
+    return { step, success: false, errorMessage };
   }
 }

--- a/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
+++ b/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
@@ -1577,7 +1577,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-tanstack-router-minimal/config": "workspace:*"
@@ -1725,6 +1727,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -1892,6 +1895,7 @@ export default nextConfig;
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start"
@@ -2200,7 +2204,9 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "^6.0.3",
     "@snapshot-next-self-fullstack/config": "workspace:*"
@@ -2308,7 +2314,9 @@ export type AppRouter = typeof appRouter;
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "^6.0.3",
     "@snapshot-next-self-fullstack/config": "workspace:*"
@@ -2454,6 +2462,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
@@ -2885,7 +2894,9 @@ export const orpc = createTanstackQueryUtils(client)
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-astro-react-integration/config": "workspace:*"
@@ -3031,6 +3042,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -3408,7 +3420,9 @@ export default defineNuxtConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-nuxt-standalone/config": "workspace:*"
@@ -3554,6 +3568,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -4179,7 +4194,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-express-node-trpc/config": "workspace:*",
@@ -4306,6 +4323,7 @@ export type AppRouter = typeof appRouter;
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "postinstall": "prisma generate",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
@@ -4966,7 +4984,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-hono-bun-orpc/config": "workspace:*"
@@ -5113,6 +5133,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -5796,6 +5817,7 @@ export default defineConfig({
   },
   "type": "module",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "openapi:verify": "bun src/verify-openapi.ts"
   },
   "devDependencies": {
@@ -5989,7 +6011,9 @@ export const openApiDocument = createOpenApiDocument();
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-hono-openapi/config": "workspace:*"
@@ -6141,6 +6165,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -6915,7 +6940,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-better-auth-full/config": "workspace:*"
@@ -7023,7 +7050,9 @@ export type AppRouter = typeof appRouter;
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-better-auth-full/config": "workspace:*"
@@ -7175,6 +7204,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
@@ -7964,6 +7994,7 @@ export default nextConfig;
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start"
@@ -8245,7 +8276,9 @@ export const trpc = createTRPCOptionsProxy<AppRouter>({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "^6.0.3",
     "@snapshot-self-next-clerk/config": "workspace:*"
@@ -8393,6 +8426,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -8939,7 +8973,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-self-tanstack-start-clerk/config": "workspace:*"
@@ -9085,6 +9121,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -9702,7 +9739,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-mongodb-mongoose/config": "workspace:*"
@@ -9828,7 +9867,9 @@ export type AppRouter = typeof appRouter;
       "default": "./src/*.ts"
     }
   },
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-mongodb-mongoose/config": "workspace:*"
@@ -10431,7 +10472,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-postgres-prisma/config": "workspace:*"
@@ -10558,6 +10601,7 @@ export type AppRouter = typeof appRouter;
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "postinstall": "prisma generate",
     "db:push": "prisma db push",
     "db:generate": "prisma generate",
@@ -11185,7 +11229,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-algolia-search-hono/config": "workspace:*"
@@ -11333,6 +11379,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -11969,7 +12016,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-ai-cli-root-tooling/config": "workspace:*"
@@ -12117,6 +12166,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -12748,7 +12798,9 @@ export default defineConfig({
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-nx-root-tooling/config": "workspace:*"
@@ -12896,6 +12948,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -13681,6 +13734,7 @@ fontWeight: "bold",
   "version": "1.0.0",
   "main": "expo-router/entry",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "expo start --clear",
     "build": "expo export",
     "android": "expo run:android",
@@ -13955,7 +14009,9 @@ export default app;
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-native-react-native/config": "workspace:*"
@@ -14103,6 +14159,7 @@ export default defineConfig({
     }
   },
   "scripts": {
+    "check-types": "tsc --noEmit",
     "db:local": "turso dev --db-file local.db",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
@@ -14384,6 +14441,7 @@ registerRootComponent(App);
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "expo start --clear",
     "build": "expo export",
     "android": "expo run:android",
@@ -14706,7 +14764,9 @@ export default app;
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {
     "typescript": "catalog:",
     "@snapshot-native-mobile-integrations/config": "workspace:*"

--- a/apps/cli/test/check-types-coverage.test.ts
+++ b/apps/cli/test/check-types-coverage.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const TEMPLATES_DIR = path.resolve(
+  import.meta.dir,
+  "../../../packages/template-generator/templates",
+);
+
+/**
+ * Generated workspace packages that intentionally do NOT ship a `check-types`
+ * script. Every entry needs a documented reason. When adding a new generated
+ * package, prefer giving it a real `check-types` script over allowlisting it —
+ * a package that is never type-checked is exactly how drift (e.g. the
+ * heroui-native and stripe apiVersion regressions) shipped silently.
+ */
+const CHECK_TYPES_ALLOWLIST = new Map<string, string>([
+  [
+    "base/package.json.hbs",
+    "Root workspace package; check-types is injected as `turbo check-types` by post-process/package-configs.ts",
+  ],
+  [
+    "packages/config/package.json.hbs",
+    "Stub package with no TypeScript source; `tsc --noEmit` would fail with TS18003 (no inputs found)",
+  ],
+  [
+    "packages/env/package.json.hbs",
+    "Source is fully conditional; deferred pending per-config validation",
+  ],
+  ["packages/infra/package.json.hbs", "Alchemy IaC package with no tsconfig"],
+  [
+    "backend/convex/packages/backend/package.json.hbs",
+    "Convex codegen-managed types; needs `convex codegen` before tsc",
+  ],
+  [
+    "frontend/redwood/package.json.hbs",
+    "RedwoodJS/CedarJS uses its own framework-managed type-check",
+  ],
+  ["frontend/redwood/web/package.json.hbs", "RedwoodJS/CedarJS framework-managed type-check"],
+  ["frontend/redwood/api/package.json.hbs", "RedwoodJS/CedarJS framework-managed type-check"],
+  [
+    "frontend/react/tanstack-start/package.json.hbs",
+    "Needs `tsr generate` + @tanstack/router-cli before tsc (follow-up, mirror tanstack-router)",
+  ],
+  ["frontend/nuxt/package.json.hbs", "Needs `nuxt typecheck` + vue-tsc (follow-up)"],
+  ["frontend/astro/package.json.hbs", "Needs `astro check` + @astrojs/check (follow-up)"],
+  [
+    "frontend/angular/package.json.hbs",
+    "Needs Angular compiler-based type-check, not plain tsc (follow-up)",
+  ],
+]);
+
+function findPackageJsonHbs(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      findPackageJsonHbs(full, acc);
+    } else if (entry === "package.json.hbs") {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function hasCheckTypes(file: string): boolean {
+  return readFileSync(file, "utf8").includes('"check-types"');
+}
+
+describe("generated package check-types coverage", () => {
+  const files = findPackageJsonHbs(TEMPLATES_DIR);
+
+  it("discovers the generated package.json templates", () => {
+    expect(files.length).toBeGreaterThan(30);
+  });
+
+  it("every generated package defines check-types or is explicitly allowlisted", () => {
+    const offenders = files
+      .map((file) => path.relative(TEMPLATES_DIR, file))
+      .filter((rel) => !CHECK_TYPES_ALLOWLIST.has(rel))
+      .filter((rel) => !hasCheckTypes(path.join(TEMPLATES_DIR, rel)));
+
+    // A non-empty list means a package would be generated without ever being
+    // type-checked. Add a `check-types` script, or allowlist it with a reason.
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the allowlist honest (no missing or already-fixed entries)", () => {
+    const stale: string[] = [];
+    for (const rel of CHECK_TYPES_ALLOWLIST.keys()) {
+      const full = path.join(TEMPLATES_DIR, rel);
+      let content: string;
+      try {
+        content = readFileSync(full, "utf8");
+      } catch {
+        stale.push(`${rel} (file no longer exists)`);
+        continue;
+      }
+      if (content.includes('"check-types"')) {
+        stale.push(`${rel} (now defines check-types — remove from allowlist)`);
+      }
+    }
+    expect(stale).toEqual([]);
+  });
+});

--- a/apps/cli/test/install-dependencies.test.ts
+++ b/apps/cli/test/install-dependencies.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "bun:test";
+import os from "node:os";
+import path from "node:path";
 
-import { getInstallArgs, getInstallEnvironment } from "../src/helpers/core/install-dependencies";
+import type { ProjectConfig } from "../src/types";
+
+import { setupDatabase } from "../src/helpers/core/db-setup";
+import {
+  getInstallArgs,
+  getInstallEnvironment,
+  installDependencies,
+} from "../src/helpers/core/install-dependencies";
 
 describe("getInstallEnvironment", () => {
   it("disables immutable Yarn CI defaults for fresh scaffolds", () => {
@@ -26,5 +35,36 @@ describe("getInstallArgs", () => {
     expect(getInstallArgs("npm")).toEqual(["install"]);
     expect(getInstallArgs("bun")).toEqual(["install"]);
     expect(getInstallArgs("yarn")).toEqual(["install"]);
+  });
+});
+
+describe("installDependencies", () => {
+  it("returns a failure result instead of swallowing the error when install fails", async () => {
+    // A non-existent cwd makes the install command fail fast (ENOENT) without
+    // running a real install. The function must report the failure to its
+    // caller rather than silently logging it (the old behavior).
+    const missingDir = path.join(os.tmpdir(), `bfs-nonexistent-${process.pid}-${Date.now()}`);
+
+    const result = await installDependencies({
+      projectDir: missingDir,
+      packageManager: "bun",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.step).toBe("Install dependencies");
+    expect(result.errorMessage).toBeTruthy();
+  });
+});
+
+describe("setupDatabase", () => {
+  it("returns null when there is no external database to provision", async () => {
+    const config = {
+      backend: "convex",
+      database: "none",
+      dbSetup: "none",
+      projectDir: os.tmpdir(),
+    } as unknown as ProjectConfig;
+
+    expect(await setupDatabase(config)).toBeNull();
   });
 });

--- a/docs/next-updates-roadmap.md
+++ b/docs/next-updates-roadmap.md
@@ -1,0 +1,209 @@
+# Better-Fullstack — Next Updates, Features & Improvements
+
+> **Generated:** 2026-06-18 from a multi-agent analysis of `apps/cli`, `packages/template-generator`, `apps/web`, the MCP server, the testing/CI/release systems, and the competitive landscape.
+>
+> **How to read this:** Start at **🔴 Fix first** (active correctness/trust bugs). Then work the tiers in order — Tier 2 (quality foundation) is the unlock that makes everything else shippable with confidence. Appendices hold the dense, file-cited findings per subsystem.
+
+---
+
+## Strategic read
+
+BFS has the **widest scaffolding surface in the market** — 8 ecosystems, 677 options, a web builder, *and* an MCP server. No competitor (including its TS-only upstream `create-better-t-stack`) matches that breadth. Three things cap the value of that breadth:
+
+1. **Quality assurance gap** — generated projects are *not compiled in CI*, and the CLI reports "success" even when a project is broken. This is the root cause of nearly every template bug in project memory.
+2. **Lifecycle gap** — BFS is a one-shot scaffolder. Competitors ship `astro add` / `sv add` (add features to existing projects) and `nx migrate` (codemod upgrades). BFS is one step from both.
+3. **Under-marketed moat + dormant features** — the polyglot multi-ecosystem monorepo is the unique wedge but it's buried, and a showcase gallery + analytics dashboard are already built but not routed.
+
+**The opportunity bet:** position BFS as **the deterministic, verified golden-path layer that AI agents scaffold into** — because AI app-builders (Lovable, v0, bolt) win greenfield demos but ship 45–80% vulnerable code and hit an iteration wall.
+
+---
+
+## 🔴 Fix first — correctness/trust bugs (not features)
+
+These four together explain BFS's entire recurring-bug history. They bleed regardless of roadmap.
+
+> **Implementation status (2026-06-18):** #1, #2, #3 **landed & verified**. #4 **substantially landed**: `check-types` added to 17 high-confidence generated packages (every documented drift target — better-auth/stripe, orpc/trpc context, heroui-native), enforced by a new coverage meta-test (`apps/cli/test/check-types-coverage.test.ts`) with a 12-entry documented allowlist; validated end-to-end on real installs (TS next+hono+trpc+drizzle+better-auth and react-native uniwind). Remaining allowlisted framework packages (nuxt/astro/angular/tanstack-start/redwood/convex) need per-framework check commands and are tracked as follow-ups. Side effect: regenerating the template bundle also fixed 10 stale-snapshot test failures.
+
+| # | Bug | Where | Why it matters |
+|---|---|---|---|
+| 1 | **Install/db-setup errors are swallowed → CLI prints "Project created successfully" on broken projects** | `apps/cli/src/helpers/core/install-dependencies.ts` (catch+log, never rethrow); `db-setup.ts` (same) | Worst trust bug. Users get green "success" + history entry + analytics event on a broken scaffold. |
+| 2 | **No rollback / cleanup on fatal failure** → half-scaffolded dir left behind | `apps/cli/src/helpers/core/create-project.ts` (catch path calls `exitWithError` with no cleanup) | Users must manually `rm` and can't cleanly retry. Add `--keep-on-error` escape hatch. |
+| 3 | **CI "pass" is gated by a regex, not step success** — install/build/typecheck failures stay green unless error text matches curated `TEMPLATE_PATTERNS` | `testing/smoke-test.ts` (`classification === "template"` gate); `testing/lib/verify.ts` (regex classifier) | This is *why* the stripe/heroui/native bugs shipped. Highest-leverage single fix in the repo. |
+| 4 | **~29 of 37 generated packages have no `check-types` script** (verifier silently skips them) | `testing/lib/verify.ts` (skip-when-absent); `templates/frontend/native/package.json.hbs`, `templates/auth/*`, `api/*` | Type drift ships silently — exactly the heroui-native & stripe-`apiVersion` drift in memory. |
+
+**Fix approach (summary):**
+- **#1** Collect per-step status (install, db-setup, build checks); rethrow or propagate failure so the outro reads "created with errors" + recovery hint; do **not** write history/fire analytics as "success" on failure.
+- **#2** If the CLI created the target dir (not merge mode), `fs.remove` it on fatal error, or print exact recovery steps; add `--keep-on-error`.
+- **#3** Replace the `classification === "template"` gate with "fail on any step where `!success && !skipped && !advisory`"; keep `environment` as the only soft class, but count + surface it.
+- **#4** Add `"check-types": "tsc --noEmit"` (and `tsr generate &&` where needed) to every generated `package.json.hbs` lacking it; run `turbo check-types` across all workspace packages in the verifier; add a meta-test asserting every generated package defines it.
+
+---
+
+## 🟢 Tier 1 — Quick wins (high impact, low effort — mostly *finishing existing work*)
+
+| Item | Effort | Notes |
+|---|---|---|
+| **Ship the `/showcase` route** | S | `apps/web/src/components/showcase/showcase-page.tsx` fully built, just unrouted. Social proof + SEO. |
+| **Ship public `/analytics` "Popular / Trending stacks" page** | S–M | Dashboard + `analytics.getStats()` (`stackCombinations`, `dbOrmCombinations`) already exist and are unused. Doubles as a builder hint. |
+| **Make `AGENTS.md` a *default* ai-docs output** (alongside CLAUDE.md) | S | create-next-app 16.2 default; now a Linux Foundation standard (60k+ repos). Currently opt-in only. |
+| **Dynamic OG images for shared stacks** | M | No `og:image` exists today — every share unfurls as a generic terminal PNG. |
+| **Fix the ".NET = 8th ecosystem" stat** across site/SEO/JSON-LD | S | `apps/web/src/lib/project-stats.ts` hardcodes `ECOSYSTEM_COUNT = 7`; under-sells the product to users *and* LLMs. |
+| **Re-run from history**: `create --from-history <n>` / `--config <bts.jsonc>` | S | History already stores full config; `create()` already accepts one. |
+| **First-run telemetry notice + `bfs telemetry` toggle** | S | Currently silent opt-out that sends the whole config — reputational/compliance risk. |
+| **Fix MCP `astroIntegration` (latent bug) + stop hardcoding `aiDocs`** | S | MCP-built Astro projects can't pick a framework integration; agents can't request `agents-md`. |
+| **⌘K command-palette search across 677 options** in the builder | M | Biggest builder friction is scrolling 48 categories. |
+
+---
+
+## 🟡 Tier 2 — Quality foundation (makes the breadth *trustworthy*)
+
+The unlock that converts "677 options" from a liability into a guarantee. Two agents independently flagged this as the #1 systemic gap.
+
+| Item | Effort | Impact |
+|---|---|---|
+| **PR-gate a minimal generated-project typecheck matrix** (~6–8 presets, one per ecosystem: real `install + check-types/build`) | M | High |
+| **Emit `check-types` in every generated workspace package** + run `turbo check-types` across all | S–M | High |
+| **Schema↔template coverage test** (every non-`none` enum value must have a real template — auto-catches the .NET "selectable but not generated" class) | M | High |
+| **Property-test the compatibility engine** (3,733 lines / ~471 conditionals vs 56 example tests): idempotence, "adjusted config satisfies all constraints," "adjusted config scaffolds" | M | High |
+| **Gate npm releases on a real smoke run** (today `release.yaml` runs only the static lane) | S–M | High |
+| **Generated-project health roll-up** (aggregator job + pass/fail table; the weekly matrix has no aggregation) | S–M | Med-High |
+| **API-literal drift guard** (stripe `apiVersion`, expo `web.output`, drizzle mysql `connection`) | M | Med-High |
+
+---
+
+## 🔵 Tier 3 — Lifecycle & moat (strategic bets for the next major)
+
+| Item | Effort | Why it's the moat |
+|---|---|---|
+| **`bfs add` for *real* features** (db/auth/api/payments/email...) into existing projects, not just addons | L | Headline lifecycle gap. `astro add`/`sv add` prove demand; compatibility engine + `bts.jsonc` make it uniquely doable *cross-ecosystem*. MCP `plan_addition` has the bones. |
+| **`bfs upgrade` migration engine** (ordered, reviewable codemods on top of `update-deps`) | L | Biggest *unsolved* problem in the space. `nx migrate` is the gold standard. |
+| **`bfs doctor`** (validate `bts.jsonc`, deps, env vars, run build checks) | M | Mostly wiring existing `--verify` infra into a diagnostic command. |
+| **MCP: structured outputs + tool annotations + `bfs_list_presets` + `bfs_recommend_stack`** (NL brief → validated stack) | M | Turns BFS from "schema you must fill" into "describe it and go." |
+| **AI builder assistant on the web** ("describe your app → stack"), reusing the compatibility engine | L | Flagship differentiator for the 677-option overwhelm. |
+| **Publish a Claude Code plugin / Agent Skill** (CLI+Skill pattern; keep MCP for orchestration) | S–M | Validated 2026 distribution; CLI tool-calls are 10–32× cheaper in tokens than MCP. |
+
+---
+
+## 🟣 Tier 4 — New integrations & growth
+
+- **Vector DB category** (`pgvector`/Pinecone/Qdrant/Chroma/Weaviate) — S–M, High. The one obvious 2026 AI primitive missing, despite 11 TS + 10 Python AI SDKs.
+- **GitHub Actions CI addon** — generated projects currently ship with *zero* CI. M, High.
+- **Golden-path "complete app" templates** (SaaS-in-a-box: auth + billing + admin + marketing) vs today's `todo`/`ai` examples. M–L, High.
+- **Programmatic per-combo SEO/GEO landing pages** ("Go + React monorepo starter") — owns long-tail no competitor can match. M, High.
+- **Preview export: ZIP download + "Open in StackBlitz"** — turns the dead-end read-only preview into a try-it loop. M.
+- **Short shareable links + a Convex `shares` table** (custom stacks currently get ugly `/new?...` URLs). M.
+- **Reposition around the polyglot monorepo + "verified golden path for AI agents"**; add `create-better-t-stack` and AI app-builders to `/compare`; fix README "450+/7" vs MCP "677/8" inconsistency. S.
+
+---
+
+## Recommended sequencing
+
+1. **Sprint 0 (now):** the four 🔴 correctness bugs + the Tier-1 "finish existing work" items (showcase, analytics, AGENTS.md default, .NET stat). Cheap; stops active bleeding and unlocks dormant value.
+2. **Sprint 1:** Tier 2 quality foundation. Once generated projects are actually compiled in CI, everything else ships with confidence instead of via manual `bun create` discovery.
+3. **Next major:** pick **one** flagship moat bet — recommend **`bfs add` for full features** first (compounds with the MCP story + AI builder assistant; plumbing partly exists).
+
+> **Confidence note:** External competitive facts (version numbers, ARR, competitor features) are web-research dated June 2026 — sanity-check before using in marketing copy. Code-cited findings (file paths, the CI gating hole, swallowed errors) were verified against the repo.
+
+---
+
+# Appendices — detailed, file-cited findings
+
+## Appendix A — CLI experience & architecture
+
+**Current state:** oRPC router via `trpc-cli` (`apps/cli/src/run.ts`) exposes `create`/`add`/`history`/`update-deps`/`sponsors`/`docs`/`builder`/`mcp`. Interactive UX is `@clack/prompts` + a custom navigation layer (`prompts/navigable.ts`, `navigable-group.ts`) with back/forward and smart back-skip. ~150 zod flags (`create-command-input.ts`), `--yes`/`--yolo`/`--part`/`--dry-run`/`--verify`. Validation is imperative (`compatibility-rules.ts` ~808 lines + `config-validation.ts` ~1317 lines). Excellent per-ecosystem post-install instructions (`post-installation.ts`). Telemetry is opt-out.
+
+**Gaps / bugs:**
+- Install failures swallowed (`install-dependencies.ts:57-62`, plus `runCargoBuild`/`runUvSync`/`runGoModTidy`/`runMavenTests`/`runGradleTests`/`runMixCompile`) → false "success" (`command-handlers.ts:506`).
+- DB-setup failures swallowed (`db-setup.ts:68-72`).
+- No rollback on fatal error (`create-project.ts:129-137`).
+- `add` command is addon/deploy-only (`run.ts:233-255`, `add-handler.ts`) — can't add db/orm/auth/api/payments/email/etc.
+- No `upgrade`/`doctor`/`eject`/`migrate`/`config` commands.
+- `update-deps` is maintainer-only but misleadingly named (`commands/update-deps.ts:47-69`).
+- Telemetry: opt-out, no first-run notice, sends whole config (`utils/analytics.ts:18`).
+- Auto-adjustments invisible under `--yes`/CI (gated on `!isSilent()`).
+- Multi-ecosystem `.env`/README collisions, bypassable with `--yolo` (`generator.ts:166-179`).
+- No final confirm gate in interactive mode; no re-run/edit-last-config; presets are TS/RN-only (`utils/templates.ts`: mern/pern/t3/uniwind).
+
+**Top recommendations:** fix swallowed errors (S/High), rollback (M/High), `bfs add` for real features (L/High), `bfs doctor` (M/High), telemetry notice + toggle (S/High), `create --from-history`/`--config` (S/High), surface auto-adjustments in non-interactive (S/Med-High), final confirm gate (S/Med), per-ecosystem presets (M/Med-High), `create --json` (S/Med).
+
+## Appendix B — Template generator & coverage
+
+**Current state:** single generator runs in Node (CLI) + browser (web) via bundled `templates.generated.ts` (~2.3 MB). TS/RN use a modular pipeline (44 processors, 32 handlers, ~423 pinned versions in `utils/add-deps.ts`); non-TS ecosystems use one monolithic handler each + Handlebars-conditional dep files. Source of truth: `packages/types/src/schemas.ts`.
+
+**Ecosystem depth:** TypeScript/RN/Python/Go/Java = production; Elixir = partial (ueberauth/guardian/gRPC are deps-only placeholders); **.NET = stub** (12 files / 439 lines, everything inline in `Program.cs.hbs`). Frontend breadth is excellent (next/nuxt/svelte/solid/astro/qwik/angular/redwood/fresh/react-router/tanstack-*/native) — coverage isn't the gap; **depth & integrations** are.
+
+**Recurring bug classes:** `noUnusedLocals` unused imports/vars (fets/orpc/trpc/Go); node16/nodenext missing `.js` extensions (drizzle/mikroorm/sequelize/typeorm barrels); missing deps/generated files (graph `--part` empty `packages/database/package.json`; `@tanstack/react-form`; `routeTree.gen.ts`); in-code API drift invisible to version checks (stripe `apiVersion`, drizzle mysql `connection`, expo `web.output:"static"`).
+
+**Missing integrations devs expect in 2026:** no vector DB anywhere; no CI/CD output in generated projects; no IaC (Terraform/Pulumi) / k8s/Helm; Clerk has no native/Expo; CMS all web-only; OpenAPI API server-only (no client).
+
+**Top recommendations:** PR-gate generated-project typecheck (M/High); `check-types` in every package (S/High); schema↔template coverage test (M/High); GitHub Actions CI addon (M/High); vector DB category (M/High); decide .NET (implement to parity or prune schema) (L or S/High); in-code API-drift guard (M/Med-High); generalize auth0/kinde/workos/clerk beyond Next-only (M/Med-High); declarative tool-option manifest to collapse the 15–29-file add-an-option checklist (L/Med-High).
+
+## Appendix C — Web platform & builder
+
+**Current state:** TanStack Start app. Builder (`components/stack-builder/stack-builder.tsx`, ~3430 lines) serves `/new`, `/stack`, `/$stackShare`; 4 view tabs (command/preview/presets/saved); URL state via `stack-url-state.ts`; client-side preview via `@better-fullstack/template-generator/browser`. Saved stacks are localStorage-only. Clean share slugs only for the 8 default stacks. `compare.tsx` is a static competitor table. Convex backends (`packages/backend/convex`, `apps/analytics/convex`) hold analytics/showcase/testimonials/videos/tweets. SEO: llms.txt + sitemap + JSON-LD; 1 blog post.
+
+**Gaps:**
+- No dynamic OG images (`$stackShare.tsx`/`stack.tsx`/`new.tsx` set no `og:image`).
+- No short links for custom stacks; no `shares` Convex table.
+- Rich analytics captured but surfaced nowhere (`analytics.getStats()`; full dashboard built but unrouted).
+- Showcase gallery built but unrouted (`showcase-page.tsx`).
+- No search across 677 options in builder; 12 categories collapsed by default.
+- Preview is a dead-end (no ZIP / Open-in-StackBlitz / WebContainer).
+- No accounts/personalization; web builder is not instrumented.
+- `.NET` under-reported: `project-stats.ts` hardcodes `ECOSYSTEM_COUNT = 7`, propagates to compare/llms.txt/JSON-LD.
+- Thin blog, no RSS; pretty stack landing pages absent from sitemap.
+
+**Top recommendations:** dynamic OG images (M/High); public "Popular/Trending" page from existing data (M/High); ⌘K option search (M/High); short links + `shares` table (M/High); fix .NET count (S/Med); wire `/showcase` (S–M/Med-High); instrument the builder (S–M/Med); preview ZIP + StackBlitz (M–L/High); AI builder assistant (L/High); RSS + extend search to guides/blog (S/Med).
+
+## Appendix D — MCP server & AI integration
+
+**Current state:** stdio-only server (`apps/cli/src/mcp.ts`, ~1348 lines). 7 tools (`bfs_get_guidance`/`get_schema`/`check_compatibility`/`plan_project`/`create_project`/`plan_addition`/`add_feature`), all returning JSON-in-text (no `structuredContent`/`outputSchema`/annotations). 3 resources (`docs://compatibility-rules`/`stack-options`/`getting-started`). No MCP prompts. `packages/create-bfs` is a pure alias. Install is local stdio across 8 agent presets.
+
+**Gaps / bugs:**
+- `bfs_create_project` hardcodes `process.cwd()` (`mcp.ts:1123`), no `targetDir`.
+- Create surface narrower than CLI: omits `astroIntegration` (latent Astro bug — hardcoded `"none"` at `:628`), `aiDocs` (hardcoded `["claude-md"]` at `:637` — agents can't request `agents-md`), `analytics`/`effect`/`versionChannel`/`shadcn*`/`verify`/`part`.
+- Throws away structured compat signal — uses `analyzeStackCompatibility` strings, ignores `evaluateCompatibility()` (`packages/types/src/compatibility.ts`) which already returns `code`/`optionId`/`suggestions`.
+- Brownfield is addon-only + low-fidelity (plan and apply are different code paths; can overwrite files silently).
+- No preset discovery; no NL→stack recommendation; thin per-option metadata (only `auth` has descriptions); token-heavy `plan_project` (full file list every call).
+
+**Top recommendations:** expose missing create fields incl. aiDocs/astroIntegration (S/High); `targetDir` input (S/High); structured outputs + annotations (S–M/High); surface `evaluateCompatibility` issues+suggestions (S–M/High); `bfs_list_presets` (S–M/High); token-efficient `plan_project` (S/Med); brownfield safety + plan/apply fidelity (S–M/High); `bfs_recommend_stack` (M–L/High); `bfs_explain_option` + enrich metadata (M/Med-High); register MCP prompts (S/Med); hosted/remote MCP + registry listing (M–L/Med-High); expand `add_feature` to non-addon categories (L/High).
+
+## Appendix E — Quality, testing, CI & release
+
+**Current state:** 5 test layers, only smoke (`testing/smoke-test.ts` + `testing/lib/verify.ts`) actually scaffolds + installs + builds/typechecks; unit/snapshot/parity layers never compile. E2E (`apps/cli/test/e2e/e2e.e2e.ts`) is TS-only, 9 configs. Combo sampling = weighted random (seeded), deduped vs a 316-row ledger. Compatibility engine = 3,733 lines / ~471 conditionals vs **56** example tests. CI on PR runs static release-guard + lint + unit + web build + smoke-strict-core/broad; the real install+dev-server `e2e-runtime` job is schedule-only. Release (`release.yaml`) runs only the static `test:release` lane before publish. No observability/dashboard/roll-up.
+
+**Risks (file-cited):**
+1. CI pass/fail gated by regex classification, not step success (`smoke-test.ts:489-492`, `verify.ts:47-95`). Highest risk.
+2. ~29/37 generated `package.json.hbs` lack `check-types`; verifier skips silently (`verify.ts:308-320`).
+3. Releases not gated on generated-project health (`release.yaml:101-103`).
+4. No rollback for stable releases (only canary can deprecate).
+5. Compatibility engine under-tested (no property/idempotence/fuzz).
+6. API-shape/literal drift never validated (stripe `apiVersion` at `templates/payments/stripe/server/base/src/lib/stripe.ts.hbs:5`).
+7. Sampler sparse; `dotnet` excluded from nightly (`smoke-test.ts:27-35`); preset source-of-truth drift (`template-matrix.yaml` hardcodes 17 vs `presets.ts` groups).
+8. Dep PRs auto-accept snapshots (`dep-freshness.yaml:67`, `deps-check.yaml:126`), masking regressions.
+9. `upstream-gap.yml` is `workflow_dispatch`-only despite docs claiming a Monday cron.
+10. Flaky timeouts self-mask (forced to `environment` → non-gating); graph/multi-ecosystem mode has zero compile coverage.
+
+**Top recommendations:** fix the smoke gating hole (S/High); unify preset source-of-truth (S/Med); gate releases on real smoke (S–M/High); mandatory `check-types` everywhere (M/High); health roll-up (S–M/High); property-test compat engine (M/High); coverage-guided sampler + add dotnet + raise nightly count (M/High); API-literal drift detection (M/Med-High); stop auto-accepting snapshots in dep PRs (S/Med); wire upstream-gap cron (S/Low-Med); flaky-rate metric (M/Med); route-check in nightly pr-core (M/Med); graph compile coverage (M/Med); local pre-push static gate (S/Low).
+
+## Appendix F — Competitive & market
+
+**Landscape (June 2026):**
+- **create-better-t-stack** (upstream sibling): v3.33.x, ~457 releases, ~5.5k stars, TS-only but deep; live `/analytics` + `/showcase`, 19 paying sponsors. BFS is far broader but BTS crushes it on release velocity, mindshare, community/growth infra.
+- **create-t3-app**: stalled (~28.6k stars); explicitly no add-to-existing / no upgrade.
+- **create-next-app** v16.2: AI-agent-first — ships `AGENTS.md` + `CLAUDE.md` by default, bundles version-matched docs for agents.
+- **create-vite** (Vite 8 / Rolldown): pure framework starters; no lifecycle tooling.
+- **create-astro / `astro add`**: gold-standard config-rewriting integration installer on existing projects; `--template <repo>`; `@astrojs/upgrade`.
+- **`sv` (Svelte CLI)**: `sv add` (better-auth/drizzle/mcp/paraglide), `sv migrate`.
+- **Nx**: `nx migrate` is the industry gold standard (ordered reviewable codemods + Migrate UI + agentic migrations); Nx MCP server; self-healing CI.
+- **Turborepo**: `turbo gen` custom generators.
+- **RedwoodJS**: sunset/split → CedarJS fork + RedwoodSDK (Cloudflare-only).
+- **Wasp / OpenSaaS**: TS spec + Mage (AI app-from-prompt); OpenSaaS = batteries-included SaaS starter shipping AGENTS.md + agent skills.
+- **Epic Stack / Bulletproof React**: opinionated templates/guides — Bulletproof's ~31.9k stars prove devs value conventions/docs as much as scaffolds.
+- **AI app builders** (Lovable ~$400M ARR, v0 Platform API, bolt, Replit Agent, Cursor, Claude Code): generate full apps from prompts — but 45–80% ship vulnerable, and hit an iteration wall / React-only lock-in.
+
+**Feature gaps to close:** automated project upgrade/migration (codemods); `add` that installs full integrations into existing projects; `AGENTS.md` as default; published Agent Skill / Claude Code plugin; golden-path SaaS-in-a-box templates; live showcase; public analytics; `--template <github-url>`; one-command deploy + "Open in" handoffs; sponsor monetization engine.
+
+**Differentiation / trend bets:** double down on 8-ecosystem breadth + polyglot monorepo (`--part`); scaffolder-as-MCP with a compatibility engine; "deterministic golden-path layer for AI agents"; secure-by-default/verified-scaffold positioning; edge/serverless-first defaults; conventions/docs as product; TS-native config (`bts.jsonc` → optional typed `bfs.config.ts`).
+
+**Top recommendations:** default AGENTS.md (S/High); ship `/showcase` (S/High); publish Agent Skill (S–M/High); public `/analytics` + trending (S–M/High); programmatic per-combo SEO pages (M/High); reframe positioning + fix stat inconsistencies + expand `/compare` (S/High); expand `add` to full integrations (M–L/High); `bfs upgrade` migration engine (L/High); golden-path complete-app templates (M–L/High); verified-scaffold guarantee/badge (S–M/Med-High); deploy + "Open in" buttons (M/Med); `--template <github-url>` (M/Med); sponsor engine (S–M/Med); edge-first preset + changelog page (M/Med).

--- a/packages/template-generator/templates/api/garph/server/package.json.hbs
+++ b/packages/template-generator/templates/api/garph/server/package.json.hbs
@@ -9,6 +9,8 @@
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {}
 }

--- a/packages/template-generator/templates/api/graphql-yoga/server/package.json.hbs
+++ b/packages/template-generator/templates/api/graphql-yoga/server/package.json.hbs
@@ -9,6 +9,8 @@
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {}
 }

--- a/packages/template-generator/templates/api/openapi/server/package.json.hbs
+++ b/packages/template-generator/templates/api/openapi/server/package.json.hbs
@@ -10,6 +10,7 @@
   },
   "type": "module",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "openapi:verify": "bun src/verify-openapi.ts"
   },
   "devDependencies": {},

--- a/packages/template-generator/templates/api/orpc/server/package.json.hbs
+++ b/packages/template-generator/templates/api/orpc/server/package.json.hbs
@@ -9,7 +9,9 @@
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {},
   "dependencies": {}
 }

--- a/packages/template-generator/templates/api/trpc/server/package.json.hbs
+++ b/packages/template-generator/templates/api/trpc/server/package.json.hbs
@@ -9,6 +9,8 @@
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {}
 }

--- a/packages/template-generator/templates/api/ts-rest/server/package.json.hbs
+++ b/packages/template-generator/templates/api/ts-rest/server/package.json.hbs
@@ -9,6 +9,8 @@
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {}
 }

--- a/packages/template-generator/templates/auth/better-auth/server/base/package.json.hbs
+++ b/packages/template-generator/templates/auth/better-auth/server/base/package.json.hbs
@@ -11,6 +11,8 @@
     }
   },
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {}
 }

--- a/packages/template-generator/templates/db/base/package.json.hbs
+++ b/packages/template-generator/templates/db/base/package.json.hbs
@@ -9,6 +9,8 @@
       "default": "./src/*.ts"
     }
   },
-  "scripts": {},
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
   "devDependencies": {}
 }

--- a/packages/template-generator/templates/frontend/native/bare/package.json.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/package.json.hbs
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "{{#if (eq mobileNavigation 'expo-router')}}expo-router/entry{{else}}index.js{{/if}}",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "expo start --clear",
     "build": "expo export",
     "android": "expo run:android",

--- a/packages/template-generator/templates/frontend/native/unistyles/package.json.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/package.json.hbs
@@ -4,6 +4,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "expo start --clear",
     "build": "expo export",
     "android": "expo run:android",

--- a/packages/template-generator/templates/frontend/native/uniwind/package.json.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/package.json.hbs
@@ -4,6 +4,7 @@
   "private": true,
   "main": "{{#if (eq mobileNavigation 'expo-router')}}expo-router/entry{{else}}index.js{{/if}}",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "start": "expo start",
     "dev": "expo start --clear",
     "build": "expo export",

--- a/packages/template-generator/templates/frontend/qwik/package.json.hbs
+++ b/packages/template-generator/templates/frontend/qwik/package.json.hbs
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "build": "qwik build",
     "build.client": "vite build",
     "build.preview": "vite build --ssr src/entry.preview.tsx",

--- a/packages/template-generator/templates/frontend/react/next/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/next/package.json.hbs
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start"

--- a/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/package.json.hbs
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check-types": "react-router typegen && tsc",
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",

--- a/packages/template-generator/templates/frontend/react/react-vite/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/react-vite/package.json.hbs
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "vite dev",
     "build": "vite build",
     "serve": "vite preview",

--- a/packages/template-generator/templates/frontend/react/vinext/package.json.hbs
+++ b/packages/template-generator/templates/frontend/react/vinext/package.json.hbs
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "vinext dev --port 3001",
     "build": "vinext build",
     "start": "vinext start",

--- a/packages/template-generator/templates/frontend/solid/package.json.hbs
+++ b/packages/template-generator/templates/frontend/solid/package.json.hbs
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "dev": "vite dev",
     "build": "vite build",
     "serve": "vite preview",

--- a/testing/smoke-test.ts
+++ b/testing/smoke-test.ts
@@ -486,7 +486,37 @@ await writeFile(
   }),
 );
 
-const hasTemplateBug = results.some((r) =>
-  r.steps.some((s) => !s.success && !s.skipped && s.classification === "template"),
+// CI gating: fail on any real (non-skipped, non-advisory) step failure.
+// Previously only `template`-classified failures gated CI, so genuine
+// compile/build/typecheck errors whose output didn't match a curated
+// TEMPLATE_PATTERN were classified `unknown` and silently passed. Transient
+// `environment` failures (network/registry/timeouts) stay non-gating to avoid
+// flakiness, but are surfaced so real hangs/regressions are not invisible.
+const realFailures = results.flatMap((r) =>
+  r.steps
+    .filter((s) => !s.success && !s.skipped && !s.advisory)
+    .map((s) => ({
+      combo: r.comboName,
+      step: s.step,
+      classification: s.classification ?? "unknown",
+    })),
 );
-if (hasTemplateBug) process.exitCode = 1;
+const environmentFailures = realFailures.filter((f) => f.classification === "environment");
+const gatingFailures = realFailures.filter((f) => f.classification !== "environment");
+
+if (environmentFailures.length > 0) {
+  console.warn(
+    `\n⚠ ${environmentFailures.length} environment-classified failure(s) did not gate CI (possible flakiness):`,
+  );
+  for (const f of environmentFailures) {
+    console.warn(`  - ${f.combo}: ${f.step}`);
+  }
+}
+
+if (gatingFailures.length > 0) {
+  console.error(`\n✗ ${gatingFailures.length} step failure(s) gating CI:`);
+  for (const f of gatingFailures) {
+    console.error(`  - ${f.combo}: ${f.step} [${f.classification}]`);
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Fixes the four correctness/trust bugs identified in a multi-agent codebase analysis (see `docs/next-updates-roadmap.md`). Together they explain most of BFS's recurring "shipped a broken template" history: the CLI reported success on broken projects, left partial output behind, CI silently passed real failures, and ~29 generated packages were never type-checked.

## What changed

**🔴 #1 — Accurate scaffold status (no more false "success")**
Install / db-setup / native-build steps no longer swallow errors. They return a structured `SetupStepResult`; `createProject` collects failures and the CLI prints **"created with N unfinished setup step(s)"** + a recovery hint instead of "created successfully". The `add` command surfaces install failure too.

**🔴 #2 — Rollback on fatal failure**
A fatal scaffolding error now removes the half-written directory the CLI created (never a pre-existing/merge dir). `BTS_KEEP_FAILED_OUTPUT=1` keeps partial output for debugging.

**🔴 #3 — CI smoke gate closed**
`testing/smoke-test.ts` only set a non-zero exit on `template`-classified failures, so genuine compile/build/typecheck errors classified `unknown` silently passed CI. Now **any** non-skipped, non-advisory step failure gates; transient `environment` failures stay soft but are surfaced.

**🔴 #4 — `check-types` for generated packages**
Added `check-types` to **17** previously-unchecked generated packages (db, auth server, all 6 api servers, 3 native, next/react-vite/vinext/react-router, solid, qwik) so root `turbo/bun check-types` actually type-checks them — closing the silent-drift hole that let `heroui-native` and `stripe apiVersion` regressions ship. The remaining **12** framework-specific packages (nuxt/astro/angular/tanstack-start/redwood/convex/stubs) are allowlisted with reasons in a new meta-test that forces every new package to either define `check-types` or be explicitly allowlisted.

## Validation

- Full CLI unit suite: **3284 pass / 0 fail** · web parity tests: **27 pass / 0 fail** · CLI + `testing/` typecheck clean · oxfmt/oxlint clean.
- **Real `bun install` + `check-types` passed end-to-end** on (a) TS next+hono+trpc+drizzle+better-auth and (b) react-native uniwind.
- Side effect: regenerating the template bundle for #4 also fixed **10 pre-existing test failures** (nx/openapi) that were caused by a stale `templates.generated.ts`.

## Notes

- `packages/template-generator/src/templates.generated.ts` is gitignored (built in CI), so only the `.hbs` sources are in the diff.
- Follow-ups: wire real `check-types` for the allowlisted framework packages (each needs a framework command + per-stack install validation).
