### PR TITLE
Add Keystatic CMS option

### DIFF
--- a/apps/cli/src/prompts/cms.ts
+++ b/apps/cli/src/prompts/cms.ts
@@ -31,6 +31,11 @@ const CMS_PROMPT_OPTIONS = [
     hint: "Open data platform and headless CMS for SQL databases",
   },
   {
+    value: "keystatic" as const,
+    label: "Keystatic",
+    hint: "Git-backed CMS for Markdown, JSON, and YAML content",
+  },
+  {
     value: "none" as const,
     label: "None",
     hint: "Skip headless CMS setup",

--- a/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
+++ b/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
@@ -766,6 +766,65 @@ exports[`Template Snapshots File Structure Snapshots file structure: algolia-sea
 ]
 `;
 
+exports[`Template Snapshots File Structure Snapshots file structure: cms-keystatic-next 1`] = `
+[
+  "CLAUDE.md",
+  "README.md",
+  "apps/web/.env",
+  "apps/web/keystatic.config.ts",
+  "apps/web/next-env.d.ts",
+  "apps/web/next.config.ts",
+  "apps/web/package.json",
+  "apps/web/postcss.config.mjs",
+  "apps/web/src/app/api/keystatic/[...params]/route.ts",
+  "apps/web/src/app/api/trpc/[trpc]/route.ts",
+  "apps/web/src/app/keystatic/[[...params]]/page.tsx",
+  "apps/web/src/app/keystatic/keystatic.ts",
+  "apps/web/src/app/keystatic/layout.tsx",
+  "apps/web/src/app/layout.tsx",
+  "apps/web/src/app/page.tsx",
+  "apps/web/src/components/header.tsx",
+  "apps/web/src/components/loader.tsx",
+  "apps/web/src/components/mode-toggle.tsx",
+  "apps/web/src/components/providers.tsx",
+  "apps/web/src/components/theme-provider.tsx",
+  "apps/web/src/components/ui/button.tsx",
+  "apps/web/src/components/ui/card.tsx",
+  "apps/web/src/components/ui/checkbox.tsx",
+  "apps/web/src/components/ui/dropdown-menu.tsx",
+  "apps/web/src/components/ui/input.tsx",
+  "apps/web/src/components/ui/label.tsx",
+  "apps/web/src/components/ui/skeleton.tsx",
+  "apps/web/src/components/ui/sonner.tsx",
+  "apps/web/src/content/posts/hello-world.mdoc",
+  "apps/web/src/index.css",
+  "apps/web/src/lib/utils.ts",
+  "apps/web/src/utils/trpc.ts",
+  "apps/web/tsconfig.json",
+  "bunfig.toml",
+  "package.json",
+  "packages/api/package.json",
+  "packages/api/src/context.ts",
+  "packages/api/src/index.ts",
+  "packages/api/src/routers/index.ts",
+  "packages/api/tsconfig.json",
+  "packages/config/package.json",
+  "packages/config/tsconfig.base.json",
+  "packages/db/drizzle.config.ts",
+  "packages/db/package.json",
+  "packages/db/src/index.ts",
+  "packages/db/src/schema/example.ts",
+  "packages/db/src/schema/index.ts",
+  "packages/db/tsconfig.json",
+  "packages/env/package.json",
+  "packages/env/src/native.ts",
+  "packages/env/src/server.ts",
+  "packages/env/src/web.ts",
+  "packages/env/tsconfig.json",
+  "tsconfig.json",
+]
+`;
+
 exports[`Template Snapshots File Structure Snapshots file structure: ai-cli-root-tooling 1`] = `
 [
   ".env",
@@ -11456,6 +11515,617 @@ export const db = drizzle({ client, schema });
       "content": 
 "{
   "extends": "@snapshot-algolia-search-hono/config/tsconfig.base.json",
+}
+"
+,
+      "path": "tsconfig.json",
+    },
+  ],
+}
+`;
+
+exports[`Template Snapshots Key File Content Snapshots key files: cms-keystatic-next 1`] = `
+{
+  "fileCount": 59,
+  "files": [
+    {
+      "content": "[exists]",
+      "path": "apps/web/.env",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/keystatic.config.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/next-env.d.ts",
+    },
+    {
+      "content": 
+"import "@snapshot-cms-keystatic-next/env/web";
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+	typedRoutes: true,
+	reactCompiler: true,
+};
+
+export default nextConfig;
+
+"
+,
+      "path": "apps/web/next.config.ts",
+    },
+    {
+      "content": 
+"{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.5.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "next-themes": "^0.4.6",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.6.0",
+    "tw-animate-css": "^1.4.0",
+    "next": "catalog:",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-cms-keystatic-next/env": "workspace:*",
+    "@snapshot-cms-keystatic-next/api": "workspace:*",
+    "@libsql/client": "catalog:",
+    "libsql": "catalog:",
+    "@trpc/server": "catalog:",
+    "@trpc/client": "catalog:",
+    "@trpc/tanstack-react-query": "^11.17.0",
+    "@tanstack/react-query": "^5.101.0",
+    "lucide-react": "^1.18.0",
+    "@keystatic/core": "^0.5.50",
+    "@keystatic/next": "^5.0.4",
+    "@markdoc/markdoc": "^0.5.7"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.3.1",
+    "tailwindcss": "^4.3.1",
+    "@types/node": "^25.9.3",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5",
+    "@snapshot-cms-keystatic-next/config": "workspace:*",
+    "@tanstack/react-query-devtools": "^5.101.0"
+  }
+}
+"
+,
+      "path": "apps/web/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/postcss.config.mjs",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/app/api/keystatic/[...params]/route.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/app/api/trpc/[trpc]/route.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/app/keystatic/[[...params]]/page.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/app/keystatic/keystatic.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/app/keystatic/layout.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/app/layout.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/app/page.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/header.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/loader.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/mode-toggle.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/providers.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/theme-provider.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/button.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/card.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/checkbox.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/dropdown-menu.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/input.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/label.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/skeleton.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/sonner.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/content/posts/hello-world.mdoc",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/index.css",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/lib/utils.ts",
+    },
+    {
+      "content": 
+"import { QueryCache, QueryClient } from '@tanstack/react-query';
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
+import type { AppRouter } from "@snapshot-cms-keystatic-next/api/routers/index";
+import { toast } from 'sonner';
+
+export const queryClient = new QueryClient({
+	queryCache: new QueryCache({
+		onError: (error, query) => {
+			toast.error(error.message, {
+				action: {
+					label: "retry",
+					onClick: query.invalidate,
+				},
+			});
+		},
+	}),
+});
+
+const trpcClient = createTRPCClient<AppRouter>({
+	links: [
+		httpBatchLink({
+			url: "/api/trpc",
+		}),
+	],
+})
+
+export const trpc = createTRPCOptionsProxy<AppRouter>({
+	client: trpcClient,
+	queryClient,
+});
+
+"
+,
+      "path": "apps/web/src/utils/trpc.ts",
+    },
+    {
+      "content": 
+"{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "./next-env.d.ts",
+    "./**/*.ts",
+    "./**/*.tsx",
+    "./.next/types/**/*.ts"
+  ],
+  "exclude": [
+    "./node_modules"
+  ]
+}
+"
+,
+      "path": "apps/web/tsconfig.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "bunfig.toml",
+    },
+    {
+      "content": "[exists]",
+      "path": "CLAUDE.md",
+    },
+    {
+      "content": 
+"{
+  "name": "snapshot-cms-keystatic-next",
+  "private": true,
+  "type": "module",
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "packages/*"
+    ],
+    "catalog": {
+      "dotenv": "^17.4.2",
+      "zod": "^4.4.3",
+      "@types/bun": "^1.3.14",
+      "next": "^16.2.9",
+      "@libsql/client": "^0.17.3",
+      "libsql": "^0.5.29",
+      "@trpc/server": "^11.17.0",
+      "@trpc/client": "^11.17.0"
+    }
+  },
+  "scripts": {
+    "dev": "bun run --filter '*' dev",
+    "build": "bun run --filter '*' build",
+    "check-types": "bun run --if-present --filter '*' check-types",
+    "dev:web": "bun run --filter web dev",
+    "db:push": "bun run --filter @snapshot-cms-keystatic-next/db db:push",
+    "db:studio": "bun run --filter @snapshot-cms-keystatic-next/db db:studio",
+    "db:generate": "bun run --filter @snapshot-cms-keystatic-next/db db:generate",
+    "db:migrate": "bun run --filter @snapshot-cms-keystatic-next/db db:migrate",
+    "db:local": "bun run --filter @snapshot-cms-keystatic-next/db db:local"
+  },
+  "packageManager": "bun@1.3.5",
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-cms-keystatic-next/env": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "@types/bun": "catalog:",
+    "@snapshot-cms-keystatic-next/config": "workspace:*"
+  }
+}
+"
+,
+      "path": "package.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-cms-keystatic-next/api",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "type": "module",
+  "scripts": {},
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "@snapshot-cms-keystatic-next/config": "workspace:*"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-cms-keystatic-next/env": "workspace:*",
+    "@snapshot-cms-keystatic-next/db": "workspace:*",
+    "@trpc/server": "catalog:",
+    "@trpc/client": "catalog:",
+    "next": "catalog:"
+  }
+}
+"
+,
+      "path": "packages/api/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/api/src/context.ts",
+    },
+    {
+      "content": 
+"import { initTRPC } from "@trpc/server";
+import type { Context } from "./context";
+
+export const t = initTRPC.context<Context>().create();
+
+export const router = t.router;
+
+export const publicProcedure = t.procedure;
+
+"
+,
+      "path": "packages/api/src/index.ts",
+    },
+    {
+      "content": 
+"import {
+  publicProcedure,
+  router,
+} from "../index";
+
+export const appRouter = router({
+  healthCheck: publicProcedure.query(() => {
+    return "OK";
+  }),
+});
+export type AppRouter = typeof appRouter;
+"
+,
+      "path": "packages/api/src/routers/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-cms-keystatic-next/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/api/tsconfig.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-cms-keystatic-next/config",
+  "version": "0.0.0",
+  "private": true
+}
+"
+,
+      "path": "packages/config/package.json",
+    },
+    {
+      "content": 
+"{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": [
+        "bun"
+
+    ]
+  }
+}
+"
+,
+      "path": "packages/config/tsconfig.base.json",
+    },
+    {
+      "content": 
+"import { defineConfig } from "drizzle-kit";
+import dotenv from "dotenv";
+
+dotenv.config({
+    path: "../../apps/web/.env",
+});
+
+export default defineConfig({
+  schema: "./src/schema",
+  out: "./src/migrations",
+  dialect: "turso",
+  dbCredentials: {
+    url: process.env.DATABASE_URL || "",
+  },
+});
+"
+,
+      "path": "packages/db/drizzle.config.ts",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-cms-keystatic-next/db",
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "scripts": {
+    "db:local": "turso dev --db-file local.db",
+    "db:push": "drizzle-kit push",
+    "db:generate": "drizzle-kit generate",
+    "db:studio": "drizzle-kit studio",
+    "db:migrate": "drizzle-kit migrate"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "@snapshot-cms-keystatic-next/config": "workspace:*",
+    "drizzle-kit": "^0.31.10"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-cms-keystatic-next/env": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "@libsql/client": "catalog:",
+    "libsql": "catalog:"
+  }
+}
+"
+,
+      "path": "packages/db/package.json",
+    },
+    {
+      "content": 
+"import { env } from "@snapshot-cms-keystatic-next/env/server";
+import * as schema from "./schema/index";
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+	url: env.DATABASE_URL,
+});
+
+export const db = drizzle({ client, schema });
+
+"
+,
+      "path": "packages/db/src/index.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/db/src/schema/example.ts",
+    },
+    {
+      "content": 
+"export * from "./example";
+"
+,
+      "path": "packages/db/src/schema/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-cms-keystatic-next/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/db/tsconfig.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-cms-keystatic-next/env",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./server": "./src/server.ts",
+    "./web": "./src/web.ts"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@t3-oss/env-nextjs": "^0.13.11",
+    "@t3-oss/env-core": "^0.13.11"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "@types/bun": "catalog:",
+    "@snapshot-cms-keystatic-next/config": "workspace:*"
+  }
+}
+"
+,
+      "path": "packages/env/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/native.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/server.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/web.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-cms-keystatic-next/config/tsconfig.base.json",
+}
+"
+,
+      "path": "packages/env/tsconfig.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "README.md",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-cms-keystatic-next/config/tsconfig.base.json",
 }
 "
 ,

--- a/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
+++ b/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
@@ -414,10 +414,14 @@ exports[`Template Snapshots File Structure Snapshots file structure: hono-apollo
   "apps/web/src/routes/dashboard.tsx",
   "apps/web/src/routes/index.tsx",
   "apps/web/src/routes/login.tsx",
+  "apps/web/src/utils/graphql.ts",
   "apps/web/tsconfig.json",
   "apps/web/vite.config.ts",
   "bunfig.toml",
   "package.json",
+  "packages/api/package.json",
+  "packages/api/src/index.ts",
+  "packages/api/tsconfig.json",
   "packages/auth/package.json",
   "packages/auth/src/index.ts",
   "packages/auth/tsconfig.json",
@@ -832,6 +836,7 @@ exports[`Template Snapshots File Structure Snapshots file structure: opensearch-
   "apps/server/.env",
   "apps/server/package.json",
   "apps/server/src/index.ts",
+  "apps/server/src/lib/search.ts",
   "apps/server/tsconfig.json",
   "apps/server/tsdown.config.ts",
   "apps/web/.env",
@@ -6559,7 +6564,7 @@ export const accountRelations = relations(account, ({ one }) => ({
 
 exports[`Template Snapshots Key File Content Snapshots key files: hono-apollo-server 1`] = `
 {
-  "fileCount": 59,
+  "fileCount": 64,
   "files": [
     {
       "content": "[exists]",
@@ -6582,9 +6587,10 @@ exports[`Template Snapshots Key File Content Snapshots key files: hono-apollo-se
     "dotenv": "catalog:",
     "zod": "catalog:",
     "@snapshot-hono-apollo-server/env": "workspace:*",
+    "@snapshot-hono-apollo-server/api": "workspace:*",
     "@snapshot-hono-apollo-server/auth": "workspace:*",
     "@snapshot-hono-apollo-server/db": "workspace:*",
-    "hono": "^4.12.25",
+    "hono": "catalog:",
     "better-auth": "catalog:"
   },
   "devDependencies": {
@@ -6601,6 +6607,7 @@ exports[`Template Snapshots Key File Content Snapshots key files: hono-apollo-se
     {
       "content": 
 "import { env } from "@snapshot-hono-apollo-server/env/server";
+import { executeApolloRequest } from "@snapshot-hono-apollo-server/api";
 import { auth } from "@snapshot-hono-apollo-server/auth";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -6622,6 +6629,12 @@ app.use(
 app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
 
 
+app.on(["GET", "POST"], "/graphql", async (c) => {
+	const session = await auth.api.getSession({
+		headers: c.req.raw.headers,
+	});
+	return executeApolloRequest(c.req.raw, { session });
+});
 
 
 
@@ -6693,6 +6706,7 @@ export default app;
     "dotenv": "catalog:",
     "zod": "catalog:",
     "@snapshot-hono-apollo-server/env": "workspace:*",
+    "@snapshot-hono-apollo-server/api": "workspace:*",
     "@snapshot-hono-apollo-server/auth": "workspace:*",
     "@libsql/client": "catalog:",
     "libsql": "catalog:",
@@ -6800,13 +6814,22 @@ import ReactDOM from "react-dom/client";
 import Loader from "./components/loader";
 import { routeTree } from "./routeTree.gen";
 
+  import { QueryClientProvider } from "@tanstack/react-query";
+  import { queryClient } from "./utils/graphql";
 
 const router = createRouter({
   routeTree,
   defaultPreload: "intent",
   defaultPendingComponent: () => <Loader />,
-  context: {},
-  });
+  context: { queryClient },
+  Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  },
+});
 
 declare module "@tanstack/react-router" {
   interface Register {
@@ -6839,6 +6862,8 @@ if (!rootElement.innerHTML) {
     {
       "content": 
 "import { createFileRoute } from "@tanstack/react-router";
+import { graphqlFetch } from "@/utils/graphql";
+import { useQuery } from "@tanstack/react-query";
 
 export const Route = createFileRoute("/")({
   component: HomeComponent,
@@ -6861,6 +6886,10 @@ const TITLE_TEXT = \`
  \`;
 
 function HomeComponent() {
+  const healthCheck = useQuery({
+    queryKey: ["healthCheck"],
+    queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),
+  });
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-2">
@@ -6892,6 +6921,10 @@ function HomeComponent() {
     {
       "content": "[exists]",
       "path": "apps/web/src/routes/login.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/utils/graphql.ts",
     },
     {
       "content": 
@@ -6967,6 +7000,7 @@ export default defineConfig({
       "zod": "^4.4.3",
       "typescript": "^6.0.3",
       "@types/bun": "^1.3.14",
+      "hono": "^4.12.25",
       "better-auth": "^1.6.18",
       "@libsql/client": "^0.17.3",
       "libsql": "^0.5.29"
@@ -7002,6 +7036,201 @@ export default defineConfig({
 "
 ,
       "path": "package.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-hono-apollo-server/api",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "type": "module",
+  "scripts": {},
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@snapshot-hono-apollo-server/config": "workspace:*"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-hono-apollo-server/env": "workspace:*",
+    "@snapshot-hono-apollo-server/auth": "workspace:*",
+    "@snapshot-hono-apollo-server/db": "workspace:*",
+    "@apollo/server": "^5.5.1",
+    "graphql": "^16.14.2",
+    "better-auth": "catalog:",
+    "hono": "catalog:"
+  }
+}
+"
+,
+      "path": "packages/api/package.json",
+    },
+    {
+      "content": 
+"import { ApolloServer, HeaderMap } from "@apollo/server";
+import type { HTTPGraphQLRequest } from "@apollo/server";
+import type { Session, User } from "better-auth";
+
+type AuthSession = { user: User; session: Session } | null;
+
+export type ApolloContext = {
+	session: AuthSession;
+};
+
+export const typeDefs = \`#graphql
+	type Query {
+		health: String!
+		me: User
+	}
+
+	type User {
+		id: ID!
+		email: String!
+		name: String
+	}
+
+	type Mutation {
+		_empty: String
+	}
+\`;
+
+export const resolvers = {
+	Query: {
+		health: () => "OK",
+		me: (_parent: unknown, _args: unknown, context: ApolloContext) => {
+			if (!context.session) return null;
+			return {
+				id: context.session.user.id,
+				email: context.session.user.email,
+				name: context.session.user.name,
+			};
+		},
+	},
+	Mutation: {
+		_empty: () => null,
+	},
+};
+
+export const apolloServer = new ApolloServer<ApolloContext>({
+	typeDefs,
+	resolvers,
+});
+
+let apolloStartPromise: Promise<void> | undefined;
+
+async function ensureApolloStarted() {
+	apolloStartPromise ??= apolloServer.start();
+	await apolloStartPromise;
+}
+
+async function parseRequestBody(request: Request) {
+	if (request.method === "GET" || request.method === "HEAD") return undefined;
+	if (!request.headers.get("content-type")?.includes("application/json")) return undefined;
+
+	const text = await request.text();
+	if (text.trim() === "") return undefined;
+
+	return JSON.parse(text) as unknown;
+}
+
+function getApolloHeaders(request: Request) {
+	const headers = new HeaderMap();
+	request.headers.forEach((value, key) => {
+		headers.set(key, value);
+	});
+	return headers;
+}
+
+function getResponseHeaders(headers: HeaderMap) {
+	const responseHeaders = new Headers();
+	for (const [key, value] of headers) {
+		responseHeaders.set(key, value);
+	}
+	return responseHeaders;
+}
+
+export async function executeApolloRequest(
+	request: Request,
+	context: ApolloContext = {
+		session: null,
+	},
+): Promise<Response> {
+	await ensureApolloStarted();
+
+	let body: unknown;
+	try {
+		body = await parseRequestBody(request);
+	} catch {
+		return Response.json({ errors: [{ message: "Invalid JSON request body" }] }, { status: 400 });
+	}
+
+	const url = new URL(request.url);
+	const httpGraphQLRequest: HTTPGraphQLRequest = {
+		method: request.method.toUpperCase(),
+		headers: getApolloHeaders(request),
+		search: url.search,
+		body,
+	};
+
+	const result = await apolloServer.executeHTTPGraphQLRequest({
+		httpGraphQLRequest,
+		context: async () => context,
+	});
+
+	const responseHeaders = getResponseHeaders(result.headers);
+	const status = result.status ?? 200;
+	const responseBody = result.body;
+
+	if (responseBody.kind === "complete") {
+		return new Response(responseBody.string, {
+			status,
+			headers: responseHeaders,
+		});
+	}
+
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		async start(controller) {
+			try {
+				for await (const chunk of responseBody.asyncIterator) {
+					controller.enqueue(encoder.encode(chunk));
+				}
+			} finally {
+				controller.close();
+			}
+		},
+	});
+
+	return new Response(stream, {
+		status,
+		headers: responseHeaders,
+	});
+}
+"
+,
+      "path": "packages/api/src/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-hono-apollo-server/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/api/tsconfig.json",
     },
     {
       "content": 
@@ -12496,7 +12725,7 @@ export const db = drizzle({ client, schema });
 
 exports[`Template Snapshots Key File Content Snapshots key files: opensearch-search-hono 1`] = `
 {
-  "fileCount": 56,
+  "fileCount": 57,
   "files": [
     {
       "content": "[exists]",
@@ -12523,7 +12752,8 @@ exports[`Template Snapshots Key File Content Snapshots key files: opensearch-sea
     "@snapshot-opensearch-search-hono/db": "workspace:*",
     "hono": "catalog:",
     "@trpc/server": "catalog:",
-    "@hono/trpc-server": "^0.4.2"
+    "@hono/trpc-server": "^0.4.2",
+    "@opensearch-project/opensearch": "^3.6.0"
   },
   "devDependencies": {
     "typescript": "catalog:",
@@ -12579,6 +12809,10 @@ export default app;
 "
 ,
       "path": "apps/server/src/index.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/server/src/lib/search.ts",
     },
     {
       "content": 

--- a/apps/cli/test/cms.test.ts
+++ b/apps/cli/test/cms.test.ts
@@ -3,6 +3,107 @@ import { describe, expect, test } from "bun:test";
 import { createCustomConfig, expectSuccess, runTRPCTest } from "./test-utils";
 
 describe("CMS Options", () => {
+  describe("Keystatic CMS", () => {
+    test("keystatic with Next.js emits admin route, config, content, and dependencies", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "keystatic-next",
+          frontend: ["next"],
+          backend: "self",
+          runtime: "none",
+          database: "sqlite",
+          cms: "keystatic",
+        }),
+      );
+
+      expectSuccess(result);
+      const pkg = await Bun.file(`${result.projectDir}/apps/web/package.json`).text();
+      const config = await Bun.file(`${result.projectDir}/apps/web/keystatic.config.ts`).text();
+      const route = await Bun.file(
+        `${result.projectDir}/apps/web/src/app/api/keystatic/[...params]/route.ts`,
+      ).text();
+      const admin = await Bun.file(
+        `${result.projectDir}/apps/web/src/app/keystatic/keystatic.ts`,
+      ).text();
+      const content = await Bun.file(
+        `${result.projectDir}/apps/web/src/content/posts/hello-world.mdoc`,
+      ).text();
+
+      expect(pkg).toContain('"@keystatic/core"');
+      expect(pkg).toContain('"@keystatic/next"');
+      expect(pkg).toContain('"@markdoc/markdoc"');
+      expect(config).toContain('kind: "local"');
+      expect(config).toContain("fields.markdoc");
+      expect(route).toContain("makeRouteHandler");
+      expect(admin).toContain("makePage");
+      expect(content).toContain("Keystatic-powered content collection");
+    });
+
+    test("keystatic with Astro emits integration config, content, and dependencies", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "keystatic-astro",
+          frontend: ["astro"],
+          astroIntegration: "vue",
+          backend: "self",
+          runtime: "none",
+          api: "orpc",
+          database: "sqlite",
+          cms: "keystatic",
+        }),
+      );
+
+      expectSuccess(result);
+      const pkg = await Bun.file(`${result.projectDir}/apps/web/package.json`).text();
+      const astroConfig = await Bun.file(`${result.projectDir}/apps/web/astro.config.mjs`).text();
+      const config = await Bun.file(`${result.projectDir}/apps/web/keystatic.config.ts`).text();
+      const content = await Bun.file(
+        `${result.projectDir}/apps/web/src/content/posts/hello-world.mdoc`,
+      ).text();
+
+      expect(pkg).toContain('"@keystatic/core"');
+      expect(pkg).toContain('"@keystatic/astro"');
+      expect(pkg).toContain('"@astrojs/react"');
+      expect(pkg).toContain('"@astrojs/markdoc"');
+      expect(pkg).toContain('"@astrojs/node"');
+      expect(astroConfig).toContain("@keystatic/astro");
+      expect(astroConfig).toContain("react()");
+      expect(astroConfig).toContain("markdoc()");
+      expect(astroConfig).toContain("keystatic()");
+      expect(astroConfig).toContain("adapter: node");
+      expect(astroConfig).toContain("standalone");
+      expect(config).toContain('kind: "local"');
+      expect(content).toContain("Keystatic-powered content collection");
+    });
+
+    test("keystatic with Astro and Workers skips unsupported CMS scaffolding", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "keystatic-astro-workers-skip",
+          frontend: ["astro"],
+          astroIntegration: "vue",
+          backend: "hono",
+          runtime: "workers",
+          serverDeploy: "cloudflare",
+          api: "orpc",
+          database: "none",
+          orm: "none",
+          cms: "keystatic",
+        }),
+      );
+
+      expectSuccess(result);
+      const pkg = await Bun.file(`${result.projectDir}/apps/web/package.json`).text();
+      const astroConfig = await Bun.file(`${result.projectDir}/apps/web/astro.config.mjs`).text();
+
+      expect(pkg).not.toContain("@keystatic/core");
+      expect(pkg).not.toContain("@keystatic/astro");
+      expect(astroConfig).not.toContain("@keystatic/astro");
+      expect(astroConfig).not.toContain("keystatic()");
+      expect(await Bun.file(`${result.projectDir}/apps/web/keystatic.config.ts`).exists()).toBe(false);
+    });
+  });
+
   describe("Directus CMS", () => {
     test("directus with TanStack Router", async () => {
       const result = await runTRPCTest(

--- a/apps/cli/test/preflight-validation.test.ts
+++ b/apps/cli/test/preflight-validation.test.ts
@@ -200,6 +200,52 @@ describe("preflight validation", () => {
     }
   });
 
+  describe("Keystatic CMS frontend support", () => {
+    test("warns without Next.js or Astro frontend", () => {
+      expect(ruleIds(config({ cms: "keystatic", frontend: ["nuxt"] }))).toContain(
+        "cms-keystatic-requires-nextjs-or-astro",
+      );
+    });
+
+    test("passes with Next.js frontend", () => {
+      expect(ruleIds(config({ cms: "keystatic", frontend: ["next"], backend: "self" }))).not.toContain(
+        "cms-keystatic-requires-nextjs-or-astro",
+      );
+    });
+
+    test("passes with Astro frontend", () => {
+      expect(ruleIds(config({ cms: "keystatic", frontend: ["astro"], backend: "self" }))).not.toContain(
+        "cms-keystatic-requires-nextjs-or-astro",
+      );
+    });
+
+    test("warns with Astro frontend on Workers runtime", () => {
+      expect(
+        ruleIds(
+          config({
+            cms: "keystatic",
+            frontend: ["astro"],
+            backend: "hono",
+            runtime: "workers",
+          }),
+        ),
+      ).toContain("cms-keystatic-astro-requires-node-runtime");
+    });
+
+    test("passes with Astro frontend on Node-compatible runtime", () => {
+      expect(
+        ruleIds(
+          config({
+            cms: "keystatic",
+            frontend: ["astro"],
+            backend: "hono",
+            runtime: "bun",
+          }),
+        ),
+      ).not.toContain("cms-keystatic-astro-requires-node-runtime");
+    });
+  });
+
   describe("payments", () => {
     test("warns with convex backend", () => {
       expect(ruleIds(config({ payments: "stripe", backend: "convex" }))).toContain(

--- a/apps/cli/test/template-snapshots.test.ts
+++ b/apps/cli/test/template-snapshots.test.ts
@@ -183,6 +183,20 @@ const SNAPSHOT_CONFIGS: Array<{
     },
   },
 
+  // === CMS VARIATIONS ===
+  {
+    name: "cms-keystatic-next",
+    config: {
+      frontend: ["next"],
+      backend: "self",
+      api: "trpc",
+      database: "sqlite",
+      orm: "drizzle",
+      auth: "none",
+      cms: "keystatic",
+    },
+  },
+
   // === AI VARIATIONS ===
   {
     name: "ai-cli-root-tooling",

--- a/apps/web/public/icon/keystatic.svg
+++ b/apps/web/public/icon/keystatic.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Keystatic">
+  <rect width="32" height="32" rx="7" fill="#111827"/>
+  <path fill="#34D399" d="M8 7h5v7.2L20.2 7H27L16.8 16.8 27.4 25h-7.1L13 19.1V25H8V7Z"/>
+  <path fill="#F8FAFC" d="M18.8 14.4 27 7h-6.8L13 14.2V7H8v18h5v-5.9l2.2 1.8 3.6-6.5Z" opacity=".2"/>
+</svg>

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -2900,6 +2900,14 @@ export const TECH_OPTIONS: Record<
       default: false,
     },
     {
+      id: "keystatic",
+      name: "Keystatic",
+      description: "Git-backed CMS for Markdown, JSON, and YAML content",
+      icon: "/icon/keystatic.svg",
+      color: "from-teal-500 to-emerald-600",
+      default: false,
+    },
+    {
       id: "none",
       name: "No CMS",
       description: "Skip headless CMS setup",

--- a/apps/web/src/lib/tech-icons.ts
+++ b/apps/web/src/lib/tech-icons.ts
@@ -412,6 +412,7 @@ export const ICON_REGISTRY: Record<string, IconConfig> = {
   strapi: { type: "si", slug: "strapi", hex: "4945FF" },
   tinacms: { type: "local", src: "/icon/tinacms.svg" },
   directus: { type: "si", slug: "directus", hex: "263238" },
+  keystatic: { type: "local", src: "/icon/keystatic.svg" },
 
   // ─── Rust ──────────────────────────────────────────────────────────────────
   axum: { type: "local", src: "/icon/axum.svg" },

--- a/apps/web/src/lib/tech-resource-links.ts
+++ b/apps/web/src/lib/tech-resource-links.ts
@@ -1001,6 +1001,10 @@ const BASE_LINKS: LinkMap = {
     docsUrl: "https://directus.io/docs",
     githubUrl: "https://github.com/directus/directus",
   },
+  keystatic: {
+    docsUrl: "https://keystatic.com/docs",
+    githubUrl: "https://github.com/Thinkmill/keystatic",
+  },
   axum: {
     docsUrl: "https://docs.rs/axum/latest/axum/",
     githubUrl: "https://github.com/tokio-rs/axum",

--- a/packages/template-generator/src/preflight-validation.ts
+++ b/packages/template-generator/src/preflight-validation.ts
@@ -134,6 +134,26 @@ const PREFLIGHT_RULES: readonly PreflightRule[] = [
       suggestions: ["Add Next.js as your frontend", "Remove CMS"],
     }),
   ),
+  {
+    id: "cms-keystatic-requires-nextjs-or-astro",
+    featureKey: "cms",
+    displayName: "CMS (Keystatic)",
+    willSkip: (c) => c.cms === "keystatic" && !c.frontend.includes("next") && !c.frontend.includes("astro"),
+    reason: "Keystatic is currently scaffolded for Next.js and Astro frontends.",
+    suggestions: ["Add Next.js or Astro as your frontend", "Remove CMS"],
+  },
+  {
+    id: "cms-keystatic-astro-requires-node-runtime",
+    featureKey: "cms",
+    displayName: "CMS (Keystatic)",
+    willSkip: (c) =>
+      c.cms === "keystatic" &&
+      !c.frontend.includes("next") &&
+      c.frontend.includes("astro") &&
+      c.runtime === "workers",
+    reason: "Keystatic's Astro integration needs Node.js APIs and is not scaffolded for Workers.",
+    suggestions: ["Use a Node-compatible runtime", "Switch to Next.js", "Remove CMS"],
+  },
 
   {
     id: "payments-skipped-convex",

--- a/packages/template-generator/src/processors/cms-deps.ts
+++ b/packages/template-generator/src/processors/cms-deps.ts
@@ -5,10 +5,11 @@ import type { VirtualFileSystem } from "../core/virtual-fs";
 import { addPackageDependency, type AvailableDependencies } from "../utils/add-deps";
 
 export function processCMSDeps(vfs: VirtualFileSystem, config: ProjectConfig): void {
-  const { cms, frontend, database } = config;
+  const { cms, frontend, database, runtime } = config;
   if (!cms || cms === "none") return;
 
   const hasNext = frontend.includes("next");
+  const hasAstro = frontend.includes("astro");
   const hasWebFrontend =
     frontend.includes("next") ||
     frontend.includes("astro") ||
@@ -29,6 +30,43 @@ export function processCMSDeps(vfs: VirtualFileSystem, config: ProjectConfig): v
         dependencies: getPayloadDeps(database),
       });
     }
+    return;
+  }
+
+  if (cms === "keystatic") {
+    if (!hasNext && !hasAstro) return;
+    if (!hasNext && hasAstro && runtime === "workers") return;
+
+    const webPath = "apps/web/package.json";
+    if (!vfs.exists(webPath)) return;
+
+    if (hasNext) {
+      addPackageDependency({
+        vfs,
+        packagePath: webPath,
+        dependencies: ["@keystatic/core", "@keystatic/next", "@markdoc/markdoc"],
+      });
+      return;
+    }
+
+    const astroDependencies: AvailableDependencies[] = [
+      "@keystatic/core",
+      "@keystatic/astro",
+      "@astrojs/react",
+      "@astrojs/markdoc",
+      "react",
+      "react-dom",
+    ];
+    if (runtime !== "workers") {
+      astroDependencies.push("@astrojs/node");
+    }
+
+    addPackageDependency({
+      vfs,
+      packagePath: webPath,
+      dependencies: astroDependencies,
+      devDependencies: ["@types/react", "@types/react-dom"],
+    });
     return;
   }
 

--- a/packages/template-generator/src/template-handlers/cms.ts
+++ b/packages/template-generator/src/template-handlers/cms.ts
@@ -37,6 +37,15 @@ export async function processCMSTemplates(
     return;
   }
 
+  if (config.cms === "keystatic") {
+    if (config.frontend.includes("next")) {
+      processTemplatesFromPrefix(vfs, templates, "cms/keystatic/web/next", "apps/web", config);
+    } else if (config.frontend.includes("astro") && config.runtime !== "workers") {
+      processTemplatesFromPrefix(vfs, templates, "cms/keystatic/web/astro", "apps/web", config);
+    }
+    return;
+  }
+
   const variant = getCMSVariant(config.frontend);
   if (!variant) return;
 

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -346,7 +346,9 @@ export const dependencyVersionMap = {
   "@react-email/components": "^1.0.12",
   "react-email": "^6.6.0",
   react: "^19.2.7",
+  "react-dom": "^19.2.7",
   "@types/react": "^19.2.17",
+  "@types/react-dom": "^19.2.3",
   nodemailer: "^9.0.0",
   "@types/nodemailer": "^8.0.1",
   postmark: "^4.0.7",
@@ -717,6 +719,15 @@ export const dependencyVersionMap = {
   // Headless CMS - TinaCMS
   tinacms: "^3.9.2",
   "@tinacms/cli": "^2.5.0",
+
+  // Headless CMS - Keystatic
+  "@keystatic/core": "^0.5.50",
+  "@keystatic/next": "^5.0.4",
+  "@keystatic/astro": "^5.1.0",
+  "@markdoc/markdoc": "^0.5.7",
+  "@astrojs/react": "^5.0.7",
+  "@astrojs/markdoc": "^1.0.6",
+  "@astrojs/node": "^10.1.4",
 
   // File Storage - Cloudinary
   cloudinary: "^2.10.0",

--- a/packages/template-generator/templates/cms/keystatic/web/astro/keystatic.config.ts.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/astro/keystatic.config.ts.hbs
@@ -1,0 +1,24 @@
+import { collection, config, fields } from "@keystatic/core";
+
+export default config({
+  storage: {
+    kind: "local",
+  },
+  ui: {
+    brand: {
+      name: "{{projectName}}",
+    },
+  },
+  collections: {
+    posts: collection({
+      label: "Posts",
+      slugField: "title",
+      path: "src/content/posts/*",
+      format: { contentField: "content" },
+      schema: {
+        title: fields.slug({ name: { label: "Title" } }),
+        content: fields.markdoc({ label: "Content" }),
+      },
+    }),
+  },
+});

--- a/packages/template-generator/templates/cms/keystatic/web/astro/src/content/posts/hello-world.mdoc.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/astro/src/content/posts/hello-world.mdoc.hbs
@@ -1,0 +1,5 @@
+---
+title: Hello World
+---
+
+Welcome to your new Keystatic-powered content collection.

--- a/packages/template-generator/templates/cms/keystatic/web/next/keystatic.config.ts.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/next/keystatic.config.ts.hbs
@@ -1,0 +1,24 @@
+import { collection, config, fields } from "@keystatic/core";
+
+export default config({
+  storage: {
+    kind: "local",
+  },
+  ui: {
+    brand: {
+      name: "{{projectName}}",
+    },
+  },
+  collections: {
+    posts: collection({
+      label: "Posts",
+      slugField: "title",
+      path: "src/content/posts/*",
+      format: { contentField: "content" },
+      schema: {
+        title: fields.slug({ name: { label: "Title" } }),
+        content: fields.markdoc({ label: "Content" }),
+      },
+    }),
+  },
+});

--- a/packages/template-generator/templates/cms/keystatic/web/next/src/app/api/keystatic/[...params]/route.ts.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/next/src/app/api/keystatic/[...params]/route.ts.hbs
@@ -1,0 +1,7 @@
+import { makeRouteHandler } from "@keystatic/next/route-handler";
+
+import config from "../../../../../keystatic.config";
+
+export const { GET, POST } = makeRouteHandler({
+  config,
+});

--- a/packages/template-generator/templates/cms/keystatic/web/next/src/app/keystatic/[[...params]]/page.tsx.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/next/src/app/keystatic/[[...params]]/page.tsx.hbs
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null;
+}

--- a/packages/template-generator/templates/cms/keystatic/web/next/src/app/keystatic/keystatic.ts.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/next/src/app/keystatic/keystatic.ts.hbs
@@ -1,0 +1,7 @@
+"use client";
+
+import { makePage } from "@keystatic/next/ui/app";
+
+import config from "../../../keystatic.config";
+
+export default makePage(config);

--- a/packages/template-generator/templates/cms/keystatic/web/next/src/app/keystatic/layout.tsx.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/next/src/app/keystatic/layout.tsx.hbs
@@ -1,0 +1,5 @@
+import KeystaticApp from "./keystatic";
+
+export default function Layout() {
+  return <KeystaticApp />;
+}

--- a/packages/template-generator/templates/cms/keystatic/web/next/src/content/posts/hello-world.mdoc.hbs
+++ b/packages/template-generator/templates/cms/keystatic/web/next/src/content/posts/hello-world.mdoc.hbs
@@ -1,0 +1,5 @@
+---
+title: Hello World
+---
+
+Welcome to your new Keystatic-powered content collection.

--- a/packages/template-generator/templates/frontend/astro/astro.config.mjs.hbs
+++ b/packages/template-generator/templates/frontend/astro/astro.config.mjs.hbs
@@ -1,7 +1,11 @@
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
-{{#if (eq astroIntegration "react")}}
+{{#if (or (eq astroIntegration "react") (and (eq cms "keystatic") (ne runtime "workers")))}}
 import react from '@astrojs/react';
+{{/if}}
+{{#if (and (eq cms "keystatic") (ne runtime "workers"))}}
+import markdoc from '@astrojs/markdoc';
+import keystatic from '@keystatic/astro';
 {{/if}}
 {{#if (eq astroIntegration "vue")}}
 import vue from '@astrojs/vue';
@@ -12,7 +16,7 @@ import svelte from '@astrojs/svelte';
 {{#if (eq astroIntegration "solid")}}
 import solidJs from '@astrojs/solid-js';
 {{/if}}
-{{#if (eq backend "self")}}
+{{#if (or (eq backend "self") (and (eq cms "keystatic") (ne runtime "workers")))}}
 import node from '@astrojs/node';
 {{/if}}
 {{#if (eq runtime "workers")}}
@@ -21,8 +25,12 @@ import cloudflare from '@astrojs/cloudflare';
 
 export default defineConfig({
 	integrations: [
-{{#if (eq astroIntegration "react")}}
+{{#if (or (eq astroIntegration "react") (and (eq cms "keystatic") (ne runtime "workers")))}}
 		react(),
+{{/if}}
+{{#if (and (eq cms "keystatic") (ne runtime "workers"))}}
+		markdoc(),
+		keystatic(),
 {{/if}}
 {{#if (eq astroIntegration "vue")}}
 		vue(),
@@ -37,12 +45,12 @@ export default defineConfig({
 	vite: {
 		plugins: [tailwindcss()],
 	},
-{{#if (or (eq backend "self") (eq runtime "workers"))}}
+{{#if (or (eq backend "self") (eq runtime "workers") (and (eq cms "keystatic") (ne runtime "workers")))}}
 	output: 'server',
-{{#if (eq backend "self")}}
-	adapter: node({ mode: 'standalone' }),
-{{else if (eq runtime "workers")}}
+{{#if (eq runtime "workers")}}
 	adapter: cloudflare(),
+{{else if (or (eq backend "self") (and (eq cms "keystatic") (ne runtime "workers")))}}
+	adapter: node({ mode: 'standalone' }),
 {{/if}}
 {{/if}}
 });

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -1780,6 +1780,14 @@ export const getDisabledReason = (
     if (optionId === "workers" && currentStack.backend !== "hono") {
       return "In Better-Fullstack, Workers runtime currently requires the Hono backend";
     }
+    if (
+      optionId === "workers" &&
+      currentStack.cms === "keystatic" &&
+      currentStack.webFrontend.includes("astro") &&
+      !currentStack.webFrontend.includes("next")
+    ) {
+      return "Keystatic with Astro requires a Node-compatible runtime";
+    }
     if (optionId === "none") {
       const allowedBackends = [
         "convex",
@@ -1979,6 +1987,18 @@ export const getDisabledReason = (
   if (category === "cms" && optionId === "payload") {
     if (!currentStack.webFrontend.includes("next")) {
       return "Payload CMS v3 requires Next.js";
+    }
+  }
+  if (category === "cms" && optionId === "keystatic") {
+    if (!currentStack.webFrontend.includes("next") && !currentStack.webFrontend.includes("astro")) {
+      return "Keystatic is currently scaffolded for Next.js and Astro";
+    }
+    if (
+      currentStack.webFrontend.includes("astro") &&
+      !currentStack.webFrontend.includes("next") &&
+      currentStack.runtime === "workers"
+    ) {
+      return "Keystatic with Astro requires a Node-compatible runtime";
     }
   }
 

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -915,7 +915,7 @@ const EXACT_LABEL_OVERRIDES: Partial<Record<OptionCategory, Partial<Record<strin
     sst: "SST",
     vercel: "Vercel",
   },
-  cms: { tinacms: "TinaCMS", directus: "Directus" },
+  cms: { tinacms: "TinaCMS", directus: "Directus", keystatic: "Keystatic" },
   auth: {
     "better-auth-organizations": "Better Auth + Organizations",
     auth0: "Auth0",

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -311,7 +311,7 @@ export const JobQueueSchema = z
   .describe("Job queue/background worker solution");
 
 export const CMSSchema = z
-  .enum(["payload", "sanity", "strapi", "tinacms", "directus", "none"])
+  .enum(["payload", "sanity", "strapi", "tinacms", "directus", "keystatic", "none"])
   .describe("Headless CMS solution");
 
 export const CachingSchema = z

--- a/packages/types/src/stack-graph.ts
+++ b/packages/types/src/stack-graph.ts
@@ -1076,6 +1076,30 @@ function createTypeScriptBackendCompatibilityIssue(
     }
   }
 
+  if (part.role === "cms" && part.toolId === "keystatic") {
+    const frontendTool = context.primaryToolIdsByRole?.frontend;
+    if (frontendTool !== "next" && frontendTool !== "astro") {
+      return createStackGraphIssue({
+        code: "INCOMPATIBLE_GRAPH_SELECTION",
+        partId: part.id,
+        role: part.role,
+        toolId: part.toolId,
+        message: "Keystatic is currently scaffolded for Next.js and Astro frontends.",
+      });
+    }
+
+    const runtimeTool = context.siblingToolIdsByRole?.runtime ?? "bun";
+    if (frontendTool === "astro" && runtimeTool === "workers") {
+      return createStackGraphIssue({
+        code: "INCOMPATIBLE_GRAPH_SELECTION",
+        partId: part.id,
+        role: part.role,
+        toolId: part.toolId,
+        message: "Keystatic with Astro requires a Node-compatible runtime.",
+      });
+    }
+  }
+
   if (part.role === "ai") {
     const frontendTool = context.primaryToolIdsByRole?.frontend;
     const frontendTools = frontendTool ? [frontendTool] : [];

--- a/packages/types/test/compatibility.test.ts
+++ b/packages/types/test/compatibility.test.ts
@@ -230,6 +230,51 @@ describe("compatibility issue helpers", () => {
     expect(getDisabledReason(DEFAULT_STACK_SELECTION, "cms", "payload")).toBe(
       "Payload CMS v3 requires a Next.js frontend.",
     );
+    expect(getDisabledReason(DEFAULT_STACK_SELECTION, "cms", "keystatic")).toBe(
+      "Keystatic is currently scaffolded for Next.js and Astro frontends.",
+    );
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          webFrontend: ["nuxt"],
+        },
+        "cms",
+        "keystatic",
+      ),
+    ).toBe("Keystatic is currently scaffolded for Next.js and Astro frontends.");
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          webFrontend: ["astro"],
+          runtime: "workers",
+        },
+        "cms",
+        "keystatic",
+      ),
+    ).toBe("Keystatic with Astro requires a Node-compatible runtime.");
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          webFrontend: ["next"],
+        },
+        "cms",
+        "keystatic",
+      ),
+    ).toBeNull();
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          webFrontend: ["astro"],
+          runtime: "node",
+        },
+        "cms",
+        "keystatic",
+      ),
+    ).toBeNull();
 
     expect(
       getDisabledReason(

--- a/packages/types/test/stack-graph.test.ts
+++ b/packages/types/test/stack-graph.test.ts
@@ -484,6 +484,62 @@ describe("stack graph", () => {
     );
   });
 
+  it("validates Keystatic CMS graph frontend and runtime support", () => {
+    const tanstackRouterParts = parseStackPartSpecs([
+      "frontend:typescript:tanstack-router",
+      "backend:typescript:hono",
+      "backend.cms:typescript:keystatic",
+    ]);
+    const nuxtParts = parseStackPartSpecs([
+      "frontend:typescript:nuxt",
+      "backend:typescript:hono",
+      "backend.cms:typescript:keystatic",
+    ]);
+    const astroWorkersParts = parseStackPartSpecs([
+      "frontend:typescript:astro",
+      "backend:typescript:hono",
+      "backend.runtime:typescript:workers",
+      "backend.cms:typescript:keystatic",
+    ]);
+    const nextParts = parseStackPartSpecs([
+      "frontend:typescript:next",
+      "backend:typescript:hono",
+      "backend.cms:typescript:keystatic",
+    ]);
+    const astroNodeParts = parseStackPartSpecs([
+      "frontend:typescript:astro",
+      "backend:typescript:hono",
+      "backend.runtime:typescript:node",
+      "backend.cms:typescript:keystatic",
+    ]);
+
+    for (const parts of [tanstackRouterParts, nuxtParts]) {
+      expect(validateStackParts(parts).issues).toContainEqual(
+        expect.objectContaining({
+          code: "INCOMPATIBLE_GRAPH_SELECTION",
+          role: "cms",
+          toolId: "keystatic",
+          message: "Keystatic is currently scaffolded for Next.js and Astro frontends.",
+        }),
+      );
+    }
+    expect(validateStackParts(astroWorkersParts).issues).toContainEqual(
+      expect.objectContaining({
+        code: "INCOMPATIBLE_GRAPH_SELECTION",
+        role: "cms",
+        toolId: "keystatic",
+        message: "Keystatic with Astro requires a Node-compatible runtime.",
+      }),
+    );
+    for (const parts of [nextParts, astroNodeParts]) {
+      expect(
+        validateStackParts(parts).issues.filter(
+          (issue) => issue.role === "cms" && issue.toolId === "keystatic",
+        ),
+      ).toEqual([]);
+    }
+  });
+
   it("rejects incompatible backend-owned TypeScript AI graph selections", () => {
     const chatSdkParts = parseStackPartSpecs([
       "frontend:typescript:nuxt",
@@ -885,7 +941,7 @@ describe("stack graph structural round-trip (phase 0)", () => {
 
   function getCompatibleBackendSingleConfig(field: string, value: string): Partial<ProjectConfig> {
     const config = { ...TS_BASE, [field]: value };
-    if (field === "cms" && value === "payload") {
+    if (field === "cms" && (value === "payload" || value === "keystatic")) {
       config.frontend = ["next"];
     }
     return config;


### PR DESCRIPTION
## Summary
- Add Keystatic as a CMS option across schema, CLI prompt, builder metadata, icon, and resource links.
- Add Next.js and Astro local-mode templates with Keystatic config, sample content, dependencies, and Astro integration wiring.
- Add conservative compatibility/preflight handling plus CMS generation, parity, and snapshot coverage.

## Validation
- `~/.bun/bin/bun run --cwd packages/types build`
- `~/.bun/bin/bun run --cwd packages/template-generator build`
- `~/.bun/bin/bun run --cwd apps/cli build`
- `~/.bun/bin/bun run --cwd apps/cli check-types`
- `~/.bun/bin/bun run --cwd packages/template-generator typecheck`
- `~/.bun/bin/bun run --cwd apps/web typecheck`
- `~/.bun/bin/bun run --cwd apps/web validate:tech-links`
- `~/.bun/bin/bun test apps/cli/test/cms.test.ts`
- `~/.bun/bin/bun test apps/cli/test/preflight-validation.test.ts`
- `~/.bun/bin/bun test apps/cli/test/template-snapshots.test.ts`
- `~/.bun/bin/bun test apps/cli/test/cli-builder-sync.test.ts`
- `~/.bun/bin/bun run --cwd packages/types lint`
- `~/.bun/bin/bun run --cwd packages/template-generator lint`
- `~/.bun/bin/bun run --cwd apps/cli lint`
- `~/.bun/bin/bun run --cwd apps/web lint`
- `~/.bun/bin/bun run test:release`

## Notes
- Keystatic support is intentionally limited to Next.js and Astro on Node-compatible runtime paths. Astro + Workers warns and skips the Keystatic CMS files.