### PR TITLE
fix(templates): gate native Expo web.output static behind expo-router

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -205,10 +205,22 @@ jobs:
 
       - name: Upload Results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: smoke-results
-          path: testing/.smoke-output/
+          path: |
+            testing/.smoke-output/
+            !testing/.smoke-output/**/node_modules/**
+            !testing/.smoke-output/**/.git/**
+            !testing/.smoke-output/**/target/**
+            !testing/.smoke-output/**/dist/**
+            !testing/.smoke-output/**/build/**
+            !testing/.smoke-output/**/.next/**
+            !testing/.smoke-output/**/.expo/**
+            !testing/.smoke-output/**/.turbo/**
+            !testing/.smoke-output/**/.venv/**
+            !testing/.smoke-output/**/__pycache__/**
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7

--- a/packages/template-generator/templates/frontend/native/bare/app.json.hbs
+++ b/packages/template-generator/templates/frontend/native/bare/app.json.hbs
@@ -23,7 +23,9 @@
       "package": "{{nativeApplicationId}}"
     },
     "web": {
+      {{#if (eq mobileNavigation "expo-router")}}
       "output": "static",
+      {{/if}}
       "favicon": "./assets/images/favicon.png"
     },
     {{#if (eq mobileOTA "expo-updates")}}

--- a/packages/template-generator/templates/frontend/native/unistyles/app.json.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/app.json.hbs
@@ -23,7 +23,9 @@
       "package": "{{nativeApplicationId}}"
     },
     "web": {
+      {{#if (eq mobileNavigation "expo-router")}}
       "output": "static",
+      {{/if}}
       "favicon": "./assets/images/favicon.png"
     },
     {{#if (eq mobileOTA "expo-updates")}}

--- a/packages/template-generator/templates/frontend/native/uniwind/app.json.hbs
+++ b/packages/template-generator/templates/frontend/native/uniwind/app.json.hbs
@@ -23,7 +23,9 @@
       "package": "{{nativeApplicationId}}"
     },
     "web": {
+      {{#if (eq mobileNavigation "expo-router")}}
       "output": "static",
+      {{/if}}
       "favicon": "./assets/images/favicon.png"
     },
     {{#if (eq mobileOTA "expo-updates")}}


### PR DESCRIPTION
## Problem

The native (Expo) templates hardcoded `"web": { "output": "static" }` in `app.json`. Expo's `output: "static"` requires Expo Router (file-based routing); for the **react-navigation** variant it broke `expo export` for web.

## Fix

Gate `"output": "static"` behind `mobileNavigation == "expo-router"` in all three native variants (`bare`, `uniwind`, `unistyles`), reusing the canonical conditional already present in those files. For react-navigation, `output` is omitted so Expo falls back to its default (`single`), which is correct for non-file-based routing.

## CI

Also fixes the `Smoke Test` workflow's `Upload Results` step, which ran the `actions/upload-artifact` process out of heap memory (OOM) when native projects were scaffolded — it was uploading their `node_modules/` (~1M files). The upload now excludes `node_modules` and other heavy build dirs, and is marked `continue-on-error` so a debug-artifact upload can never fail a run whose tests have already passed.

## Verification

- `bun run test:release` passes.
- Native `app.json` renders valid JSON in both navigation modes: expo-router keeps `"output": "static"`, react-navigation omits it (favicon preserved, no dangling comma).
