### PR TITLE
Add OpenSearch search provider

### DIFF
--- a/apps/cli/src/prompts/search.ts
+++ b/apps/cli/src/prompts/search.ts
@@ -21,6 +21,11 @@ const SEARCH_PROMPT_OPTIONS = [
     hint: "Distributed search and analytics engine with local and cloud deployments",
   },
   {
+    value: "opensearch" as const,
+    label: "OpenSearch",
+    hint: "Open-source search and analytics suite compatible with Elasticsearch APIs",
+  },
+  {
     value: "algolia" as const,
     label: "Algolia",
     hint: "Hosted search API with instant results, typo tolerance, and analytics",

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -1011,10 +1011,11 @@ function validateRateLimitConstraints(config: Partial<ProjectConfig>) {
 
 function validateSearchConstraints(config: Partial<ProjectConfig>) {
   if (!config.search || config.search === "none") return;
-  if (config.ecosystem !== "typescript" && config.search !== "meilisearch") {
+  const ecosystem = config.ecosystem ?? "typescript";
+  if (ecosystem !== "typescript" && config.search !== "meilisearch") {
     incompatibilityError({
       message: "Only Meilisearch search is available for non-TypeScript ecosystems.",
-      provided: { ecosystem: config.ecosystem ?? "typescript", search: config.search },
+      provided: { ecosystem, search: config.search },
       suggestions: ["Use --search meilisearch", "Use --search none"],
     });
   }

--- a/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
+++ b/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
@@ -766,6 +766,63 @@ exports[`Template Snapshots File Structure Snapshots file structure: algolia-sea
 ]
 `;
 
+exports[`Template Snapshots File Structure Snapshots file structure: opensearch-search-hono 1`] = `
+[
+  "CLAUDE.md",
+  "README.md",
+  "apps/server/.env",
+  "apps/server/package.json",
+  "apps/server/src/index.ts",
+  "apps/server/src/lib/search.ts",
+  "apps/server/tsconfig.json",
+  "apps/server/tsdown.config.ts",
+  "apps/web/.env",
+  "apps/web/index.html",
+  "apps/web/package.json",
+  "apps/web/src/components/header.tsx",
+  "apps/web/src/components/loader.tsx",
+  "apps/web/src/components/mode-toggle.tsx",
+  "apps/web/src/components/theme-provider.tsx",
+  "apps/web/src/components/ui/button.tsx",
+  "apps/web/src/components/ui/card.tsx",
+  "apps/web/src/components/ui/checkbox.tsx",
+  "apps/web/src/components/ui/dropdown-menu.tsx",
+  "apps/web/src/components/ui/input.tsx",
+  "apps/web/src/components/ui/label.tsx",
+  "apps/web/src/components/ui/skeleton.tsx",
+  "apps/web/src/components/ui/sonner.tsx",
+  "apps/web/src/index.css",
+  "apps/web/src/lib/utils.ts",
+  "apps/web/src/main.tsx",
+  "apps/web/src/routes/__root.tsx",
+  "apps/web/src/routes/index.tsx",
+  "apps/web/src/utils/trpc.ts",
+  "apps/web/tsconfig.json",
+  "apps/web/vite.config.ts",
+  "bunfig.toml",
+  "package.json",
+  "packages/api/package.json",
+  "packages/api/src/context.ts",
+  "packages/api/src/index.ts",
+  "packages/api/src/routers/index.ts",
+  "packages/api/tsconfig.json",
+  "packages/config/package.json",
+  "packages/config/tsconfig.base.json",
+  "packages/db/drizzle.config.ts",
+  "packages/db/package.json",
+  "packages/db/src/index.ts",
+  "packages/db/src/schema/example.ts",
+  "packages/db/src/schema/index.ts",
+  "packages/db/tsconfig.json",
+  "packages/env/package.json",
+  "packages/env/src/native.ts",
+  "packages/env/src/server.ts",
+  "packages/env/src/web.ts",
+  "packages/env/tsconfig.json",
+  "tsconfig.json",
+]
+`;
+
 exports[`Template Snapshots File Structure Snapshots file structure: ai-cli-root-tooling 1`] = `
 [
   ".env",
@@ -11456,6 +11513,785 @@ export const db = drizzle({ client, schema });
       "content": 
 "{
   "extends": "@snapshot-algolia-search-hono/config/tsconfig.base.json",
+}
+"
+,
+      "path": "tsconfig.json",
+    },
+  ],
+}
+`;
+
+exports[`Template Snapshots Key File Content Snapshots key files: opensearch-search-hono 1`] = `
+{
+  "fileCount": 57,
+  "files": [
+    {
+      "content": "[exists]",
+      "path": "apps/server/.env",
+    },
+    {
+      "content": 
+"{
+  "name": "server",
+  "main": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsdown",
+    "check-types": "tsc -b",
+    "compile": "bun build --compile --minify --sourcemap --bytecode ./src/index.ts --outfile server",
+    "dev": "bun run --hot src/index.ts",
+    "start": "bun run dist/index.js"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-opensearch-search-hono/env": "workspace:*",
+    "@snapshot-opensearch-search-hono/api": "workspace:*",
+    "@snapshot-opensearch-search-hono/db": "workspace:*",
+    "hono": "catalog:",
+    "@trpc/server": "catalog:",
+    "@hono/trpc-server": "^0.4.2",
+    "@opensearch-project/opensearch": "^3.6.0"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "tsdown": "^0.22.2",
+    "@snapshot-opensearch-search-hono/config": "workspace:*",
+    "@types/bun": "catalog:"
+  }
+}
+"
+,
+      "path": "apps/server/package.json",
+    },
+    {
+      "content": 
+"import { env } from "@snapshot-opensearch-search-hono/env/server";
+import { trpcServer } from "@hono/trpc-server";
+import { createContext } from "@snapshot-opensearch-search-hono/api/context";
+import { appRouter } from "@snapshot-opensearch-search-hono/api/routers/index";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+
+const app = new Hono();
+
+app.use(logger());
+app.use(
+	"/*",
+	cors({
+		origin: env.CORS_ORIGIN,
+		allowMethods: ["GET", "POST", "OPTIONS"],
+	})
+);
+
+
+
+app.use(
+	"/trpc/*",
+	trpcServer({
+		router: appRouter,
+		createContext: (_opts, context) => {
+			return createContext({ context });
+		},
+	})
+);
+
+
+
+app.get("/", (c) => {
+	return c.text("OK");
+});
+
+export default app;
+"
+,
+      "path": "apps/server/src/index.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/server/src/lib/search.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-opensearch-search-hono/config/tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+		"outDir": "dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  }
+}
+"
+,
+      "path": "apps/server/tsconfig.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/server/tsdown.config.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/.env",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/index.html",
+    },
+    {
+      "content": 
+"{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite",
+    "check-types": "tsr generate && tsc --noEmit"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.5.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "next-themes": "^0.4.6",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.6.0",
+    "@tailwindcss/vite": "^4.3.1",
+    "tw-animate-css": "^1.4.0",
+    "@tanstack/react-router": "^1.170.15",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-opensearch-search-hono/env": "workspace:*",
+    "@snapshot-opensearch-search-hono/api": "workspace:*",
+    "@libsql/client": "catalog:",
+    "libsql": "catalog:",
+    "@trpc/tanstack-react-query": "^11.17.0",
+    "@trpc/client": "catalog:",
+    "@trpc/server": "catalog:",
+    "@tanstack/react-query": "^5.101.0",
+    "lucide-react": "^1.18.0"
+  },
+  "devDependencies": {
+    "@tanstack/react-router-devtools": "^1.167.0",
+    "@tanstack/router-cli": "^1.167.17",
+    "@tanstack/router-plugin": "^1.168.18",
+    "@types/node": "^25.9.3",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "postcss": "^8.5.15",
+    "tailwindcss": "^4.3.1",
+    "vite": "^8.0.16",
+    "typescript": "catalog:",
+    "@snapshot-opensearch-search-hono/config": "workspace:*",
+    "@tanstack/react-query-devtools": "^5.101.0"
+  }
+}
+"
+,
+      "path": "apps/web/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/header.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/loader.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/mode-toggle.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/theme-provider.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/button.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/card.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/checkbox.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/dropdown-menu.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/input.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/label.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/skeleton.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/sonner.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/index.css",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/lib/utils.ts",
+    },
+    {
+      "content": 
+"import { RouterProvider, createRouter } from "@tanstack/react-router";
+import ReactDOM from "react-dom/client";
+import Loader from "./components/loader";
+import { routeTree } from "./routeTree.gen";
+
+  import { QueryClientProvider } from "@tanstack/react-query";
+  import { queryClient, trpc } from "./utils/trpc";
+
+const router = createRouter({
+  routeTree,
+  defaultPreload: "intent",
+  defaultPendingComponent: () => <Loader />,
+  context: { trpc, queryClient },
+  Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  },
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+const rootElement = document.getElementById("app");
+
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+
+if (!rootElement.innerHTML) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<RouterProvider router={router} />);
+}
+"
+,
+      "path": "apps/web/src/main.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/routes/__root.tsx",
+    },
+    {
+      "content": 
+"import { createFileRoute } from "@tanstack/react-router";
+import { trpc } from "@/utils/trpc";
+import { useQuery } from "@tanstack/react-query";
+
+export const Route = createFileRoute("/")({
+  component: HomeComponent,
+});
+
+const TITLE_TEXT = \`
+ ██████╗ ███████╗████████╗████████╗███████╗██████╗
+ ██╔══██╗██╔════╝╚══██╔══╝╚══██╔══╝██╔════╝██╔══██╗
+ ██████╔╝█████╗     ██║      ██║   █████╗  ██████╔╝
+ ██╔══██╗██╔══╝     ██║      ██║   ██╔══╝  ██╔══██╗
+ ██████╔╝███████╗   ██║      ██║   ███████╗██║  ██║
+ ╚═════╝ ╚══════╝   ╚═╝      ╚═╝   ╚══════╝╚═╝  ╚═╝
+
+ ████████╗    ███████╗████████╗ █████╗  ██████╗██╗  ██╗
+ ╚══██╔══╝    ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝
+    ██║       ███████╗   ██║   ███████║██║     █████╔╝
+    ██║       ╚════██║   ██║   ██╔══██║██║     ██╔═██╗
+    ██║       ███████║   ██║   ██║  ██║╚██████╗██║  ██╗
+    ╚═╝       ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝
+ \`;
+
+function HomeComponent() {
+  const healthCheck = useQuery(trpc.healthCheck.queryOptions());
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-2">
+      <pre className="overflow-x-auto font-mono text-sm">{TITLE_TEXT}</pre>
+      <div className="grid gap-6">
+        <section className="rounded-lg border p-4">
+          <h2 className="mb-2 font-medium">API Status</h2>
+            <div className="flex items-center gap-2">
+              <div
+                className={\`h-2 w-2 rounded-full \${healthCheck.data ? "bg-green-500" : "bg-red-500"}\`}
+              />
+              <span className="text-sm text-muted-foreground">
+                {healthCheck.isLoading
+                  ? "Checking..."
+                  : healthCheck.data
+                    ? "Connected"
+                    : "Disconnected"}
+              </span>
+            </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+"
+,
+      "path": "apps/web/src/routes/index.tsx",
+    },
+    {
+      "content": 
+"import type { AppRouter } from "@snapshot-opensearch-search-hono/api/routers/index";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
+import { toast } from "sonner";
+import { env } from "@snapshot-opensearch-search-hono/env/web";
+
+export const queryClient = new QueryClient({
+	queryCache: new QueryCache({
+		onError: (error, query) => {
+			toast.error(error.message, {
+				action: {
+					label: "retry",
+					onClick: query.invalidate,
+				},
+			});
+		},
+	}),
+});
+
+export const trpcClient = createTRPCClient<AppRouter>({
+	links: [
+		httpBatchLink({
+			url: \`\${env.VITE_SERVER_URL}/trpc\`,
+		}),
+	],
+});
+
+export const trpc = createTRPCOptionsProxy<AppRouter>({
+	client: trpcClient,
+	queryClient,
+});
+"
+,
+      "path": "apps/web/src/utils/trpc.ts",
+    },
+    {
+      "content": 
+"{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "rootDirs": ["."],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+"
+,
+      "path": "apps/web/tsconfig.json",
+    },
+    {
+      "content": 
+"import tailwindcss from "@tailwindcss/vite";
+import { tanstackRouter } from "@tanstack/router-plugin/vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    tailwindcss(),
+    tanstackRouter({}),
+    react(),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 3001,
+  },
+});
+"
+,
+      "path": "apps/web/vite.config.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "bunfig.toml",
+    },
+    {
+      "content": "[exists]",
+      "path": "CLAUDE.md",
+    },
+    {
+      "content": 
+"{
+  "name": "snapshot-opensearch-search-hono",
+  "private": true,
+  "type": "module",
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "packages/*"
+    ],
+    "catalog": {
+      "dotenv": "^17.4.2",
+      "zod": "^4.4.3",
+      "typescript": "^6.0.3",
+      "@types/bun": "^1.3.14",
+      "hono": "^4.12.25",
+      "@trpc/server": "^11.17.0",
+      "@libsql/client": "^0.17.3",
+      "libsql": "^0.5.29",
+      "@trpc/client": "^11.17.0"
+    }
+  },
+  "scripts": {
+    "dev": "bun run --filter '*' dev",
+    "build": "bun run --filter '*' build",
+    "check-types": "bun run --if-present --filter '*' check-types",
+    "dev:web": "bun run --filter web dev",
+    "dev:server": "bun run --filter server dev",
+    "db:push": "bun run --filter @snapshot-opensearch-search-hono/db db:push",
+    "db:studio": "bun run --filter @snapshot-opensearch-search-hono/db db:studio",
+    "db:generate": "bun run --filter @snapshot-opensearch-search-hono/db db:generate",
+    "db:migrate": "bun run --filter @snapshot-opensearch-search-hono/db db:migrate",
+    "db:local": "bun run --filter @snapshot-opensearch-search-hono/db db:local"
+  },
+  "packageManager": "bun@1.3.5",
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-opensearch-search-hono/env": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@types/bun": "catalog:",
+    "@snapshot-opensearch-search-hono/config": "workspace:*"
+  }
+}
+"
+,
+      "path": "package.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-opensearch-search-hono/api",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "type": "module",
+  "scripts": {},
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@snapshot-opensearch-search-hono/config": "workspace:*"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-opensearch-search-hono/env": "workspace:*",
+    "@snapshot-opensearch-search-hono/db": "workspace:*",
+    "@trpc/server": "catalog:",
+    "@trpc/client": "catalog:",
+    "hono": "catalog:"
+  }
+}
+"
+,
+      "path": "packages/api/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/api/src/context.ts",
+    },
+    {
+      "content": 
+"import { initTRPC } from "@trpc/server";
+import type { Context } from "./context";
+
+export const t = initTRPC.context<Context>().create();
+
+export const router = t.router;
+
+export const publicProcedure = t.procedure;
+
+"
+,
+      "path": "packages/api/src/index.ts",
+    },
+    {
+      "content": 
+"import {
+  publicProcedure,
+  router,
+} from "../index";
+
+export const appRouter = router({
+  healthCheck: publicProcedure.query(() => {
+    return "OK";
+  }),
+});
+export type AppRouter = typeof appRouter;
+"
+,
+      "path": "packages/api/src/routers/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-opensearch-search-hono/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/api/tsconfig.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-opensearch-search-hono/config",
+  "version": "0.0.0",
+  "private": true
+}
+"
+,
+      "path": "packages/config/package.json",
+    },
+    {
+      "content": 
+"{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": [
+        "bun"
+
+    ]
+  }
+}
+"
+,
+      "path": "packages/config/tsconfig.base.json",
+    },
+    {
+      "content": 
+"import { defineConfig } from "drizzle-kit";
+import dotenv from "dotenv";
+
+dotenv.config({
+    path: "../../apps/server/.env",
+});
+
+export default defineConfig({
+  schema: "./src/schema",
+  out: "./src/migrations",
+  dialect: "turso",
+  dbCredentials: {
+    url: process.env.DATABASE_URL || "",
+  },
+});
+"
+,
+      "path": "packages/db/drizzle.config.ts",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-opensearch-search-hono/db",
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "scripts": {
+    "db:local": "turso dev --db-file local.db",
+    "db:push": "drizzle-kit push",
+    "db:generate": "drizzle-kit generate",
+    "db:studio": "drizzle-kit studio",
+    "db:migrate": "drizzle-kit migrate"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@snapshot-opensearch-search-hono/config": "workspace:*",
+    "drizzle-kit": "^0.31.10"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-opensearch-search-hono/env": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "@libsql/client": "catalog:",
+    "libsql": "catalog:"
+  }
+}
+"
+,
+      "path": "packages/db/package.json",
+    },
+    {
+      "content": 
+"import { env } from "@snapshot-opensearch-search-hono/env/server";
+import * as schema from "./schema/index";
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+	url: env.DATABASE_URL,
+});
+
+export const db = drizzle({ client, schema });
+
+"
+,
+      "path": "packages/db/src/index.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/db/src/schema/example.ts",
+    },
+    {
+      "content": 
+"export * from "./example";
+"
+,
+      "path": "packages/db/src/schema/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-opensearch-search-hono/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/db/tsconfig.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-opensearch-search-hono/env",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./server": "./src/server.ts",
+    "./web": "./src/web.ts"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@t3-oss/env-core": "^0.13.11"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@types/bun": "catalog:",
+    "@snapshot-opensearch-search-hono/config": "workspace:*"
+  }
+}
+"
+,
+      "path": "packages/env/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/native.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/server.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/web.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-opensearch-search-hono/config/tsconfig.base.json",
+}
+"
+,
+      "path": "packages/env/tsconfig.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "README.md",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-opensearch-search-hono/config/tsconfig.base.json",
 }
 "
 ,

--- a/apps/cli/test/cross-ecosystem-search.test.ts
+++ b/apps/cli/test/cross-ecosystem-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { createVirtual } from "../src/index";
+import { validateConfigForProgrammaticUse } from "../src/utils/config-validation";
 import {
   expectError,
   runTRPCTest,
@@ -110,6 +111,16 @@ describe("Cross-ecosystem search services", () => {
       result,
       "Meilisearch search for Java requires Maven or Gradle to manage the SDK dependency",
     );
+  });
+
+  it("allows TypeScript search providers when ecosystem defaults to TypeScript", () => {
+    expect(() =>
+      validateConfigForProgrammaticUse({
+        backend: "hono",
+        frontend: ["tanstack-router"],
+        search: "opensearch",
+      }),
+    ).not.toThrow();
   });
 
   it("rejects non-TypeScript search providers that are not implemented cross-ecosystem", async () => {

--- a/apps/cli/test/search.test.ts
+++ b/apps/cli/test/search.test.ts
@@ -647,6 +647,48 @@ describe("Search Options", () => {
     });
   });
 
+  describe("OpenSearch with different backends", () => {
+    test("opensearch with Hono backend", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "opensearch-hono",
+          frontend: ["tanstack-router"],
+          backend: "hono",
+          search: "opensearch",
+        }),
+      );
+      expectSuccess(result);
+    });
+
+    test("opensearch with Express backend", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "opensearch-express",
+          frontend: ["tanstack-router"],
+          backend: "express",
+          runtime: "node",
+          search: "opensearch",
+        }),
+      );
+      expectSuccess(result);
+    });
+  });
+
+  describe("OpenSearch with fullstack frameworks", () => {
+    test("opensearch with Next.js fullstack", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "opensearch-nextjs",
+          frontend: ["next"],
+          backend: "self",
+          runtime: "none",
+          search: "opensearch",
+        }),
+      );
+      expectSuccess(result);
+    });
+  });
+
   describe("Algolia with different backends", () => {
     test("algolia with Hono backend", async () => {
       const result = await runTRPCTest(
@@ -772,8 +814,38 @@ describe("Search Options", () => {
       expect(env).toContain("ELASTICSEARCH_CLOUD_ID=");
     });
 
+    test("server backends emit search helper, dependency, and env for opensearch", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "opensearch-server-files",
+          frontend: ["tanstack-router"],
+          backend: "hono",
+          search: "opensearch",
+        }),
+      );
+      expectSuccess(result);
+
+      const projectDir = result.projectDir!;
+      const helper = await readFile(join(projectDir, "apps/server/src/lib/search.ts"), "utf-8");
+      const pkg = await readFile(join(projectDir, "apps/server/package.json"), "utf-8");
+      const env = await readFile(join(projectDir, "apps/server/.env"), "utf-8");
+
+      expect(helper).toContain('from "@opensearch-project/opensearch"');
+      expect(helper).toContain("response.body");
+      expect(pkg).toContain('"@opensearch-project/opensearch"');
+      expect(env).toContain("OPENSEARCH_NODE=http://localhost:9200");
+      expect(env).toContain("OPENSEARCH_USERNAME=");
+      expect(env).toContain("OPENSEARCH_PASSWORD=");
+    });
+
     test("self backends emit search helper, dependency, and env for all search engines", async () => {
-      const searches = ["meilisearch", "typesense", "elasticsearch", "algolia"] as const;
+      const searches = [
+        "meilisearch",
+        "typesense",
+        "elasticsearch",
+        "opensearch",
+        "algolia",
+      ] as const;
 
       for (const search of searches) {
         const result = await runTRPCTest(
@@ -803,6 +875,9 @@ describe("Search Options", () => {
           expect(pkg).toContain('"algoliasearch"');
           expect(env).toContain("ALGOLIA_APP_ID=");
           expect(env).toContain("ALGOLIA_API_KEY=");
+        } else if (search === "opensearch") {
+          expect(pkg).toContain('"@opensearch-project/opensearch"');
+          expect(env).toContain("OPENSEARCH_NODE=http://localhost:9200");
         } else {
           expect(pkg).toContain('"@elastic/elasticsearch"');
           expect(env).toContain("ELASTICSEARCH_NODE=http://localhost:9200");

--- a/apps/cli/test/template-snapshots.test.ts
+++ b/apps/cli/test/template-snapshots.test.ts
@@ -182,6 +182,18 @@ const SNAPSHOT_CONFIGS: Array<{
       search: "algolia",
     },
   },
+  {
+    name: "opensearch-search-hono",
+    config: {
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      api: "trpc",
+      database: "sqlite",
+      orm: "drizzle",
+      auth: "none",
+      search: "opensearch",
+    },
+  },
 
   // === AI VARIATIONS ===
   {

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -2707,6 +2707,14 @@ export const TECH_OPTIONS: Record<
       default: false,
     },
     {
+      id: "opensearch",
+      name: "OpenSearch",
+      description: "Open-source search and analytics suite for self-managed or managed clusters",
+      icon: "https://cdn.simpleicons.org/opensearch/005EB8",
+      color: "from-blue-500 to-sky-700",
+      default: false,
+    },
+    {
       id: "algolia",
       name: "Algolia",
       description: "Hosted search API with instant results, typo tolerance, and analytics",

--- a/apps/web/src/lib/tech-icons.ts
+++ b/apps/web/src/lib/tech-icons.ts
@@ -386,6 +386,7 @@ export const ICON_REGISTRY: Record<string, IconConfig> = {
   meilisearch: { type: "si", slug: "meilisearch", hex: "FF5CAA" },
   typesense: { type: "local", src: "/icon/typesense.png" },
   elasticsearch: { type: "si", slug: "elasticsearch", hex: "005571" },
+  opensearch: { type: "si", slug: "opensearch", hex: "005EB8" },
   algolia: { type: "si", slug: "algolia", hex: "003DFF" },
 
   // ─── File Storage ──────────────────────────────────────────────────────────

--- a/apps/web/src/lib/tech-resource-links.ts
+++ b/apps/web/src/lib/tech-resource-links.ts
@@ -938,6 +938,10 @@ const BASE_LINKS: LinkMap = {
     docsUrl: "https://www.elastic.co/docs",
     githubUrl: "https://github.com/elastic/elasticsearch",
   },
+  opensearch: {
+    docsUrl: "https://opensearch.org/docs/latest/",
+    githubUrl: "https://github.com/opensearch-project/OpenSearch",
+  },
   algolia: {
     docsUrl: "https://www.algolia.com/doc/",
     githubUrl: "https://github.com/algolia/algoliasearch-client-javascript",

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -1586,6 +1586,24 @@ function buildServerVars(
         "Basic auth password. Used only when ELASTICSEARCH_API_KEY is empty and both username/password are provided",
     },
     {
+      key: "OPENSEARCH_NODE",
+      value: "http://localhost:9200",
+      condition: search === "opensearch",
+      comment: "OpenSearch node URL",
+    },
+    {
+      key: "OPENSEARCH_USERNAME",
+      value: "",
+      condition: search === "opensearch",
+      comment: "OpenSearch username (optional for local development)",
+    },
+    {
+      key: "OPENSEARCH_PASSWORD",
+      value: "",
+      condition: search === "opensearch",
+      comment: "OpenSearch password (optional for local development)",
+    },
+    {
       key: "ALGOLIA_APP_ID",
       value: "",
       condition: search === "algolia",

--- a/packages/template-generator/src/processors/search-deps.ts
+++ b/packages/template-generator/src/processors/search-deps.ts
@@ -55,6 +55,9 @@ function getSearchDeps(search: ProjectConfig["search"]): AvailableDependencies[]
     case "elasticsearch":
       deps.push("@elastic/elasticsearch");
       break;
+    case "opensearch":
+      deps.push("@opensearch-project/opensearch");
+      break;
     case "algolia":
       deps.push("algoliasearch");
       break;

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -750,6 +750,9 @@ export const dependencyVersionMap = {
   // Search - Elasticsearch
   "@elastic/elasticsearch": "^9.4.2",
 
+  // Search - OpenSearch
+  "@opensearch-project/opensearch": "^3.6.0",
+
   // Search - Algolia
   algoliasearch: "^5.54.0",
 

--- a/packages/template-generator/templates/search/opensearch/server/base/src/lib/search.ts.hbs
+++ b/packages/template-generator/templates/search/opensearch/server/base/src/lib/search.ts.hbs
@@ -1,0 +1,300 @@
+import {
+  Client,
+  type API,
+} from "@opensearch-project/opensearch";
+
+/**
+ * Resolve OpenSearch connection options from environment variables.
+ * Supports basic auth when OPENSEARCH_USERNAME is provided.
+ */
+function resolveConnection(): ConstructorParameters<typeof Client>[0] {
+  const username = process.env.OPENSEARCH_USERNAME;
+  const password = process.env.OPENSEARCH_PASSWORD;
+
+  return {
+    node: process.env.OPENSEARCH_NODE || "http://localhost:9200",
+    auth:
+      username && username.length > 0
+        ? {
+            username,
+            password: password || "",
+          }
+        : undefined,
+  };
+}
+
+/**
+ * OpenSearch client for distributed full-text search and analytics.
+ */
+export const searchClient = new Client(resolveConnection());
+
+export type SearchHit<T extends Record<string, unknown>> = {
+  id: string;
+  score: number | null;
+  source: T;
+};
+
+export type NormalizedSearchResponse<T extends Record<string, unknown>> = {
+  hits: SearchHit<T>[];
+  total: number;
+  took: number;
+};
+
+type SearchResponseBody<T extends Record<string, unknown>> = {
+  hits: {
+    hits: Array<{
+      _id?: string;
+      _score?: number | null;
+      _source?: T;
+    }>;
+    total?: number | { value?: number };
+  };
+  took?: number;
+};
+
+/**
+ * Search documents across one or more indices with the OpenSearch query DSL.
+ */
+export async function search<T extends Record<string, unknown>>(
+  params: API.Search_Request,
+): Promise<NormalizedSearchResponse<T>> {
+  const response = await searchClient.search(params);
+  const body = response.body as SearchResponseBody<T>;
+  const total =
+    typeof body.hits.total === "number" ? body.hits.total : body.hits.total?.value ?? 0;
+
+  return {
+    hits: body.hits.hits
+      .filter((hit) => hit._source)
+      .map((hit) => ({
+        id: hit._id ?? "",
+        score: hit._score ?? null,
+        source: hit._source as T,
+      })),
+    total,
+    took: body.took ?? 0,
+  };
+}
+
+/**
+ * Index multiple documents in bulk. Optionally provide an `id` field on each document to set the document ID.
+ */
+export async function indexDocuments<T extends Record<string, unknown>>(
+  index: string,
+  documents: Array<T & { id?: string | number }>,
+  options?: { refresh?: boolean | "wait_for" },
+): Promise<{ indexed: number; errors: boolean }> {
+  if (documents.length === 0) {
+    return { indexed: 0, errors: false };
+  }
+
+  const body: Record<string, unknown>[] = [];
+  for (const document of documents) {
+    const { id, ...source } = document;
+    body.push({ index: { _index: index, ...(id !== undefined ? { _id: String(id) } : {}) } });
+    body.push(source);
+  }
+
+  const response = await searchClient.bulk({
+    body,
+    refresh: options?.refresh,
+  });
+  const responseBody = response.body as { errors?: boolean };
+
+  return {
+    indexed: documents.length,
+    errors: Boolean(responseBody.errors),
+  };
+}
+
+/**
+ * Execute arbitrary bulk operations in a single request.
+ */
+export async function bulk(
+  operations: Record<string, unknown>[],
+  options?: { refresh?: boolean | "wait_for" },
+): Promise<{ errors: boolean; items?: unknown[] }> {
+  const response = await searchClient.bulk({
+    body: operations,
+    refresh: options?.refresh,
+  });
+  const body = response.body as { errors?: boolean; items?: unknown[] };
+
+  return {
+    errors: Boolean(body.errors),
+    items: body.items,
+  };
+}
+
+/**
+ * Update a single document by ID (partial update). Supports upsert via `docAsUpsert`.
+ */
+export async function updateDocument<T extends Record<string, unknown>>(
+  index: string,
+  id: string | number,
+  document: Partial<T>,
+  options?: { refresh?: boolean | "wait_for"; docAsUpsert?: boolean },
+): Promise<{ id: string; result: string }> {
+  const response = await searchClient.update({
+    index,
+    id: String(id),
+    body: {
+      doc: document,
+      doc_as_upsert: options?.docAsUpsert,
+    },
+    refresh: options?.refresh,
+  });
+  const body = response.body as { _id?: string; result?: string };
+
+  return {
+    id: body._id ?? String(id),
+    result: body.result ?? "",
+  };
+}
+
+/**
+ * Delete a single document by ID.
+ */
+export async function deleteDocument(
+  index: string,
+  id: string | number,
+  options?: { refresh?: boolean | "wait_for" },
+): Promise<{ id: string; result: string }> {
+  const response = await searchClient.delete({
+    index,
+    id: String(id),
+    refresh: options?.refresh,
+  });
+  const body = response.body as { _id?: string; result?: string };
+
+  return {
+    id: body._id ?? String(id),
+    result: body.result ?? "",
+  };
+}
+
+/**
+ * Delete documents matching a query.
+ */
+export async function deleteByQuery(
+  index: string,
+  query: Record<string, unknown>,
+  options?: { refresh?: boolean; conflicts?: "abort" | "proceed" },
+): Promise<{ deleted: number }> {
+  const response = await searchClient.deleteByQuery({
+    index,
+    body: { query },
+    refresh: options?.refresh,
+    conflicts: options?.conflicts,
+  });
+  const body = response.body as { deleted?: number };
+
+  return { deleted: body.deleted ?? 0 };
+}
+
+/**
+ * Delete all documents in an index.
+ */
+export async function deleteAllDocuments(
+  index: string,
+  options?: { refresh?: boolean },
+): Promise<{ deleted: number }> {
+  return deleteByQuery(index, { match_all: {} }, { refresh: options?.refresh });
+}
+
+/**
+ * Get a single document by ID. Returns null if not found.
+ */
+export async function getDocument<T extends Record<string, unknown>>(
+  index: string,
+  id: string | number,
+): Promise<T | null> {
+  try {
+    const response = await searchClient.get({
+      index,
+      id: String(id),
+    });
+    const body = response.body as { _source?: T };
+
+    return body._source ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create an index with optional mappings, settings, and aliases.
+ */
+export async function createIndex(
+  index: string,
+  options?: {
+    mappings?: API.Indices_Create_RequestBody["mappings"];
+    settings?: API.Indices_Create_RequestBody["settings"];
+    aliases?: API.Indices_Create_RequestBody["aliases"];
+  },
+): Promise<{ acknowledged: boolean; index: string }> {
+  const response = await searchClient.indices.create({
+    index,
+    body: {
+      mappings: options?.mappings,
+      settings: options?.settings,
+      aliases: options?.aliases,
+    },
+  });
+  const body = response.body as { acknowledged?: boolean };
+
+  return {
+    acknowledged: Boolean(body.acknowledged),
+    index,
+  };
+}
+
+/**
+ * Delete an index.
+ */
+export async function deleteIndex(index: string): Promise<{ acknowledged: boolean }> {
+  const response = await searchClient.indices.delete({ index });
+  const body = response.body as { acknowledged?: boolean };
+
+  return { acknowledged: Boolean(body.acknowledged) };
+}
+
+/**
+ * Check whether an index exists.
+ */
+export async function indexExists(index: string): Promise<boolean> {
+  const response = await searchClient.indices.exists({ index });
+  return Boolean(response.body);
+}
+
+/**
+ * List indices matching an optional glob pattern (defaults to all).
+ */
+export async function listIndices(
+  pattern = "*",
+): Promise<Array<{ index: string; health?: string; status?: string; docsCount?: string }>> {
+  const response = await searchClient.cat.indices({
+    index: pattern,
+    format: "json",
+  });
+  const body = response.body as Array<Record<string, string>>;
+
+  return body.map((entry) => ({
+    index: entry.index ?? "",
+    health: entry.health,
+    status: entry.status,
+    docsCount: entry["docs.count"],
+  }));
+}
+
+/**
+ * Health check for OpenSearch.
+ */
+export async function healthCheck(): Promise<{ status: "available" | "unavailable" }> {
+  try {
+    await searchClient.ping();
+    return { status: "available" };
+  } catch {
+    return { status: "unavailable" };
+  }
+}

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -985,6 +985,7 @@ const EXACT_LABEL_OVERRIDES: Partial<Record<OptionCategory, Partial<Record<strin
     meilisearch: "Meilisearch",
     typesense: "Typesense",
     elasticsearch: "Elasticsearch",
+    opensearch: "OpenSearch",
     algolia: "Algolia",
   },
   fileStorage: {

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -327,9 +327,9 @@ export const I18nSchema = z
   .describe("Internationalization (i18n) library");
 
 export const SearchSchema = z
-  .enum(["meilisearch", "typesense", "elasticsearch", "algolia", "none"])
+  .enum(["meilisearch", "typesense", "elasticsearch", "opensearch", "algolia", "none"])
   .describe(
-    "Search engine solution (meilisearch, typesense, elasticsearch, or algolia for fast search experiences)",
+    "Search engine solution (meilisearch, typesense, elasticsearch, opensearch, or algolia for fast search experiences)",
   );
 
 export const FileStorageSchema = z


### PR DESCRIPTION
## Summary
- add OpenSearch as a TypeScript search provider across schema, CLI prompts, builder metadata, dependencies, env vars, and templates
- add template coverage, snapshots, and a validator regression for default TypeScript search providers

## Verification
- ~/.bun/bin/bun run --filter=@better-fullstack/types build
- ~/.bun/bin/bun run --filter=@better-fullstack/template-generator generate-templates
- ~/.bun/bin/bun run --filter=@better-fullstack/template-generator build
- ~/.bun/bin/bun run --filter=create-better-fullstack build
- ~/.bun/bin/bun test apps/cli/test/template-snapshots.test.ts -u
- ~/.bun/bin/bun test apps/cli/test/template-snapshots.test.ts
- ~/.bun/bin/bun test apps/cli/test/cli-builder-sync.test.ts
- ~/.bun/bin/bun test apps/cli/test/search.test.ts
- ~/.bun/bin/bun test apps/cli/test/cross-ecosystem-search.test.ts
- ~/.bun/bin/bun run --cwd apps/cli check-types
- ~/.bun/bin/bun run --cwd apps/web typecheck
- ~/.bun/bin/bun run --cwd apps/web validate:tech-links
- ~/.bun/bin/bun test apps/cli/test/template-validation.test.ts
- OpenSearch Hono scaffold check: ~/.bun/bin/bun install && ~/.bun/bin/bun run check-types
- pre-commit lint hook