### PR TITLE
Add optional DevContainer generation

### DIFF
--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -77,6 +77,7 @@ export const ADDON_COMPATIBILITY = {
   fumadocs: [],
   opentui: [],
   wxt: [],
+  devcontainer: [],
   "docker-compose": [],
   msw: [],
   storybook: ["tanstack-router", "react-router", "react-vite", "next", "vinext", "nuxt", "svelte", "solid"],

--- a/apps/cli/src/prompts/addons.ts
+++ b/apps/cli/src/prompts/addons.ts
@@ -122,6 +122,10 @@ function getAddonDisplay(addon: Addons): { label: string; hint: string } {
       label = "Backend Utils";
       hint = "asyncHandler, ApiResponse & global error handler for your server";
       break;
+    case "devcontainer":
+      label = "DevContainer";
+      hint = "VS Code container config with stack-aware ports and extensions";
+      break;
     case "docker-compose":
       label = "Docker Compose";
       hint = "Containerize your app for deployment";
@@ -137,7 +141,7 @@ function getAddonDisplay(addon: Addons): { label: string; hint: string } {
 const ADDON_GROUPS: Record<string, Addons[]> = {
   Tooling: ["turborepo", "nx", "biome", "oxlint", "ultracite", "husky", "lefthook"],
   Documentation: ["starlight", "fumadocs"],
-  Extensions: ["pwa", "tauri", "opentui", "wxt", "ruler", "docker-compose"],
+  Extensions: ["pwa", "tauri", "opentui", "wxt", "ruler", "devcontainer", "docker-compose"],
   Integrations: ["msw", "storybook", "backend-utils"],
   "AI Agents": ["mcp", "skills"],
   "Data Fetching": ["swr"],

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -530,7 +530,7 @@ export async function gatherConfig(
       addons: ({ results }) => {
         if (results.ecosystem !== "typescript") {
           const nonTypeScriptAddons = (flags.addons ?? []).filter(
-            (addon): addon is Addons => addon === "docker-compose",
+            (addon): addon is Addons => addon === "docker-compose" || addon === "devcontainer",
           );
           return Promise.resolve(nonTypeScriptAddons);
         }

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -486,43 +486,55 @@ export function validateAddonCompatibility(
     }
   }
 
-  // Docker Compose targets containerized/self-hosted stacks only.
-  if (addon === "docker-compose") {
+  // Docker Compose-backed addons target containerized/self-hosted stacks only.
+  if (addon === "docker-compose" || addon === "devcontainer") {
+    const label = addon === "devcontainer" ? "DevContainer" : "docker-compose";
+    const title = addon === "devcontainer" ? "DevContainer" : "Docker Compose";
+
     if (backend === "convex") {
       return {
         isCompatible: false,
-        reason: "docker-compose is not compatible with Convex backend (managed service)",
+        reason: `${label} is not compatible with Convex backend (managed service)`,
       };
     }
     if (runtime === "workers") {
       return {
         isCompatible: false,
-        reason: "docker-compose is not compatible with Cloudflare Workers runtime",
+        reason: `${label} is not compatible with Cloudflare Workers runtime`,
+      };
+    }
+    if (
+      ecosystem !== undefined &&
+      !["typescript", "python", "go", "rust", "java"].includes(ecosystem)
+    ) {
+      return {
+        isCompatible: false,
+        reason: `${title} currently supports TypeScript, Python, Go, Rust, or Java projects`,
       };
     }
     if (ecosystem === "typescript" && !hasDockerComposeCompatibleFrontend(frontend)) {
       return {
         isCompatible: false,
         reason:
-          "Docker Compose currently supports Next.js, Vinext, TanStack Router, React Router, React Vite, Solid, or Astro",
+          `${title} currently supports Next.js, Vinext, TanStack Router, React Router, React Vite, Solid, or Astro`,
       };
     }
     if (ecosystem === "typescript" && backend === "self" && !frontend.includes("next") && !frontend.includes("vinext")) {
       return {
         isCompatible: false,
-        reason: "Docker Compose self-backend support currently requires Next.js or Vinext",
+        reason: `${title} self-backend support currently requires Next.js or Vinext`,
       };
     }
     if (ecosystem === "rust" && rustFrontend && rustFrontend !== "none") {
       return {
         isCompatible: false,
-        reason: "Docker Compose for Rust currently supports server-only projects",
+        reason: `${title} for Rust currently supports server-only projects`,
       };
     }
     if (ecosystem === "java" && javaWebFramework && javaWebFramework !== "spring-boot") {
       return {
         isCompatible: false,
-        reason: "Docker Compose for Java currently requires Spring Boot",
+        reason: `${title} for Java currently requires Spring Boot`,
       };
     }
     if (
@@ -534,7 +546,7 @@ export function validateAddonCompatibility(
     ) {
       return {
         isCompatible: false,
-        reason: "Docker Compose for Python ORM projects currently supports SQLite defaults or Postgres",
+        reason: `${title} for Python ORM projects currently supports SQLite defaults or Postgres`,
       };
     }
   }

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -848,6 +848,124 @@ describe("Addon Configurations", () => {
       });
     });
 
+    describe("DevContainer Addon", () => {
+      it("should not generate DevContainer files when only docker-compose is selected", async () => {
+        const result = await runTRPCTest({
+          projectName: "docker-compose-no-devcontainer",
+          addons: ["docker-compose"],
+          frontend: ["tanstack-router"],
+          backend: "hono",
+          runtime: "bun",
+          database: "postgres",
+          orm: "drizzle",
+          auth: "none",
+          api: "trpc",
+          examples: ["none"],
+          dbSetup: "none",
+          webDeploy: "none",
+          serverDeploy: "none",
+          install: false,
+        });
+
+        expectSuccess(result);
+        expect(result.projectDir).toBeDefined();
+        expect(existsSync(join(result.projectDir!, ".devcontainer", "devcontainer.json"))).toBe(false);
+      });
+
+      it("should generate stack-aware DevContainer files for TypeScript Docker Compose stacks", async () => {
+        const result = await runTRPCTest({
+          projectName: "devcontainer-hono-postgres",
+          addons: ["devcontainer"],
+          frontend: ["tanstack-router"],
+          backend: "hono",
+          runtime: "bun",
+          database: "postgres",
+          orm: "drizzle",
+          auth: "none",
+          api: "trpc",
+          cssFramework: "tailwind",
+          examples: ["none"],
+          dbSetup: "none",
+          webDeploy: "none",
+          serverDeploy: "none",
+          install: false,
+        });
+
+        expectSuccess(result);
+        expect(result.projectDir).toBeDefined();
+
+        const devcontainerPath = join(result.projectDir!, ".devcontainer", "devcontainer.json");
+        const overridePath = join(result.projectDir!, ".devcontainer", "docker-compose.devcontainer.yml");
+        const composePath = join(result.projectDir!, "docker-compose.yml");
+        const devcontainer = JSON.parse(readFileSync(devcontainerPath, "utf8"));
+        const override = readFileSync(overridePath, "utf8");
+
+        expect(existsSync(composePath)).toBe(true);
+        expect(devcontainer.dockerComposeFile).toEqual([
+          "../docker-compose.yml",
+          "docker-compose.devcontainer.yml",
+        ]);
+        expect(devcontainer.runServices).toEqual(["devcontainer", "web", "server", "db"]);
+        expect(devcontainer.forwardPorts).toEqual([3001, 3000, 5432]);
+        expect(devcontainer.postCreateCommand).toBe("bun install && bun run --if-present db:push");
+        expect(devcontainer.customizations.vscode.extensions).toEqual([
+          "ms-azuretools.vscode-docker",
+          "dbaeumer.vscode-eslint",
+          "esbenp.prettier-vscode",
+          "bradlc.vscode-tailwindcss",
+        ]);
+        expect(override).toContain('image: "oven/bun:1"');
+        expect(override).toContain("- ..:/workspaces/devcontainer-hono-postgres:cached");
+      });
+
+      it("should generate language-aware DevContainer files for Python Docker Compose stacks", async () => {
+        const result = await runTRPCTest({
+          projectName: "devcontainer-python-postgres",
+          ecosystem: "python",
+          addons: ["devcontainer"],
+          database: "postgres",
+          pythonWebFramework: "fastapi",
+          pythonOrm: "sqlalchemy",
+          pythonValidation: "pydantic",
+          pythonAi: [],
+          pythonAuth: "none",
+          pythonApi: "none",
+          pythonTaskQueue: "none",
+          pythonGraphql: "none",
+          pythonQuality: "ruff",
+          pythonTesting: [],
+          pythonCaching: "none",
+          pythonRealtime: "none",
+          pythonObservability: "none",
+          pythonCli: [],
+          install: false,
+        });
+
+        expectSuccess(result);
+        expect(result.projectDir).toBeDefined();
+
+        const devcontainer = JSON.parse(
+          readFileSync(join(result.projectDir!, ".devcontainer", "devcontainer.json"), "utf8"),
+        );
+        const override = readFileSync(
+          join(result.projectDir!, ".devcontainer", "docker-compose.devcontainer.yml"),
+          "utf8",
+        );
+
+        expect(existsSync(join(result.projectDir!, "docker-compose.yml"))).toBe(true);
+        expect(existsSync(join(result.projectDir!, "Dockerfile"))).toBe(true);
+        expect(devcontainer.runServices).toEqual(["devcontainer", "app", "db"]);
+        expect(devcontainer.forwardPorts).toEqual([8000, 5432]);
+        expect(devcontainer.postCreateCommand).toBe("python -m pip install -e '.[dev]'");
+        expect(devcontainer.customizations.vscode.extensions).toEqual([
+          "ms-azuretools.vscode-docker",
+          "ms-python.python",
+          "ms-python.vscode-pylance",
+        ]);
+        expect(override).toContain('image: "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm"');
+      });
+    });
+
     describe("MSW Addon", () => {
       const mswCompatibleFrontends = [
         "tanstack-router",

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -907,7 +907,7 @@ describe("Addon Configurations", () => {
         ]);
         expect(devcontainer.runServices).toEqual(["devcontainer", "web", "server", "db"]);
         expect(devcontainer.forwardPorts).toEqual([3001, 3000, 5432]);
-        expect(devcontainer.postCreateCommand).toBe("bun install && bun run --if-present db:push");
+        expect(devcontainer.postCreateCommand).toBe("bun install");
         expect(devcontainer.customizations.vscode.extensions).toEqual([
           "ms-azuretools.vscode-docker",
           "dbaeumer.vscode-eslint",

--- a/apps/cli/test/addons.test.ts
+++ b/apps/cli/test/addons.test.ts
@@ -915,7 +915,7 @@ describe("Addon Configurations", () => {
           "bradlc.vscode-tailwindcss",
         ]);
         expect(override).toContain('image: "oven/bun:1"');
-        expect(override).toContain("- ..:/workspaces/devcontainer-hono-postgres:cached");
+        expect(override).toContain("- .:/workspaces/devcontainer-hono-postgres:cached");
       });
 
       it("should generate language-aware DevContainer files for Python Docker Compose stacks", async () => {
@@ -963,6 +963,7 @@ describe("Addon Configurations", () => {
           "ms-python.vscode-pylance",
         ]);
         expect(override).toContain('image: "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm"');
+        expect(override).toContain("- .:/workspaces/devcontainer-python-postgres:cached");
       });
     });
 

--- a/apps/cli/test/cli-builder-sync.test.ts
+++ b/apps/cli/test/cli-builder-sync.test.ts
@@ -106,6 +106,7 @@ describe("CLI and Builder catalog parity", () => {
       ["javaLibraries", "spring-devtools", "Spring Boot DevTools"],
       ["javaLibraries", "micrometer-prometheus", "Micrometer Prometheus"],
       ["javaLibraries", "thymeleaf", "Thymeleaf"],
+      ["appPlatforms", "devcontainer", "DevContainer"],
     ];
 
     for (const [category, id, label] of expectedLabels) {

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -2279,6 +2279,14 @@ export const TECH_OPTIONS: Record<
       default: false,
     },
     {
+      id: "devcontainer",
+      name: "DevContainer",
+      description: "VS Code container config with forwarded services",
+      icon: "https://cdn.simpleicons.org/visualstudiocode/007ACC",
+      color: "from-sky-500 to-blue-700",
+      default: false,
+    },
+    {
       id: "wxt",
       name: "WXT",
       description: "Build browser extensions",

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -2282,7 +2282,7 @@ export const TECH_OPTIONS: Record<
       id: "devcontainer",
       name: "DevContainer",
       description: "VS Code container config with forwarded services",
-      icon: "https://cdn.simpleicons.org/visualstudiocode/007ACC",
+      icon: "https://cdn.simpleicons.org/docker/2496ED",
       color: "from-sky-500 to-blue-700",
       default: false,
     },

--- a/apps/web/src/lib/tech-icons.ts
+++ b/apps/web/src/lib/tech-icons.ts
@@ -213,6 +213,7 @@ export const ICON_REGISTRY: Record<string, IconConfig> = {
   upstash: { type: "si", slug: "upstash", hex: "00E9A3" },
   docker: { type: "si", slug: "docker", hex: "2496ED" },
   "docker-compose": { type: "si", slug: "docker", hex: "2496ED" },
+  devcontainer: { type: "si", slug: "visualstudiocode", hex: "007ACC" },
   nx: { type: "si", slug: "nx", hex: "143055", needsInvert: "dark" },
 
   // ─── Deploy ────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/tech-icons.ts
+++ b/apps/web/src/lib/tech-icons.ts
@@ -213,7 +213,7 @@ export const ICON_REGISTRY: Record<string, IconConfig> = {
   upstash: { type: "si", slug: "upstash", hex: "00E9A3" },
   docker: { type: "si", slug: "docker", hex: "2496ED" },
   "docker-compose": { type: "si", slug: "docker", hex: "2496ED" },
-  devcontainer: { type: "si", slug: "visualstudiocode", hex: "007ACC" },
+  devcontainer: { type: "si", slug: "docker", hex: "2496ED" },
   nx: { type: "si", slug: "nx", hex: "143055", needsInvert: "dark" },
 
   // ─── Deploy ────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/tech-resource-links.ts
+++ b/apps/web/src/lib/tech-resource-links.ts
@@ -345,6 +345,10 @@ const BASE_LINKS: LinkMap = {
     docsUrl: "https://docs.docker.com/compose/",
     githubUrl: "https://github.com/docker/compose",
   },
+  devcontainer: {
+    docsUrl: "https://containers.dev/",
+    githubUrl: "https://github.com/devcontainers/spec",
+  },
   cloudflare: {
     docsUrl: "https://developers.cloudflare.com/",
     githubUrl: "https://github.com/cloudflare/cloudflare-docs",

--- a/packages/template-generator/src/core/template-processor.ts
+++ b/packages/template-generator/src/core/template-processor.ts
@@ -1,5 +1,4 @@
 import type { ProjectConfig } from "@better-fullstack/types";
-
 import Handlebars from "handlebars";
 import { extname } from "pathe";
 
@@ -79,6 +78,185 @@ Handlebars.registerHelper("shadcnRadiusValue", function (this: ProjectConfig) {
 /** Returns the project name with a trailing brace for compose default syntax. */
 Handlebars.registerHelper("projectNameWithClosingBrace", function (this: ProjectConfig) {
   return `${this.projectName ?? ""}}`;
+});
+
+function jsonHelper(value: unknown) {
+  return new Handlebars.SafeString(JSON.stringify(value, null, 2));
+}
+
+function addDatabasePorts(config: ProjectConfig, ports: Set<number>) {
+  if (config.database === "postgres") ports.add(5432);
+  if (config.database === "mysql") ports.add(3306);
+  if (config.database === "mongodb") ports.add(27017);
+}
+
+function getDevcontainerExtensions(config: ProjectConfig) {
+  const extensions = new Set(["ms-azuretools.vscode-docker"]);
+
+  if (config.ecosystem === "typescript") {
+    extensions.add("dbaeumer.vscode-eslint");
+    extensions.add("esbenp.prettier-vscode");
+
+    if (config.cssFramework === "tailwind") {
+      extensions.add("bradlc.vscode-tailwindcss");
+    }
+    if (config.orm === "prisma") {
+      extensions.add("Prisma.prisma");
+    }
+  }
+
+  if (config.ecosystem === "rust") {
+    extensions.add("rust-lang.rust-analyzer");
+  }
+
+  if (config.ecosystem === "python") {
+    extensions.add("ms-python.python");
+    extensions.add("ms-python.vscode-pylance");
+  }
+
+  if (config.ecosystem === "go") {
+    extensions.add("golang.go");
+  }
+
+  if (config.ecosystem === "java") {
+    extensions.add("vscjava.vscode-java-pack");
+  }
+
+  return [...extensions];
+}
+
+function getDevcontainerForwardPorts(config: ProjectConfig) {
+  const ports = new Set<number>();
+
+  if (config.ecosystem === "typescript") {
+    ports.add(3001);
+    if (config.backend !== "self" && config.backend !== "none") {
+      ports.add(3000);
+    }
+    addDatabasePorts(config, ports);
+  } else if (config.ecosystem === "python") {
+    ports.add(8000);
+    if (config.database === "postgres" && config.pythonOrm !== "none") {
+      ports.add(5432);
+    }
+  } else if (config.ecosystem === "go") {
+    ports.add(8080);
+    if (config.goOrm !== "none") {
+      ports.add(5432);
+    }
+  } else if (config.ecosystem === "rust") {
+    ports.add(3000);
+    if (config.rustApi === "tonic") {
+      ports.add(50051);
+    }
+    if (config.rustOrm !== "none") {
+      ports.add(5432);
+    }
+  } else if (config.ecosystem === "java") {
+    ports.add(8080);
+  }
+
+  return [...ports];
+}
+
+function getDevcontainerRunServices(config: ProjectConfig) {
+  const services = new Set<string>(["devcontainer"]);
+
+  if (config.ecosystem === "typescript") {
+    services.add("web");
+    if (config.backend !== "self" && config.backend !== "none") {
+      services.add("server");
+    }
+    if (["postgres", "mysql", "mongodb"].includes(config.database)) {
+      services.add("db");
+    }
+  } else {
+    services.add("app");
+    if (
+      (config.ecosystem === "python" &&
+        config.database === "postgres" &&
+        config.pythonOrm !== "none") ||
+      (config.ecosystem === "go" && config.goOrm !== "none") ||
+      (config.ecosystem === "rust" && config.rustOrm !== "none")
+    ) {
+      services.add("db");
+    }
+  }
+
+  return [...services];
+}
+
+function getDevcontainerImage(config: ProjectConfig) {
+  if (config.ecosystem === "python") {
+    return "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm";
+  }
+  if (config.ecosystem === "go") {
+    return "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm";
+  }
+  if (config.ecosystem === "rust") {
+    return "mcr.microsoft.com/devcontainers/rust:1-1-bookworm";
+  }
+  if (config.ecosystem === "java") {
+    return "mcr.microsoft.com/devcontainers/java:1-21-bookworm";
+  }
+  if (config.ecosystem === "typescript" && config.packageManager === "bun") {
+    return "oven/bun:1";
+  }
+  return "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm";
+}
+
+function getTypeScriptPostCreateCommand(packageManager: ProjectConfig["packageManager"]) {
+  if (packageManager === "bun") {
+    return "bun install && bun run --if-present db:push";
+  }
+  if (packageManager === "pnpm") {
+    return "corepack enable && pnpm install && pnpm run --if-present db:push";
+  }
+  if (packageManager === "yarn") {
+    return "corepack enable && yarn install && if node -e \"process.exit(require('./package.json').scripts?.['db:push'] ? 0 : 1)\"; then yarn run db:push; fi";
+  }
+  return "npm install && npm run db:push --if-present";
+}
+
+function getDevcontainerPostCreateCommand(config: ProjectConfig) {
+  if (config.ecosystem === "typescript") {
+    return getTypeScriptPostCreateCommand(config.packageManager);
+  }
+  if (config.ecosystem === "python") {
+    return "python -m pip install -e '.[dev]'";
+  }
+  if (config.ecosystem === "go") {
+    return "go mod download";
+  }
+  if (config.ecosystem === "rust") {
+    return "cargo fetch";
+  }
+  if (config.ecosystem === "java") {
+    return config.javaBuildTool === "gradle"
+      ? "./gradlew dependencies"
+      : "./mvnw -DskipTests dependency:go-offline";
+  }
+  return "";
+}
+
+Handlebars.registerHelper("devcontainerExtensions", function (this: ProjectConfig) {
+  return jsonHelper(getDevcontainerExtensions(this));
+});
+
+Handlebars.registerHelper("devcontainerForwardPorts", function (this: ProjectConfig) {
+  return jsonHelper(getDevcontainerForwardPorts(this));
+});
+
+Handlebars.registerHelper("devcontainerRunServices", function (this: ProjectConfig) {
+  return jsonHelper(getDevcontainerRunServices(this));
+});
+
+Handlebars.registerHelper("devcontainerImage", function (this: ProjectConfig) {
+  return getDevcontainerImage(this);
+});
+
+Handlebars.registerHelper("devcontainerPostCreateCommand", function (this: ProjectConfig) {
+  return jsonHelper(getDevcontainerPostCreateCommand(this));
 });
 
 export function normalizeElixirAppName(projectName?: string): string {

--- a/packages/template-generator/src/core/template-processor.ts
+++ b/packages/template-generator/src/core/template-processor.ts
@@ -207,15 +207,15 @@ function getDevcontainerImage(config: ProjectConfig) {
 
 function getTypeScriptPostCreateCommand(packageManager: ProjectConfig["packageManager"]) {
   if (packageManager === "bun") {
-    return "bun install && bun run --if-present db:push";
+    return "bun install";
   }
   if (packageManager === "pnpm") {
-    return "corepack enable && pnpm install && pnpm run --if-present db:push";
+    return "corepack enable && pnpm install";
   }
   if (packageManager === "yarn") {
-    return "corepack enable && yarn install && if node -e \"process.exit(require('./package.json').scripts?.['db:push'] ? 0 : 1)\"; then yarn run db:push; fi";
+    return "corepack enable && yarn install";
   }
-  return "npm install && npm run db:push --if-present";
+  return "npm install";
 }
 
 function getDevcontainerPostCreateCommand(config: ProjectConfig) {

--- a/packages/template-generator/src/template-handlers/addons.ts
+++ b/packages/template-generator/src/template-handlers/addons.ts
@@ -1,8 +1,112 @@
 import { isBackendUtilsCompatibleBackend, type ProjectConfig } from "@better-fullstack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
-
 import { type TemplateData, processSingleTemplate, processTemplatesFromPrefix } from "./utils";
+
+function processDockerComposeTemplates(
+  vfs: VirtualFileSystem,
+  templates: TemplateData,
+  config: ProjectConfig,
+): void {
+  if (config.ecosystem !== "typescript") {
+    processSingleTemplate(
+      vfs,
+      templates,
+      "addons/docker-compose/.dockerignore",
+      ".dockerignore",
+      config,
+    );
+    processSingleTemplate(
+      vfs,
+      templates,
+      "addons/docker-compose/docker-compose.yml",
+      "docker-compose.yml",
+      config,
+    );
+    processSingleTemplate(
+      vfs,
+      templates,
+      `addons/docker-compose/${config.ecosystem}/Dockerfile`,
+      "Dockerfile",
+      config,
+    );
+    return;
+  }
+
+  // Place docker-compose.yml at project root
+  processTemplatesFromPrefix(vfs, templates, "addons/docker-compose", "", config, [
+    "addons/docker-compose/apps/server",
+    "addons/docker-compose/apps/web",
+    "addons/docker-compose/go",
+    "addons/docker-compose/java",
+    "addons/docker-compose/python",
+    "addons/docker-compose/rust",
+  ]);
+
+  // Place server Dockerfile if backend exists
+  if (config.backend !== "self" && config.backend !== "none") {
+    processTemplatesFromPrefix(
+      vfs,
+      templates,
+      "addons/docker-compose/apps/server",
+      "apps/server",
+      config,
+    );
+  }
+
+  // Place web Dockerfile based on frontend
+  if (config.frontend.includes("next") || config.frontend.includes("vinext")) {
+    processSingleTemplate(
+      vfs,
+      templates,
+      "addons/docker-compose/apps/web/.dockerignore",
+      "apps/web/.dockerignore",
+      config,
+    );
+    processSingleTemplate(
+      vfs,
+      templates,
+      "addons/docker-compose/apps/web/Dockerfile.next",
+      "apps/web/Dockerfile.next",
+      config,
+    );
+  } else if (
+    config.frontend.some((f) =>
+      ["tanstack-router", "react-router", "react-vite", "solid", "astro"].includes(f),
+    )
+  ) {
+    processSingleTemplate(
+      vfs,
+      templates,
+      "addons/docker-compose/apps/web/.dockerignore",
+      "apps/web/.dockerignore",
+      config,
+    );
+    processSingleTemplate(
+      vfs,
+      templates,
+      "addons/docker-compose/apps/web/Dockerfile.vite",
+      "apps/web/Dockerfile.vite",
+      config,
+    );
+    processSingleTemplate(
+      vfs,
+      templates,
+      "addons/docker-compose/apps/web/nginx.conf",
+      "apps/web/nginx.conf",
+      config,
+    );
+  }
+}
+
+function processDevcontainerTemplates(
+  vfs: VirtualFileSystem,
+  templates: TemplateData,
+  config: ProjectConfig,
+): void {
+  processDockerComposeTemplates(vfs, templates, config);
+  processTemplatesFromPrefix(vfs, templates, "addons/devcontainer", "", config);
+}
 
 export async function processAddonTemplates(
   vfs: VirtualFileSystem,
@@ -75,101 +179,12 @@ export async function processAddonTemplates(
     }
 
     if (addon === "docker-compose") {
-      if (config.ecosystem !== "typescript") {
-        processSingleTemplate(
-          vfs,
-          templates,
-          "addons/docker-compose/.dockerignore",
-          ".dockerignore",
-          config,
-        );
-        processSingleTemplate(
-          vfs,
-          templates,
-          "addons/docker-compose/docker-compose.yml",
-          "docker-compose.yml",
-          config,
-        );
-        processSingleTemplate(
-          vfs,
-          templates,
-          `addons/docker-compose/${config.ecosystem}/Dockerfile`,
-          "Dockerfile",
-          config,
-        );
-        continue;
-      }
+      processDockerComposeTemplates(vfs, templates, config);
+      continue;
+    }
 
-      // Place docker-compose.yml at project root
-      processTemplatesFromPrefix(vfs, templates, "addons/docker-compose", "", config, [
-        "addons/docker-compose/apps/server",
-        "addons/docker-compose/apps/web",
-        "addons/docker-compose/go",
-        "addons/docker-compose/java",
-        "addons/docker-compose/python",
-        "addons/docker-compose/rust",
-      ]);
-
-      // Place server Dockerfile if backend exists
-      if (config.backend !== "self" && config.backend !== "none") {
-        processTemplatesFromPrefix(
-          vfs,
-          templates,
-          "addons/docker-compose/apps/server",
-          "apps/server",
-          config,
-        );
-      }
-
-      // Place web Dockerfile based on frontend
-      if (config.frontend.includes("next") || config.frontend.includes("vinext")) {
-        processSingleTemplate(
-          vfs,
-          templates,
-          "addons/docker-compose/apps/web/.dockerignore",
-          "apps/web/.dockerignore",
-          config,
-        );
-        processSingleTemplate(
-          vfs,
-          templates,
-          "addons/docker-compose/apps/web/Dockerfile.next",
-          "apps/web/Dockerfile.next",
-          config,
-        );
-      } else if (
-        config.frontend.some((f) =>
-          [
-            "tanstack-router",
-            "react-router",
-            "react-vite",
-            "solid",
-            "astro",
-          ].includes(f),
-        )
-      ) {
-        processSingleTemplate(
-          vfs,
-          templates,
-          "addons/docker-compose/apps/web/.dockerignore",
-          "apps/web/.dockerignore",
-          config,
-        );
-        processSingleTemplate(
-          vfs,
-          templates,
-          "addons/docker-compose/apps/web/Dockerfile.vite",
-          "apps/web/Dockerfile.vite",
-          config,
-        );
-        processSingleTemplate(
-          vfs,
-          templates,
-          "addons/docker-compose/apps/web/nginx.conf",
-          "apps/web/nginx.conf",
-          config,
-        );
-      }
+    if (addon === "devcontainer") {
+      processDevcontainerTemplates(vfs, templates, config);
       continue;
     }
 

--- a/packages/template-generator/templates/addons/devcontainer/.devcontainer/devcontainer.json.hbs
+++ b/packages/template-generator/templates/addons/devcontainer/.devcontainer/devcontainer.json.hbs
@@ -1,0 +1,17 @@
+{
+  "name": "{{projectName}}",
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "docker-compose.devcontainer.yml"
+  ],
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/{{projectName}}",
+  "runServices": {{devcontainerRunServices}},
+  "forwardPorts": {{devcontainerForwardPorts}},
+  "postCreateCommand": {{devcontainerPostCreateCommand}},
+  "customizations": {
+    "vscode": {
+      "extensions": {{devcontainerExtensions}}
+    }
+  }
+}

--- a/packages/template-generator/templates/addons/devcontainer/.devcontainer/docker-compose.devcontainer.yml.hbs
+++ b/packages/template-generator/templates/addons/devcontainer/.devcontainer/docker-compose.devcontainer.yml.hbs
@@ -6,4 +6,4 @@ services:
     environment:
       DEVCONTAINER: "true"
     volumes:
-      - ..:/workspaces/{{projectName}}:cached
+      - .:/workspaces/{{projectName}}:cached

--- a/packages/template-generator/templates/addons/devcontainer/.devcontainer/docker-compose.devcontainer.yml.hbs
+++ b/packages/template-generator/templates/addons/devcontainer/.devcontainer/docker-compose.devcontainer.yml.hbs
@@ -1,0 +1,9 @@
+services:
+  devcontainer:
+    image: "{{devcontainerImage}}"
+    command: sleep infinity
+    init: true
+    environment:
+      DEVCONTAINER: "true"
+    volumes:
+      - ..:/workspaces/{{projectName}}:cached

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -2075,31 +2075,36 @@ export const getDisabledReason = (
     if (optionId === "tauri" && !hasTauriCompatibleFrontend(currentStack.webFrontend)) {
       return "Tauri requires TanStack Router, React Router, Nuxt, Svelte, Solid, Next.js, or Astro";
     }
-    if (optionId === "docker-compose") {
+    if (optionId === "docker-compose" || optionId === "devcontainer") {
+      const title = optionId === "devcontainer" ? "DevContainer" : "Docker Compose";
+
       if (currentStack.backend === "convex") {
-        return "Docker Compose is not compatible with Convex backend (managed service)";
+        return `${title} is not compatible with Convex backend (managed service)`;
       }
       if (currentStack.runtime === "workers") {
-        return "Docker Compose is not compatible with Cloudflare Workers runtime";
+        return `${title} is not compatible with Cloudflare Workers runtime`;
+      }
+      if (!["typescript", "python", "go", "rust", "java"].includes(currentStack.ecosystem)) {
+        return `${title} currently supports TypeScript, Python, Go, Rust, or Java projects`;
       }
       if (
         currentStack.ecosystem === "typescript" &&
         !hasDockerComposeCompatibleFrontend(currentStack.webFrontend)
       ) {
-        return "Docker Compose currently supports Next.js, TanStack Router, React Router, React Vite, Solid, or Astro";
+        return `${title} currently supports Next.js, TanStack Router, React Router, React Vite, Solid, or Astro`;
       }
       if (
         currentStack.ecosystem === "typescript" &&
         currentStack.backend === "self" &&
         !currentStack.webFrontend.includes("next")
       ) {
-        return "Docker Compose self-backend support currently requires Next.js";
+        return `${title} self-backend support currently requires Next.js`;
       }
       if (currentStack.ecosystem === "rust" && currentStack.rustFrontend !== "none") {
-        return "Docker Compose for Rust currently supports server-only projects";
+        return `${title} for Rust currently supports server-only projects`;
       }
       if (currentStack.ecosystem === "java" && currentStack.javaWebFramework !== "spring-boot") {
-        return "Docker Compose for Java currently requires Spring Boot";
+        return `${title} for Java currently requires Spring Boot`;
       }
       if (
         currentStack.ecosystem === "python" &&
@@ -2107,7 +2112,7 @@ export const getDisabledReason = (
         currentStack.database !== "sqlite" &&
         currentStack.database !== "postgres"
       ) {
-        return "Docker Compose for Python ORM projects currently supports SQLite defaults or Postgres";
+        return `${title} for Python ORM projects currently supports SQLite defaults or Postgres`;
       }
     }
     if (optionId === "backend-utils") {
@@ -3219,6 +3224,7 @@ const ADDON_COMPATIBILITY: Record<Addons, readonly Frontend[]> = {
   ],
   "backend-utils": [],
   "docker-compose": [],
+  devcontainer: [],
   none: [],
 };
 

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -692,6 +692,7 @@ const APP_PLATFORM_VALUES = [
   "tanstack-db",
   "tanstack-pacer",
   "backend-utils",
+  "devcontainer",
   "docker-compose",
 ] as const satisfies readonly string[];
 
@@ -1073,6 +1074,7 @@ const EXACT_LABEL_OVERRIDES: Partial<Record<OptionCategory, Partial<Record<strin
     "tanstack-virtual": "TanStack Virtual",
     "tanstack-db": "TanStack DB",
     "tanstack-pacer": "TanStack Pacer",
+    devcontainer: "DevContainer",
     "docker-compose": "Docker Compose",
   },
   versionChannel: {

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -164,6 +164,7 @@ export const AddonsSchema = z
     "tanstack-db",
     "tanstack-pacer",
     "backend-utils",
+    "devcontainer",
     "docker-compose",
     "none",
   ])

--- a/packages/types/src/stack-graph.ts
+++ b/packages/types/src/stack-graph.ts
@@ -338,6 +338,7 @@ const WORKSPACE_TOOLING_ADDONS = new Set([
   "turborepo",
   "nx",
   "docker-compose",
+  "devcontainer",
   "ruler",
   "mcp",
   "skills",
@@ -1488,14 +1489,16 @@ function createAddonCompatibilityIssue(
   }
 
   if (part.role === "workspaceTooling") {
-    if (part.toolId === "docker-compose") {
+    if (part.toolId === "docker-compose" || part.toolId === "devcontainer") {
+      const title = part.toolId === "devcontainer" ? "DevContainer" : "Docker Compose";
+
       if (backendTool === "convex") {
         return createStackGraphIssue({
           code: "INCOMPATIBLE_GRAPH_SELECTION",
           partId: part.id,
           role: part.role,
           toolId: part.toolId,
-          message: "Docker Compose is not compatible with Convex backend.",
+          message: `${title} is not compatible with Convex backend.`,
         });
       }
       if (runtimeTool === "workers") {
@@ -1504,7 +1507,7 @@ function createAddonCompatibilityIssue(
           partId: part.id,
           role: part.role,
           toolId: part.toolId,
-          message: "Docker Compose is not compatible with Cloudflare Workers runtime.",
+          message: `${title} is not compatible with Cloudflare Workers runtime.`,
         });
       }
       if (
@@ -1517,7 +1520,7 @@ function createAddonCompatibilityIssue(
           partId: part.id,
           role: part.role,
           toolId: part.toolId,
-          message: "Docker Compose is not wired for the selected web frontend.",
+          message: `${title} is not wired for the selected web frontend.`,
         });
       }
       if (backendEcosystem === "typescript" && backendTool === "self" && frontendTool !== "next") {
@@ -1526,7 +1529,7 @@ function createAddonCompatibilityIssue(
           partId: part.id,
           role: part.role,
           toolId: part.toolId,
-          message: "Docker Compose self-backend support currently requires Next.js.",
+          message: `${title} self-backend support currently requires Next.js.`,
         });
       }
     }

--- a/packages/types/src/stack-translation.ts
+++ b/packages/types/src/stack-translation.ts
@@ -938,6 +938,7 @@ const COMMAND_ADDONS = new Set([
   "turborepo",
   "nx",
   "docker-compose",
+  "devcontainer",
   "ultracite",
   "fumadocs",
   "oxlint",


### PR DESCRIPTION
## Summary
- Adds a `devcontainer` addon option for CLI and builder catalogs.
- Emits `.devcontainer/devcontainer.json` plus a Docker Compose override when selected.
- Reuses Docker Compose assets and fills VS Code extensions, forwarded ports, services, and post-create commands from the selected stack.

## Validation
- `git diff --check`
- `bun run --cwd packages/types build`
- `bun run --cwd packages/template-generator generate-templates`
- `bun run --cwd packages/template-generator build`
- `bun run --cwd apps/cli build`
- `bun test apps/cli/test/addons.test.ts --timeout 120000`
- `bun test apps/cli/test/cli-builder-sync.test.ts`
- `bun test packages/types/test/stack-translation.test.ts packages/types/test/stack-graph.test.ts packages/types/test/compatibility.test.ts`
- `bun run --cwd apps/web typecheck`
- `bun run test:release`
