### PR TITLE
Add Apollo Server API option

### DIFF
--- a/apps/cli/src/prompts/api.ts
+++ b/apps/cli/src/prompts/api.ts
@@ -31,6 +31,11 @@ const API_PROMPT_OPTION_MAP: Record<API, PromptOption<API>> = {
     label: "GraphQL Yoga",
     hint: "Batteries-included GraphQL server with Pothos schema builder",
   },
+  "apollo-server": {
+    value: "apollo-server",
+    label: "Apollo Server",
+    hint: "Spec-compliant GraphQL server with a schema-first starter",
+  },
   openapi: {
     value: "openapi",
     label: "OpenAPI",

--- a/apps/cli/src/utils/config-validation.ts
+++ b/apps/cli/src/utils/config-validation.ts
@@ -663,15 +663,17 @@ function validateFrontendConstraints(
 }
 
 function validateApiConstraints(config: Partial<ProjectConfig>, _options: CLIInput) {
-  if (config.api !== "openapi") return;
+  if (config.api !== "openapi" && config.api !== "apollo-server") return;
+
+  const apiDisplayName = config.api === "apollo-server" ? "Apollo Server" : "OpenAPI";
 
   const frontend = config.frontend ?? [];
   if (
     frontend.some((item) => ["native-bare", "native-uniwind", "native-unistyles"].includes(item))
   ) {
     incompatibilityError({
-      message: "OpenAPI is currently available for web frontends, not React Native.",
-      provided: { api: "openapi", frontend },
+      message: `${apiDisplayName} is currently available for web frontends, not React Native.`,
+      provided: { api: config.api, frontend },
       suggestions: ["Use --api trpc", "Use --api orpc", "Use a web frontend"],
     });
   }
@@ -679,8 +681,8 @@ function validateApiConstraints(config: Partial<ProjectConfig>, _options: CLIInp
   const supportedBackends = ["hono", "express", "fastify", "elysia"];
   if (!config.backend || !supportedBackends.includes(config.backend)) {
     incompatibilityError({
-      message: "OpenAPI currently supports Hono, Express, Fastify, and Elysia backends.",
-      provided: { api: "openapi", backend: config.backend ?? "none" },
+      message: `${apiDisplayName} currently supports Hono, Express, Fastify, and Elysia backends.`,
+      provided: { api: config.api, backend: config.backend ?? "none" },
       suggestions: [
         "Use --backend hono",
         "Use --backend express",

--- a/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
+++ b/apps/cli/test/__snapshots__/template-snapshots.test.ts.snap
@@ -379,6 +379,69 @@ exports[`Template Snapshots File Structure Snapshots file structure: hono-openap
 ]
 `;
 
+exports[`Template Snapshots File Structure Snapshots file structure: hono-apollo-server 1`] = `
+[
+  "CLAUDE.md",
+  "README.md",
+  "apps/server/.env",
+  "apps/server/package.json",
+  "apps/server/src/index.ts",
+  "apps/server/tsconfig.json",
+  "apps/server/tsdown.config.ts",
+  "apps/web/.env",
+  "apps/web/index.html",
+  "apps/web/package.json",
+  "apps/web/src/components/header.tsx",
+  "apps/web/src/components/loader.tsx",
+  "apps/web/src/components/mode-toggle.tsx",
+  "apps/web/src/components/sign-in-form.tsx",
+  "apps/web/src/components/sign-up-form.tsx",
+  "apps/web/src/components/theme-provider.tsx",
+  "apps/web/src/components/ui/button.tsx",
+  "apps/web/src/components/ui/card.tsx",
+  "apps/web/src/components/ui/checkbox.tsx",
+  "apps/web/src/components/ui/dropdown-menu.tsx",
+  "apps/web/src/components/ui/input.tsx",
+  "apps/web/src/components/ui/label.tsx",
+  "apps/web/src/components/ui/skeleton.tsx",
+  "apps/web/src/components/ui/sonner.tsx",
+  "apps/web/src/components/user-menu.tsx",
+  "apps/web/src/index.css",
+  "apps/web/src/lib/auth-client.ts",
+  "apps/web/src/lib/utils.ts",
+  "apps/web/src/main.tsx",
+  "apps/web/src/routes/__root.tsx",
+  "apps/web/src/routes/dashboard.tsx",
+  "apps/web/src/routes/index.tsx",
+  "apps/web/src/routes/login.tsx",
+  "apps/web/src/utils/graphql.ts",
+  "apps/web/tsconfig.json",
+  "apps/web/vite.config.ts",
+  "bunfig.toml",
+  "package.json",
+  "packages/api/package.json",
+  "packages/api/src/index.ts",
+  "packages/api/tsconfig.json",
+  "packages/auth/package.json",
+  "packages/auth/src/index.ts",
+  "packages/auth/tsconfig.json",
+  "packages/config/package.json",
+  "packages/config/tsconfig.base.json",
+  "packages/db/drizzle.config.ts",
+  "packages/db/package.json",
+  "packages/db/src/index.ts",
+  "packages/db/src/schema/auth.ts",
+  "packages/db/src/schema/index.ts",
+  "packages/db/tsconfig.json",
+  "packages/env/package.json",
+  "packages/env/src/native.ts",
+  "packages/env/src/server.ts",
+  "packages/env/src/web.ts",
+  "packages/env/tsconfig.json",
+  "tsconfig.json",
+]
+`;
+
 exports[`Template Snapshots File Structure Snapshots file structure: better-auth-full 1`] = `
 [
   "CLAUDE.md",
@@ -6374,6 +6437,1085 @@ export const accountRelations = relations(account, ({ one }) => ({
       "content": 
 "{
   "extends": "@snapshot-hono-openapi/config/tsconfig.base.json",
+}
+"
+,
+      "path": "tsconfig.json",
+    },
+  ],
+}
+`;
+
+exports[`Template Snapshots Key File Content Snapshots key files: hono-apollo-server 1`] = `
+{
+  "fileCount": 64,
+  "files": [
+    {
+      "content": "[exists]",
+      "path": "apps/server/.env",
+    },
+    {
+      "content": 
+"{
+  "name": "server",
+  "main": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsdown",
+    "check-types": "tsc -b",
+    "compile": "bun build --compile --minify --sourcemap --bytecode ./src/index.ts --outfile server",
+    "dev": "bun run --hot src/index.ts",
+    "start": "bun run dist/index.js"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-hono-apollo-server/env": "workspace:*",
+    "@snapshot-hono-apollo-server/api": "workspace:*",
+    "@snapshot-hono-apollo-server/auth": "workspace:*",
+    "@snapshot-hono-apollo-server/db": "workspace:*",
+    "hono": "catalog:",
+    "better-auth": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "tsdown": "^0.22.2",
+    "@snapshot-hono-apollo-server/config": "workspace:*",
+    "@types/bun": "catalog:"
+  }
+}
+"
+,
+      "path": "apps/server/package.json",
+    },
+    {
+      "content": 
+"import { env } from "@snapshot-hono-apollo-server/env/server";
+import { executeApolloRequest } from "@snapshot-hono-apollo-server/api";
+import { auth } from "@snapshot-hono-apollo-server/auth";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { logger } from "hono/logger";
+
+const app = new Hono();
+
+app.use(logger());
+app.use(
+	"/*",
+	cors({
+		origin: env.CORS_ORIGIN,
+		allowMethods: ["GET", "POST", "OPTIONS"],
+		allowHeaders: ["Content-Type", "Authorization"],
+		credentials: true,
+	})
+);
+
+app.on(["POST", "GET"], "/api/auth/*", (c) => auth.handler(c.req.raw));
+
+
+app.on(["GET", "POST"], "/graphql", async (c) => {
+	const session = await auth.api.getSession({
+		headers: c.req.raw.headers,
+	});
+	return executeApolloRequest(c.req.raw, { session });
+});
+
+
+
+app.get("/", (c) => {
+	return c.text("OK");
+});
+
+export default app;
+"
+,
+      "path": "apps/server/src/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-hono-apollo-server/config/tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+		"outDir": "dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  }
+}
+"
+,
+      "path": "apps/server/tsconfig.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/server/tsdown.config.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/.env",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/index.html",
+    },
+    {
+      "content": 
+"{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "serve": "vite preview",
+    "start": "vite",
+    "check-types": "tsr generate && tsc --noEmit"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.5.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "next-themes": "^0.4.6",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.6.0",
+    "@tailwindcss/vite": "^4.3.1",
+    "tw-animate-css": "^1.4.0",
+    "@tanstack/react-router": "^1.170.15",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-hono-apollo-server/env": "workspace:*",
+    "@snapshot-hono-apollo-server/api": "workspace:*",
+    "@snapshot-hono-apollo-server/auth": "workspace:*",
+    "@libsql/client": "catalog:",
+    "libsql": "catalog:",
+    "@tanstack/react-query": "^5.101.0",
+    "better-auth": "catalog:",
+    "@tanstack/react-form": "^1.33.0",
+    "lucide-react": "^1.18.0"
+  },
+  "devDependencies": {
+    "@tanstack/react-router-devtools": "^1.167.0",
+    "@tanstack/router-cli": "^1.167.17",
+    "@tanstack/router-plugin": "^1.168.18",
+    "@types/node": "^25.9.3",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "postcss": "^8.5.15",
+    "tailwindcss": "^4.3.1",
+    "vite": "^8.0.16",
+    "typescript": "catalog:",
+    "@snapshot-hono-apollo-server/config": "workspace:*",
+    "@tanstack/react-query-devtools": "^5.101.0"
+  }
+}
+"
+,
+      "path": "apps/web/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/header.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/loader.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/mode-toggle.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/sign-in-form.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/sign-up-form.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/theme-provider.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/button.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/card.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/checkbox.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/dropdown-menu.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/input.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/label.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/skeleton.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/ui/sonner.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/components/user-menu.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/index.css",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/lib/auth-client.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/lib/utils.ts",
+    },
+    {
+      "content": 
+"import { RouterProvider, createRouter } from "@tanstack/react-router";
+import ReactDOM from "react-dom/client";
+import Loader from "./components/loader";
+import { routeTree } from "./routeTree.gen";
+
+  import { QueryClientProvider } from "@tanstack/react-query";
+  import { queryClient } from "./utils/graphql";
+
+const router = createRouter({
+  routeTree,
+  defaultPreload: "intent",
+  defaultPendingComponent: () => <Loader />,
+  context: { queryClient },
+  Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  },
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+const rootElement = document.getElementById("app");
+
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+
+if (!rootElement.innerHTML) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<RouterProvider router={router} />);
+}
+"
+,
+      "path": "apps/web/src/main.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/routes/__root.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/routes/dashboard.tsx",
+    },
+    {
+      "content": 
+"import { createFileRoute } from "@tanstack/react-router";
+import { graphqlFetch } from "@/utils/graphql";
+import { useQuery } from "@tanstack/react-query";
+
+export const Route = createFileRoute("/")({
+  component: HomeComponent,
+});
+
+const TITLE_TEXT = \`
+ ██████╗ ███████╗████████╗████████╗███████╗██████╗
+ ██╔══██╗██╔════╝╚══██╔══╝╚══██╔══╝██╔════╝██╔══██╗
+ ██████╔╝█████╗     ██║      ██║   █████╗  ██████╔╝
+ ██╔══██╗██╔══╝     ██║      ██║   ██╔══╝  ██╔══██╗
+ ██████╔╝███████╗   ██║      ██║   ███████╗██║  ██║
+ ╚═════╝ ╚══════╝   ╚═╝      ╚═╝   ╚══════╝╚═╝  ╚═╝
+
+ ████████╗    ███████╗████████╗ █████╗  ██████╗██╗  ██╗
+ ╚══██╔══╝    ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝
+    ██║       ███████╗   ██║   ███████║██║     █████╔╝
+    ██║       ╚════██║   ██║   ██╔══██║██║     ██╔═██╗
+    ██║       ███████║   ██║   ██║  ██║╚██████╗██║  ██╗
+    ╚═╝       ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝
+ \`;
+
+function HomeComponent() {
+  const healthCheck = useQuery({
+    queryKey: ["healthCheck"],
+    queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),
+  });
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-2">
+      <pre className="overflow-x-auto font-mono text-sm">{TITLE_TEXT}</pre>
+      <div className="grid gap-6">
+        <section className="rounded-lg border p-4">
+          <h2 className="mb-2 font-medium">API Status</h2>
+            <div className="flex items-center gap-2">
+              <div
+                className={\`h-2 w-2 rounded-full \${healthCheck.data ? "bg-green-500" : "bg-red-500"}\`}
+              />
+              <span className="text-sm text-muted-foreground">
+                {healthCheck.isLoading
+                  ? "Checking..."
+                  : healthCheck.data
+                    ? "Connected"
+                    : "Disconnected"}
+              </span>
+            </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+"
+,
+      "path": "apps/web/src/routes/index.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/routes/login.tsx",
+    },
+    {
+      "content": "[exists]",
+      "path": "apps/web/src/utils/graphql.ts",
+    },
+    {
+      "content": 
+"{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "rootDirs": ["."],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+"
+,
+      "path": "apps/web/tsconfig.json",
+    },
+    {
+      "content": 
+"import tailwindcss from "@tailwindcss/vite";
+import { tanstackRouter } from "@tanstack/router-plugin/vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    tailwindcss(),
+    tanstackRouter({}),
+    react(),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 3001,
+  },
+});
+"
+,
+      "path": "apps/web/vite.config.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "bunfig.toml",
+    },
+    {
+      "content": "[exists]",
+      "path": "CLAUDE.md",
+    },
+    {
+      "content": 
+"{
+  "name": "snapshot-hono-apollo-server",
+  "private": true,
+  "type": "module",
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "packages/*"
+    ],
+    "catalog": {
+      "dotenv": "^17.4.2",
+      "zod": "^4.4.3",
+      "typescript": "^6.0.3",
+      "@types/bun": "^1.3.14",
+      "hono": "^4.12.25",
+      "better-auth": "^1.6.18",
+      "@libsql/client": "^0.17.3",
+      "libsql": "^0.5.29"
+    }
+  },
+  "scripts": {
+    "dev": "bun run --filter '*' dev",
+    "build": "bun run --filter '*' build",
+    "check-types": "bun run --if-present --filter '*' check-types",
+    "dev:web": "bun run --filter web dev",
+    "dev:server": "bun run --filter server dev",
+    "db:push": "bun run --filter @snapshot-hono-apollo-server/db db:push",
+    "db:studio": "bun run --filter @snapshot-hono-apollo-server/db db:studio",
+    "db:generate": "bun run --filter @snapshot-hono-apollo-server/db db:generate",
+    "db:migrate": "bun run --filter @snapshot-hono-apollo-server/db db:migrate",
+    "db:local": "bun run --filter @snapshot-hono-apollo-server/db db:local"
+  },
+  "packageManager": "bun@1.3.5",
+  "overrides": {
+    "kysely": "0.28.17"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-hono-apollo-server/env": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@types/bun": "catalog:",
+    "@snapshot-hono-apollo-server/config": "workspace:*"
+  }
+}
+"
+,
+      "path": "package.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-hono-apollo-server/api",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "type": "module",
+  "scripts": {},
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@snapshot-hono-apollo-server/config": "workspace:*"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-hono-apollo-server/env": "workspace:*",
+    "@snapshot-hono-apollo-server/auth": "workspace:*",
+    "@snapshot-hono-apollo-server/db": "workspace:*",
+    "@apollo/server": "^5.5.1",
+    "graphql": "^16.14.2",
+    "better-auth": "catalog:",
+    "hono": "catalog:"
+  }
+}
+"
+,
+      "path": "packages/api/package.json",
+    },
+    {
+      "content": 
+"import { ApolloServer, HeaderMap } from "@apollo/server";
+import type { HTTPGraphQLRequest } from "@apollo/server";
+import type { Session, User } from "better-auth";
+
+type AuthSession = { user: User; session: Session } | null;
+
+export type ApolloContext = {
+	session: AuthSession;
+};
+
+export const typeDefs = \`#graphql
+	type Query {
+		health: String!
+		me: User
+	}
+
+	type User {
+		id: ID!
+		email: String!
+		name: String
+	}
+
+	type Mutation {
+		_empty: String
+	}
+\`;
+
+export const resolvers = {
+	Query: {
+		health: () => "OK",
+		me: (_parent: unknown, _args: unknown, context: ApolloContext) => {
+			if (!context.session) return null;
+			return {
+				id: context.session.user.id,
+				email: context.session.user.email,
+				name: context.session.user.name,
+			};
+		},
+	},
+	Mutation: {
+		_empty: () => null,
+	},
+};
+
+export const apolloServer = new ApolloServer<ApolloContext>({
+	typeDefs,
+	resolvers,
+});
+
+let apolloStartPromise: Promise<void> | undefined;
+
+async function ensureApolloStarted() {
+	apolloStartPromise ??= apolloServer.start();
+	await apolloStartPromise;
+}
+
+async function parseRequestBody(request: Request) {
+	if (request.method === "GET" || request.method === "HEAD") return undefined;
+	if (!request.headers.get("content-type")?.includes("application/json")) return undefined;
+
+	const text = await request.text();
+	if (text.trim() === "") return undefined;
+
+	return JSON.parse(text) as unknown;
+}
+
+function getApolloHeaders(request: Request) {
+	const headers = new HeaderMap();
+	request.headers.forEach((value, key) => {
+		headers.set(key, value);
+	});
+	return headers;
+}
+
+function getResponseHeaders(headers: HeaderMap) {
+	const responseHeaders = new Headers();
+	for (const [key, value] of headers) {
+		responseHeaders.set(key, value);
+	}
+	return responseHeaders;
+}
+
+export async function executeApolloRequest(
+	request: Request,
+	context: ApolloContext = {
+		session: null,
+	},
+): Promise<Response> {
+	await ensureApolloStarted();
+
+	let body: unknown;
+	try {
+		body = await parseRequestBody(request);
+	} catch {
+		return Response.json({ errors: [{ message: "Invalid JSON request body" }] }, { status: 400 });
+	}
+
+	const url = new URL(request.url);
+	const httpGraphQLRequest: HTTPGraphQLRequest = {
+		method: request.method.toUpperCase(),
+		headers: getApolloHeaders(request),
+		search: url.search,
+		body,
+	};
+
+	const result = await apolloServer.executeHTTPGraphQLRequest({
+		httpGraphQLRequest,
+		context: async () => context,
+	});
+
+	const responseHeaders = getResponseHeaders(result.headers);
+	const status = result.status ?? 200;
+	const responseBody = result.body;
+
+	if (responseBody.kind === "complete") {
+		return new Response(responseBody.string, {
+			status,
+			headers: responseHeaders,
+		});
+	}
+
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		async start(controller) {
+			try {
+				for await (const chunk of responseBody.asyncIterator) {
+					controller.enqueue(encoder.encode(chunk));
+				}
+			} finally {
+				controller.close();
+			}
+		},
+	});
+
+	return new Response(stream, {
+		status,
+		headers: responseHeaders,
+	});
+}
+"
+,
+      "path": "packages/api/src/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-hono-apollo-server/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/api/tsconfig.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-hono-apollo-server/auth",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "type": "module",
+  "scripts": {},
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@snapshot-hono-apollo-server/config": "workspace:*"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-hono-apollo-server/env": "workspace:*",
+    "@snapshot-hono-apollo-server/db": "workspace:*",
+    "better-auth": "catalog:",
+    "@better-auth/drizzle-adapter": "^1.6.18"
+  }
+}
+"
+,
+      "path": "packages/auth/package.json",
+    },
+    {
+      "content": 
+"
+import { betterAuth } from "better-auth";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { env } from "@snapshot-hono-apollo-server/env/server";
+import { db } from "@snapshot-hono-apollo-server/db";
+import * as schema from "@snapshot-hono-apollo-server/db/schema/auth";
+
+
+export const auth = betterAuth({
+	database: drizzleAdapter(db, {
+
+provider: "sqlite",
+
+		schema: schema,
+	}),
+	trustedOrigins: [
+		env.CORS_ORIGIN,
+	],
+	emailAndPassword: {
+		enabled: true,
+	},
+	advanced: {
+		defaultCookieAttributes: {
+			sameSite: "none",
+			secure: true,
+			httpOnly: true,
+		},
+	},
+	plugins: [
+	],
+});
+
+
+
+
+"
+,
+      "path": "packages/auth/src/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-hono-apollo-server/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/auth/tsconfig.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-hono-apollo-server/config",
+  "version": "0.0.0",
+  "private": true
+}
+"
+,
+      "path": "packages/config/package.json",
+    },
+    {
+      "content": 
+"{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": [
+        "bun"
+
+    ]
+  }
+}
+"
+,
+      "path": "packages/config/tsconfig.base.json",
+    },
+    {
+      "content": 
+"import { defineConfig } from "drizzle-kit";
+import dotenv from "dotenv";
+
+dotenv.config({
+    path: "../../apps/server/.env",
+});
+
+export default defineConfig({
+  schema: "./src/schema",
+  out: "./src/migrations",
+  dialect: "turso",
+  dbCredentials: {
+    url: process.env.DATABASE_URL || "",
+  },
+});
+"
+,
+      "path": "packages/db/drizzle.config.ts",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-hono-apollo-server/db",
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "scripts": {
+    "db:local": "turso dev --db-file local.db",
+    "db:push": "drizzle-kit push",
+    "db:generate": "drizzle-kit generate",
+    "db:studio": "drizzle-kit studio",
+    "db:migrate": "drizzle-kit migrate"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@snapshot-hono-apollo-server/config": "workspace:*",
+    "drizzle-kit": "^0.31.10"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@snapshot-hono-apollo-server/env": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "@libsql/client": "catalog:",
+    "libsql": "catalog:"
+  }
+}
+"
+,
+      "path": "packages/db/package.json",
+    },
+    {
+      "content": 
+"import { env } from "@snapshot-hono-apollo-server/env/server";
+import * as schema from "./schema/index";
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+	url: env.DATABASE_URL,
+});
+
+export const db = drizzle({ client, schema });
+
+"
+,
+      "path": "packages/db/src/index.ts",
+    },
+    {
+      "content": 
+"import { relations, sql } from "drizzle-orm";
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+
+export const user = sqliteTable("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: integer("email_verified", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  image: text("image"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+});
+
+export const session = sqliteTable(
+  "session",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("session_userId_idx").on(table.userId)],
+);
+
+export const account = sqliteTable(
+  "account",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: integer("access_token_expires_at", {
+      mode: "timestamp_ms",
+    }),
+    refreshTokenExpiresAt: integer("refresh_token_expires_at", {
+      mode: "timestamp_ms",
+    }),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("account_userId_idx").on(table.userId)],
+);
+
+export const verification = sqliteTable(
+  "verification",
+  {
+    id: text("id").primaryKey(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .default(sql\`(cast(unixepoch('subsecond') * 1000 as integer))\`)
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("verification_identifier_idx").on(table.identifier)],
+);
+
+export const userRelations = relations(user, ({ many }) => ({
+  sessions: many(session),
+  accounts: many(account),
+}));
+
+export const sessionRelations = relations(session, ({ one }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+  }),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
+}));
+
+"
+,
+      "path": "packages/db/src/schema/auth.ts",
+    },
+    {
+      "content": 
+"export * from "./auth";
+"
+,
+      "path": "packages/db/src/schema/index.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-hono-apollo-server/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}
+"
+,
+      "path": "packages/db/tsconfig.json",
+    },
+    {
+      "content": 
+"{
+  "name": "@snapshot-hono-apollo-server/env",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./server": "./src/server.ts",
+    "./web": "./src/web.ts"
+  },
+  "dependencies": {
+    "dotenv": "catalog:",
+    "zod": "catalog:",
+    "@t3-oss/env-core": "^0.13.11"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@types/bun": "catalog:",
+    "@snapshot-hono-apollo-server/config": "workspace:*"
+  }
+}
+"
+,
+      "path": "packages/env/package.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/native.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/server.ts",
+    },
+    {
+      "content": "[exists]",
+      "path": "packages/env/src/web.ts",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-hono-apollo-server/config/tsconfig.base.json",
+}
+"
+,
+      "path": "packages/env/tsconfig.json",
+    },
+    {
+      "content": "[exists]",
+      "path": "README.md",
+    },
+    {
+      "content": 
+"{
+  "extends": "@snapshot-hono-apollo-server/config/tsconfig.base.json",
 }
 "
 ,

--- a/apps/cli/test/api.test.ts
+++ b/apps/cli/test/api.test.ts
@@ -960,7 +960,16 @@ describe("API Configurations", () => {
   });
 
   describe("All API Types", () => {
-    const apis = ["trpc", "orpc", "ts-rest", "garph", "graphql-yoga", "openapi", "none"];
+    const apis = [
+      "trpc",
+      "orpc",
+      "ts-rest",
+      "garph",
+      "graphql-yoga",
+      "apollo-server",
+      "openapi",
+      "none",
+    ];
 
     for (const api of apis) {
       it(`should work with ${api} API`, async () => {
@@ -995,6 +1004,119 @@ describe("API Configurations", () => {
         expectSuccess(result);
       });
     }
+  });
+
+  describe("Apollo Server API", () => {
+    const supportedBackends: Backend[] = ["hono", "express", "fastify", "elysia"];
+
+    for (const backend of supportedBackends) {
+      it(`should generate Apollo Server routes for ${backend}`, async () => {
+        const result = await runTRPCTest({
+          projectName: `apollo-server-${backend}`,
+          api: "apollo-server",
+          frontend: ["tanstack-router"],
+          backend,
+          runtime: backend === "elysia" ? "bun" : "node",
+          database: "sqlite",
+          orm: "drizzle",
+          auth: "none",
+          addons: ["none"],
+          examples: ["none"],
+          dbSetup: "none",
+          webDeploy: "none",
+          serverDeploy: "none",
+          install: false,
+        });
+
+        expectSuccess(result);
+        const projectDir = result.projectDir!;
+        const apiIndex = await readFile(`${projectDir}/packages/api/src/index.ts`, "utf-8");
+        const serverIndex = await readFile(`${projectDir}/apps/server/src/index.ts`, "utf-8");
+        const apiPackage = await readFile(`${projectDir}/packages/api/package.json`, "utf-8");
+        const webGraphql = await readFile(`${projectDir}/apps/web/src/utils/graphql.ts`, "utf-8");
+
+        expect(apiIndex).toContain('from "@apollo/server"');
+        expect(apiIndex).toContain("new ApolloServer");
+        expect(apiIndex).toContain("executeHTTPGraphQLRequest");
+        expect(apiIndex).toContain("health: () => \"OK\"");
+        expect(serverIndex).toContain('"/graphql"');
+        expect(serverIndex).toContain("executeApolloRequest");
+        expect(apiPackage).toContain('"@apollo/server"');
+        expect(apiPackage).toContain('"graphql"');
+        expect(webGraphql).toContain("/graphql");
+      });
+    }
+
+    it("should include Better Auth session context", async () => {
+      const result = await runTRPCTest({
+        projectName: "apollo-server-better-auth",
+        api: "apollo-server",
+        frontend: ["tanstack-router"],
+        backend: "hono",
+        runtime: "bun",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "better-auth",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        install: false,
+      });
+
+      expectSuccess(result);
+      const apiIndex = await readFile(`${result.projectDir}/packages/api/src/index.ts`, "utf-8");
+      const serverIndex = await readFile(`${result.projectDir}/apps/server/src/index.ts`, "utf-8");
+
+      expect(apiIndex).toContain("export type ApolloContext = {");
+      expect(apiIndex).toContain("session: AuthSession;");
+      expect(apiIndex).toContain("me: User");
+      expect(serverIndex).toContain("auth.api.getSession");
+      expect(serverIndex).toContain("executeApolloRequest(c.req.raw, { session })");
+    });
+
+    it("should reject Apollo Server for unsupported backends", async () => {
+      const result = await runTRPCTest({
+        projectName: "apollo-server-self-fail",
+        api: "apollo-server",
+        frontend: ["next"],
+        backend: "self",
+        runtime: "none",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        expectError: true,
+      });
+
+      expectError(result, "Apollo Server currently supports Hono, Express, Fastify, and Elysia backends");
+    });
+
+    it("should reject Apollo Server for non-React web frontends", async () => {
+      const result = await runTRPCTest({
+        projectName: "apollo-server-svelte-fail",
+        api: "apollo-server",
+        frontend: ["svelte"],
+        backend: "hono",
+        runtime: "bun",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        expectError: true,
+      });
+
+      expectError(result, "Apollo Server API requires React-based frontends");
+    });
   });
 
   describe("OpenAPI API", () => {

--- a/apps/cli/test/api.test.ts
+++ b/apps/cli/test/api.test.ts
@@ -1117,6 +1117,28 @@ describe("API Configurations", () => {
 
       expectError(result, "Apollo Server API requires React-based frontends");
     });
+
+    it("should reject Apollo Server for Astro without React integration", async () => {
+      const result = await runTRPCTest({
+        projectName: "apollo-server-astro-none-fail",
+        api: "apollo-server",
+        frontend: ["astro"],
+        astroIntegration: "none",
+        backend: "hono",
+        runtime: "bun",
+        database: "sqlite",
+        orm: "drizzle",
+        auth: "none",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+        expectError: true,
+      });
+
+      expectError(result, "Apollo Server API requires React integration with Astro");
+    });
   });
 
   describe("OpenAPI API", () => {

--- a/apps/cli/test/matrix/combination-generator.ts
+++ b/apps/cli/test/matrix/combination-generator.ts
@@ -117,9 +117,9 @@ const CONVEX_INCOMPATIBLE_FRONTENDS: readonly Frontend[] = [
 
 /**
  * Frontend-API compatibility rules
- * tRPC, ts-rest, garph require React-based frontends
+ * tRPC, ts-rest, garph, and Apollo Server require React-based frontends
  */
-const REACT_ONLY_APIS: readonly API[] = ["trpc", "ts-rest", "garph"];
+const REACT_ONLY_APIS: readonly API[] = ["trpc", "ts-rest", "garph", "apollo-server"];
 
 /**
  * React-based web frontends (support tRPC and other React-only APIs)
@@ -137,7 +137,7 @@ const REACT_WEB_FRONTENDS: readonly Frontend[] = [
 const NATIVE_FRONTENDS: readonly Frontend[] = ["native-bare", "native-uniwind", "native-unistyles"];
 
 /**
- * Frontends that only support oRPC (not tRPC/ts-rest/garph)
+ * Frontends that only support oRPC (not tRPC/ts-rest/garph/Apollo Server)
  */
 const ORPC_ONLY_FRONTENDS: readonly Frontend[] = ["nuxt", "svelte", "solid"];
 
@@ -218,7 +218,7 @@ export function isValidFrontendApi(
   // oRPC works with all frontends (except NO_API_FRONTENDS, handled above)
   if (api === "orpc") return true;
 
-  // tRPC, ts-rest, garph require React-based frontends
+  // tRPC, ts-rest, garph, and Apollo Server require React-based frontends
   if (REACT_ONLY_APIS.includes(api)) {
     // React web frontends support all APIs
     if (REACT_WEB_FRONTENDS.includes(frontend)) return true;
@@ -362,7 +362,7 @@ const ALL_ORMS: readonly ORM[] = [
   "none",
 ];
 
-const ALL_APIS: readonly API[] = ["trpc", "orpc", "ts-rest", "garph", "none"];
+const ALL_APIS: readonly API[] = ["trpc", "orpc", "ts-rest", "garph", "apollo-server", "none"];
 
 const ALL_AUTHS: readonly Auth[] = ["better-auth", "clerk", "nextauth", "none"];
 

--- a/apps/cli/test/template-snapshots.test.ts
+++ b/apps/cli/test/template-snapshots.test.ts
@@ -98,6 +98,18 @@ const SNAPSHOT_CONFIGS: Array<{
       auth: "better-auth",
     },
   },
+  {
+    name: "hono-apollo-server",
+    config: {
+      frontend: ["tanstack-router"],
+      backend: "hono",
+      runtime: "bun",
+      api: "apollo-server",
+      database: "sqlite",
+      orm: "drizzle",
+      auth: "better-auth",
+    },
+  },
 
   // === AUTH VARIATIONS ===
   {

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -69,6 +69,13 @@ export const TECH_OPTIONS: Record<
       color: "from-pink-500 to-rose-600",
     },
     {
+      id: "apollo-server",
+      name: "Apollo Server",
+      description: "Schema-first GraphQL server for Node.js runtimes",
+      icon: "https://cdn.simpleicons.org/apollographql/311C87",
+      color: "from-indigo-500 to-violet-700",
+    },
+    {
       id: "openapi",
       name: "OpenAPI",
       description: "REST endpoints with OpenAPI 3.1 and Scalar docs",

--- a/apps/web/src/lib/tech-icons.ts
+++ b/apps/web/src/lib/tech-icons.ts
@@ -130,6 +130,7 @@ export const ICON_REGISTRY: Record<string, IconConfig> = {
   trpc: { type: "si", slug: "trpc", hex: "398CCB" },
   orpc: { type: "local", src: "/icon/orpc.svg", needsInvert: "dark" }, // black circle SVG
   "graphql-yoga": { type: "si", slug: "graphql", hex: "E10098" },
+  "apollo-server": { type: "si", slug: "apollographql", hex: "311C87" },
   openapi: { type: "si", slug: "openapiinitiative", hex: "6BA539" },
 
   // ─── Web Frontend ──────────────────────────────────────────────────────────

--- a/apps/web/src/lib/tech-resource-links.ts
+++ b/apps/web/src/lib/tech-resource-links.ts
@@ -17,6 +17,10 @@ const BASE_LINKS: LinkMap = {
     docsUrl: "https://the-guild.dev/graphql/yoga-server/docs",
     githubUrl: "https://github.com/dotansimha/graphql-yoga",
   },
+  "apollo-server": {
+    docsUrl: "https://www.apollographql.com/docs/apollo-server/",
+    githubUrl: "https://github.com/apollographql/apollo-server",
+  },
   openapi: {
     docsUrl: "https://spec.openapis.org/oas/latest.html",
     githubUrl: "https://github.com/OAI/OpenAPI-Specification",

--- a/packages/template-generator/src/processors/api-deps.ts
+++ b/packages/template-generator/src/processors/api-deps.ts
@@ -106,6 +106,15 @@ function addApiPackageDeps(
       packagePath: pkgPath,
       dependencies: ["graphql-yoga", "graphql", "@pothos/core"],
     });
+  } else if (api === "apollo-server") {
+    addPackageDependency({
+      vfs,
+      packagePath: pkgPath,
+      dependencies: ["@apollo/server", "graphql"],
+    });
+    if (isBetterAuth(auth)) {
+      addPackageDependency({ vfs, packagePath: pkgPath, dependencies: ["better-auth"] });
+    }
   } else if (api === "openapi") {
     addPackageDependency({
       vfs,

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -244,6 +244,9 @@ export const dependencyVersionMap = {
   // GraphQL Yoga + Pothos
   "@pothos/core": "^4.12.0",
 
+  // Apollo Server
+  "@apollo/server": "^5.5.1",
+
   // OpenAPI
   "@asteasolutions/zod-to-openapi": "^8.5.0",
   "@scalar/express-api-reference": "^0.10.3",

--- a/packages/template-generator/src/utils/dependency-checker.ts
+++ b/packages/template-generator/src/utils/dependency-checker.ts
@@ -151,6 +151,7 @@ export const ECOSYSTEM_GROUPS: Record<string, string[]> = {
   trpc: ["@trpc/server", "@trpc/client", "@trpc/tanstack-react-query"],
   orpc: ["@orpc/server", "@orpc/client", "@orpc/openapi", "@orpc/zod", "@orpc/tanstack-query"],
   "ts-rest": ["@ts-rest/core", "@ts-rest/react-query", "@ts-rest/serverless", "@ts-rest/next"],
+  "apollo-server": ["@apollo/server", "graphql"],
   openapi: [
     "@hono/zod-openapi",
     "@scalar/hono-api-reference",

--- a/packages/template-generator/templates/api/apollo-server/server/_gitignore
+++ b/packages/template-generator/templates/api/apollo-server/server/_gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/template-generator/templates/api/apollo-server/server/package.json.hbs
+++ b/packages/template-generator/templates/api/apollo-server/server/package.json.hbs
@@ -1,0 +1,15 @@
+{
+  "name": "@{{projectName}}/api",
+  "exports": {
+    ".": {
+      "default": "./src/index.ts"
+    },
+    "./*": {
+      "default": "./src/*.ts"
+    }
+  },
+  "type": "module",
+  "scripts": {},
+  "devDependencies": {},
+  "dependencies": {}
+}

--- a/packages/template-generator/templates/api/apollo-server/server/src/index.ts.hbs
+++ b/packages/template-generator/templates/api/apollo-server/server/src/index.ts.hbs
@@ -1,0 +1,157 @@
+import { ApolloServer, HeaderMap } from "@apollo/server";
+import type { HTTPGraphQLRequest } from "@apollo/server";
+{{#if (isBetterAuth auth)}}
+import type { Session, User } from "better-auth";
+{{/if}}
+
+{{#if (isBetterAuth auth)}}
+type AuthSession = { user: User; session: Session } | null;
+
+{{/if}}
+{{#if (isBetterAuth auth)}}
+export type ApolloContext = {
+	session: AuthSession;
+};
+{{else}}
+export type ApolloContext = Record<string, never>;
+{{/if}}
+
+export const typeDefs = `#graphql
+	type Query {
+		health: String!
+{{#if (isBetterAuth auth)}}
+		me: User
+{{/if}}
+	}
+
+{{#if (isBetterAuth auth)}}
+	type User {
+		id: ID!
+		email: String!
+		name: String
+	}
+
+{{/if}}
+	type Mutation {
+		_empty: String
+	}
+`;
+
+export const resolvers = {
+	Query: {
+		health: () => "OK",
+{{#if (isBetterAuth auth)}}
+		me: (_parent: unknown, _args: unknown, context: ApolloContext) => {
+			if (!context.session) return null;
+			return {
+				id: context.session.user.id,
+				email: context.session.user.email,
+				name: context.session.user.name,
+			};
+		},
+{{/if}}
+	},
+	Mutation: {
+		_empty: () => null,
+	},
+};
+
+export const apolloServer = new ApolloServer<ApolloContext>({
+	typeDefs,
+	resolvers,
+});
+
+let apolloStartPromise: Promise<void> | undefined;
+
+async function ensureApolloStarted() {
+	apolloStartPromise ??= apolloServer.start();
+	await apolloStartPromise;
+}
+
+async function parseRequestBody(request: Request) {
+	if (request.method === "GET" || request.method === "HEAD") return undefined;
+	if (!request.headers.get("content-type")?.includes("application/json")) return undefined;
+
+	const text = await request.text();
+	if (text.trim() === "") return undefined;
+
+	return JSON.parse(text) as unknown;
+}
+
+function getApolloHeaders(request: Request) {
+	const headers = new HeaderMap();
+	request.headers.forEach((value, key) => {
+		headers.set(key, value);
+	});
+	return headers;
+}
+
+function getResponseHeaders(headers: HeaderMap) {
+	const responseHeaders = new Headers();
+	for (const [key, value] of headers) {
+		responseHeaders.set(key, value);
+	}
+	return responseHeaders;
+}
+
+export async function executeApolloRequest(
+	request: Request,
+{{#if (isBetterAuth auth)}}
+	context: ApolloContext = {
+		session: null,
+	},
+{{else}}
+	context: ApolloContext = {},
+{{/if}}
+): Promise<Response> {
+	await ensureApolloStarted();
+
+	let body: unknown;
+	try {
+		body = await parseRequestBody(request);
+	} catch {
+		return Response.json({ errors: [{ message: "Invalid JSON request body" }] }, { status: 400 });
+	}
+
+	const url = new URL(request.url);
+	const httpGraphQLRequest: HTTPGraphQLRequest = {
+		method: request.method.toUpperCase(),
+		headers: getApolloHeaders(request),
+		search: url.search,
+		body,
+	};
+
+	const result = await apolloServer.executeHTTPGraphQLRequest({
+		httpGraphQLRequest,
+		context: async () => context,
+	});
+
+	const responseHeaders = getResponseHeaders(result.headers);
+	const status = result.status ?? 200;
+	const responseBody = result.body;
+
+	if (responseBody.kind === "complete") {
+		return new Response(responseBody.string, {
+			status,
+			headers: responseHeaders,
+		});
+	}
+
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		async start(controller) {
+			try {
+				for await (const chunk of responseBody.asyncIterator) {
+					controller.enqueue(encoder.encode(chunk));
+				}
+			} finally {
+				controller.close();
+			}
+		},
+	});
+
+	return new Response(stream, {
+		status,
+		headers: responseHeaders,
+	});
+}

--- a/packages/template-generator/templates/api/apollo-server/server/tsconfig.json.hbs
+++ b/packages/template-generator/templates/api/apollo-server/server/tsconfig.json.hbs
@@ -1,0 +1,10 @@
+{
+  "extends": "@{{projectName}}/config/tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "composite": true
+  }
+}

--- a/packages/template-generator/templates/api/apollo-server/web/react/base/src/utils/graphql.ts.hbs
+++ b/packages/template-generator/templates/api/apollo-server/web/react/base/src/utils/graphql.ts.hbs
@@ -1,0 +1,39 @@
+import { QueryClient } from "@tanstack/react-query";
+import { env } from "@{{projectName}}/env/web";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 2,
+      staleTime: 1000 * 60,
+    },
+  },
+});
+
+{{#if (includes frontend "next")}}
+const GRAPHQL_URL = `${env.NEXT_PUBLIC_SERVER_URL}/graphql`;
+{{else}}
+const GRAPHQL_URL = `${env.VITE_SERVER_URL}/graphql`;
+{{/if}}
+
+export async function graphqlFetch<T = unknown>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+{{#if (isBetterAuth auth)}}
+    credentials: "include",
+{{/if}}
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const json = await response.json();
+
+  if (json.errors) {
+    throw new Error(json.errors.map((e: { message: string }) => e.message).join(", "));
+  }
+
+  return json.data as T;
+}

--- a/packages/template-generator/templates/backend/server/elysia/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/elysia/src/index.ts.hbs
@@ -26,6 +26,9 @@ import { onError } from "@orpc/server";
 import { appRouter } from "@{{projectName}}/api/routers/index";
 import { createContext } from "@{{projectName}}/api/context";
 {{/if}}
+{{#if (eq api "apollo-server")}}
+import { executeApolloRequest } from "@{{projectName}}/api";
+{{/if}}
 {{#if (isBetterAuth auth)}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
@@ -140,6 +143,24 @@ new Elysia()
 		});
 		return res;
 	})
+{{/if}}
+{{#if (eq api "apollo-server")}}
+	.all(
+		"/graphql",
+		async ({ request }) => {
+{{#if (isBetterAuth auth)}}
+			const session = await auth.api.getSession({
+				headers: request.headers,
+			});
+			return executeApolloRequest(request, { session });
+{{else}}
+			return executeApolloRequest(request);
+{{/if}}
+		},
+		{
+			parse: "none",
+		}
+	)
 {{/if}}
 {{#if (eq api "openapi")}}
 	.get(

--- a/packages/template-generator/templates/backend/server/express/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/express/src/index.ts.hbs
@@ -17,8 +17,11 @@ import { createContext } from "@{{projectName}}/api/context";
 import { createOpenApiDocument } from "@{{projectName}}/api";
 import { apiReference } from "@scalar/express-api-reference";
 {{/if}}
+{{#if (eq api "apollo-server")}}
+import { executeApolloRequest } from "@{{projectName}}/api";
+{{/if}}
 import cors from "cors";
-import express{{#if (and (eq api "openapi") (isBetterAuth auth))}}, { type Request }{{/if}} from "express";
+import express{{#if (or (eq api "apollo-server") (and (eq api "openapi") (isBetterAuth auth)))}}, { type Request }{{/if}} from "express";
 {{#if (includes examples "ai")}}
 import { streamText, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
 import { google } from "@ai-sdk/google";
@@ -95,6 +98,48 @@ app.use(async (req, res, next) => {
 {{/if}}
 
 app.use(express.json());
+{{#if (eq api "apollo-server")}}
+function expressHeadersToWebHeaders(headers: Request["headers"]) {
+	const webHeaders = new Headers();
+	for (const [key, value] of Object.entries(headers)) {
+		if (Array.isArray(value)) {
+			for (const item of value) webHeaders.append(key, item);
+		} else if (typeof value === "string") {
+			webHeaders.set(key, value);
+		}
+	}
+	return webHeaders;
+}
+
+function expressRequestToWebRequest(req: Request) {
+	const headers = expressHeadersToWebHeaders(req.headers);
+	const url = `${req.protocol}://${req.get("host")}${req.originalUrl}`;
+	const init: RequestInit = {
+		method: req.method,
+		headers,
+	};
+	if (req.method !== "GET" && req.method !== "HEAD" && req.body !== undefined) {
+		init.body = JSON.stringify(req.body);
+	}
+	return new Request(url, init);
+}
+
+app.all("/graphql", async (req, res) => {
+	const webRequest = expressRequestToWebRequest(req);
+{{#if (isBetterAuth auth)}}
+	const session = await auth.api.getSession({
+		headers: webRequest.headers,
+	});
+	const apolloResponse = await executeApolloRequest(webRequest, { session });
+{{else}}
+	const apolloResponse = await executeApolloRequest(webRequest);
+{{/if}}
+	res.status(apolloResponse.status);
+	apolloResponse.headers.forEach((value, key) => res.setHeader(key, value));
+	res.send(await apolloResponse.text());
+});
+
+{{/if}}
 {{#if (eq api "openapi")}}
 app.get("/health", (_req, res) => {
 	res.status(200).json({ status: "ok" });

--- a/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
@@ -1,5 +1,5 @@
 import { env } from "@{{projectName}}/env/server";
-import Fastify from "fastify";
+import Fastify{{#if (eq api "apollo-server")}}, { type FastifyRequest }{{/if}} from "fastify";
 import fastifyCors from "@fastify/cors";
 {{#if (eq api "openapi")}}
 import swagger from "@fastify/swagger";
@@ -26,6 +26,9 @@ import { RPCHandler } from "@orpc/server/fastify";
 import { onError } from "@orpc/server";
 import { appRouter } from "@{{projectName}}/api/routers/index";
 import { createContext } from "@{{projectName}}/api/context";
+{{/if}}
+{{#if (eq api "apollo-server")}}
+import { executeApolloRequest } from "@{{projectName}}/api";
 {{/if}}
 
 {{#if (includes examples "ai")}}
@@ -64,6 +67,36 @@ const baseCorsConfig = {
 	maxAge: 86400,
 };
 
+{{#if (eq api "apollo-server")}}
+function firstHeader(value: string | string[] | undefined, fallback: string) {
+	if (Array.isArray(value)) return value[0] ?? fallback;
+	return value ?? fallback;
+}
+
+function fastifyRequestToWebRequest(request: FastifyRequest) {
+	const headers = new Headers();
+	for (const [key, value] of Object.entries(request.headers)) {
+		if (Array.isArray(value)) {
+			for (const item of value) headers.append(key, item);
+		} else if (typeof value === "string") {
+			headers.set(key, value);
+		}
+	}
+
+	const protocol = firstHeader(request.headers["x-forwarded-proto"], "http");
+	const host = firstHeader(request.headers.host, "localhost:3000");
+	const init: RequestInit = {
+		method: request.method,
+		headers,
+	};
+	if (request.method !== "GET" && request.method !== "HEAD" && request.body !== undefined) {
+		init.body = JSON.stringify(request.body);
+	}
+
+	return new Request(`${protocol}://${host}${request.url}`, init);
+}
+
+{{/if}}
 {{#if (eq api "orpc")}}
 const rpcHandler = new RPCHandler(appRouter, {
 	interceptors: [
@@ -173,6 +206,27 @@ fastify.route({
 			});
 		}
 	}
+});
+{{/if}}
+
+{{#if (eq api "apollo-server")}}
+fastify.route({
+	method: ["GET", "POST"],
+	url: "/graphql",
+	async handler(request, reply) {
+		const webRequest = fastifyRequestToWebRequest(request);
+{{#if (isBetterAuth auth)}}
+		const session = await auth.api.getSession({
+			headers: webRequest.headers,
+		});
+		const apolloResponse = await executeApolloRequest(webRequest, { session });
+{{else}}
+		const apolloResponse = await executeApolloRequest(webRequest);
+{{/if}}
+		reply.status(apolloResponse.status);
+		apolloResponse.headers.forEach((value, key) => reply.header(key, value));
+		reply.send(await apolloResponse.text());
+	},
 });
 {{/if}}
 

--- a/packages/template-generator/templates/backend/server/hono/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/hono/src/index.ts.hbs
@@ -25,6 +25,9 @@ import {
 {{/if}}
 } from "@{{projectName}}/api";
 {{/if}}
+{{#if (eq api "apollo-server")}}
+import { executeApolloRequest } from "@{{projectName}}/api";
+{{/if}}
 {{#if (isBetterAuth auth)}}
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
@@ -121,6 +124,18 @@ app.use(
 		},
 	})
 );
+{{/if}}
+{{#if (eq api "apollo-server")}}
+app.on(["GET", "POST"], "/graphql", async (c) => {
+{{#if (isBetterAuth auth)}}
+	const session = await auth.api.getSession({
+		headers: c.req.raw.headers,
+	});
+	return executeApolloRequest(c.req.raw, { session });
+{{else}}
+	return executeApolloRequest(c.req.raw);
+{{/if}}
+});
 {{/if}}
 {{#if (eq api "openapi")}}
 const openApiApp = new OpenAPIHono();

--- a/packages/template-generator/templates/frontend/react/next/src/app/page.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/next/src/app/page.tsx.hbs
@@ -2,7 +2,7 @@
 {{#if (eq backend "convex")}}
 import { useQuery } from "convex/react";
 import { api } from "@{{projectName}}/backend/convex/_generated/api";
-{{else if (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga"))}}
+{{else if (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "apollo-server"))}}
 import { useQuery } from "@tanstack/react-query";
   {{#if (eq api "orpc")}}
 import { orpc } from "@/utils/orpc";
@@ -13,7 +13,7 @@ import { trpc } from "@/utils/trpc";
   {{#if (eq api "garph")}}
 import { query, resolved } from "@/utils/garph";
   {{/if}}
-  {{#if (eq api "graphql-yoga")}}
+  {{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
 import { graphqlFetch } from "@/utils/graphql";
   {{/if}}
 {{/if}}
@@ -50,7 +50,7 @@ export default function Home() {
     queryKey: ["healthCheck"],
     queryFn: () => resolved(() => query.health),
   });
-  {{else if (eq api "graphql-yoga")}}
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   const healthCheck = useQuery({
     queryKey: ["healthCheck"],
     queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),
@@ -91,7 +91,7 @@ export default function Home() {
                   : "Error"}
             </span>
           </div>
-          {{else if (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "openapi"))}}
+          {{else if (or (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "apollo-server")) (eq api "openapi"))}}
             <div className="flex items-center gap-2">
               <div
                 className={`h-2 w-2 rounded-full ${healthCheck.data ? "bg-green-500" : "bg-red-500"}`}

--- a/packages/template-generator/templates/frontend/react/next/src/components/providers.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/next/src/components/providers.tsx.hbs
@@ -28,7 +28,7 @@ import { queryClient } from "@/utils/trpc";
 {{#if (eq api "garph")}}
 import { queryClient } from "@/utils/garph";
 {{/if}}
-{{#if (eq api "graphql-yoga")}}
+{{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
 import { queryClient } from "@/utils/graphql";
 {{/if}}
 {{#if (eq api "ts-rest")}}

--- a/packages/template-generator/templates/frontend/react/react-router/src/root.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/src/root.tsx.hbs
@@ -38,6 +38,9 @@ import { queryClient } from "./utils/trpc";
     {{#if (eq api "garph")}}
 import { queryClient } from "./utils/garph";
     {{/if}}
+    {{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
+import { queryClient } from "./utils/graphql";
+    {{/if}}
   {{/unless}}
 {{/if}}
 
@@ -136,7 +139,7 @@ export default function App() {
     </QueryClientProvider>
   );
 }
-{{else if (or (eq api "trpc") (eq api "garph"))}}
+{{else if (or (or (eq api "trpc") (eq api "garph")) (or (eq api "graphql-yoga") (eq api "apollo-server")))}}
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>

--- a/packages/template-generator/templates/frontend/react/react-router/src/routes/_index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/react-router/src/routes/_index.tsx.hbs
@@ -1,7 +1,7 @@
 {{#if (eq backend "convex")}}
 import { useQuery } from "convex/react";
 import { api } from "@{{projectName}}/backend/convex/_generated/api";
-{{else if (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga"))}}
+{{else if (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "apollo-server"))}}
 import { useQuery } from "@tanstack/react-query";
   {{#if (eq api "orpc")}}
   import { orpc } from "@/utils/orpc";
@@ -12,7 +12,7 @@ import { useQuery } from "@tanstack/react-query";
   {{#if (eq api "garph")}}
   import { query, resolved } from "@/utils/garph";
   {{/if}}
-  {{#if (eq api "graphql-yoga")}}
+  {{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   import { graphqlFetch } from "@/utils/graphql";
   {{/if}}
 {{/if}}
@@ -53,7 +53,7 @@ export default function Home() {
     queryKey: ["healthCheck"],
     queryFn: () => resolved(() => query.health),
   });
-  {{else if (eq api "graphql-yoga")}}
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   const healthCheck = useQuery({
     queryKey: ["healthCheck"],
     queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),

--- a/packages/template-generator/templates/frontend/react/react-vite/src/app-shell.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/react-vite/src/app-shell.tsx.hbs
@@ -17,6 +17,11 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/utils/garph";
 {{/if}}
+{{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { queryClient } from "@/utils/graphql";
+{{/if}}
 {{#if (eq backend "convex")}}
 import { ConvexReactClient } from "convex/react";
 import { env } from "@{{projectName}}/env/web";
@@ -85,6 +90,13 @@ export default function AppShell() {
     </QueryClientProvider>
   );
   {{else if (eq api "garph")}}
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RoutedLayout />
+      <ReactQueryDevtools position="bottom" buttonPosition="bottom-right" />
+    </QueryClientProvider>
+  );
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   return (
     <QueryClientProvider client={queryClient}>
       <RoutedLayout />

--- a/packages/template-generator/templates/frontend/react/react-vite/src/routes/home.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/react-vite/src/routes/home.tsx.hbs
@@ -1,7 +1,7 @@
 {{#if (eq backend "convex")}}
 import { useQuery } from "convex/react";
 import { api } from "@{{projectName}}/backend/convex/_generated/api";
-{{else if (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga"))}}
+{{else if (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "apollo-server"))}}
 import { useQuery } from "@tanstack/react-query";
   {{#if (eq api "orpc")}}
 import { orpc } from "@/utils/orpc";
@@ -12,7 +12,7 @@ import { trpc } from "@/utils/trpc";
   {{#if (eq api "garph")}}
 import { query, resolved } from "@/utils/garph";
   {{/if}}
-  {{#if (eq api "graphql-yoga")}}
+  {{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
 import { graphqlFetch } from "@/utils/graphql";
   {{/if}}
 {{/if}}
@@ -49,7 +49,7 @@ export default function Home() {
     queryKey: ["healthCheck"],
     queryFn: () => resolved(() => query.health),
   });
-  {{else if (eq api "graphql-yoga")}}
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   const healthCheck = useQuery({
     queryKey: ["healthCheck"],
     queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),
@@ -90,7 +90,7 @@ export default function Home() {
                   : "Error"}
             </span>
           </div>
-          {{else if (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "openapi"))}}
+          {{else if (or (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "apollo-server")) (eq api "openapi"))}}
           <div className="flex items-center gap-2">
             <div
               className={`h-2 w-2 rounded-full ${healthCheck.data ? "bg-green-500" : "bg-red-500"}`}

--- a/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/src/main.tsx.hbs
@@ -15,6 +15,10 @@ import { routeTree } from "./routeTree.gen";
   import { QueryClientProvider } from "@tanstack/react-query";
   import { queryClient } from "./utils/garph";
 {{/if}}
+{{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
+  import { QueryClientProvider } from "@tanstack/react-query";
+  import { queryClient } from "./utils/graphql";
+{{/if}}
 {{#if (eq backend "convex")}}
   import { ConvexReactClient } from "convex/react";
   import { env } from "@{{projectName}}/env/web";
@@ -53,6 +57,15 @@ const router = createRouter({
     );
   },
   {{else if (eq api "garph")}}
+  context: { queryClient },
+  Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  },
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   context: { queryClient },
   Wrap: function WrapComponent({ children }: { children: React.ReactNode }) {
     return (

--- a/packages/template-generator/templates/frontend/react/tanstack-router/src/routes/index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-router/src/routes/index.tsx.hbs
@@ -13,7 +13,7 @@ import { tsr } from "@/utils/ts-rest";
 {{else if (eq api "garph")}}
 import { query, resolved } from "@/utils/garph";
 import { useQuery } from "@tanstack/react-query";
-{{else if (eq api "graphql-yoga")}}
+{{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
 import { graphqlFetch } from "@/utils/graphql";
 import { useQuery } from "@tanstack/react-query";
 {{else if (eq api "openapi")}}
@@ -55,7 +55,7 @@ function HomeComponent() {
     queryKey: ["healthCheck"],
     queryFn: () => resolved(() => query.health),
   });
-  {{else if (eq api "graphql-yoga")}}
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   const healthCheck = useQuery({
     queryKey: ["healthCheck"],
     queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),

--- a/packages/template-generator/templates/frontend/react/tanstack-start/src/routes/index.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/tanstack-start/src/routes/index.tsx.hbs
@@ -16,7 +16,7 @@ import { tsr } from "@/utils/ts-rest";
 {{else if (eq api "garph")}}
 import { useQuery } from "@tanstack/react-query";
 import { query, resolved } from "@/utils/garph";
-{{else if (eq api "graphql-yoga")}}
+{{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
 import { useQuery } from "@tanstack/react-query";
 import { graphqlFetch } from "@/utils/graphql";
 {{else if (eq api "openapi")}}
@@ -59,7 +59,7 @@ function HomeComponent() {
     queryKey: ["healthCheck"],
     queryFn: () => resolved(() => query.health),
   });
-  {{else if (eq api "graphql-yoga")}}
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   const healthCheck = useQuery({
     queryKey: ["healthCheck"],
     queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),

--- a/packages/template-generator/templates/frontend/react/vinext/src/app/page.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/vinext/src/app/page.tsx.hbs
@@ -2,7 +2,7 @@
 {{#if (eq backend "convex")}}
 import { useQuery } from "convex/react";
 import { api } from "@{{projectName}}/backend/convex/_generated/api";
-{{else if (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga"))}}
+{{else if (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "apollo-server"))}}
 import { useQuery } from "@tanstack/react-query";
   {{#if (eq api "orpc")}}
 import { orpc } from "@/utils/orpc";
@@ -13,7 +13,7 @@ import { trpc } from "@/utils/trpc";
   {{#if (eq api "garph")}}
 import { query, resolved } from "@/utils/garph";
   {{/if}}
-  {{#if (eq api "graphql-yoga")}}
+  {{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
 import { graphqlFetch } from "@/utils/graphql";
   {{/if}}
 {{/if}}
@@ -50,7 +50,7 @@ export default function Home() {
     queryKey: ["healthCheck"],
     queryFn: () => resolved(() => query.health),
   });
-  {{else if (eq api "graphql-yoga")}}
+  {{else if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
   const healthCheck = useQuery({
     queryKey: ["healthCheck"],
     queryFn: () => graphqlFetch<{ health: string }>("{ health }").then((d) => d.health),
@@ -91,7 +91,7 @@ export default function Home() {
                   : "Error"}
             </span>
           </div>
-          {{else if (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "openapi"))}}
+          {{else if (or (or (or (or (or (eq api "orpc") (eq api "trpc")) (eq api "garph")) (eq api "graphql-yoga")) (eq api "apollo-server")) (eq api "openapi"))}}
             <div className="flex items-center gap-2">
               <div
                 className={`h-2 w-2 rounded-full ${healthCheck.isLoading ? "bg-orange-500" : healthCheck.data ? "bg-green-500" : "bg-red-500"}`}

--- a/packages/template-generator/templates/frontend/react/vinext/src/components/providers.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/vinext/src/components/providers.tsx.hbs
@@ -28,6 +28,9 @@ import { queryClient } from "@/utils/trpc";
 {{#if (eq api "garph")}}
 import { queryClient } from "@/utils/garph";
 {{/if}}
+{{#if (or (eq api "graphql-yoga") (eq api "apollo-server"))}}
+import { queryClient } from "@/utils/graphql";
+{{/if}}
 {{#if (eq api "ts-rest")}}
 import { queryClient } from "@/utils/ts-rest";
 {{/if}}

--- a/packages/template-generator/test/processors/api-deps.test.ts
+++ b/packages/template-generator/test/processors/api-deps.test.ts
@@ -143,4 +143,29 @@ describe("processApiDeps", () => {
       "@tanstack/solid-router-devtools",
     ]);
   });
+
+  it("adds Apollo Server dependencies to the API package and React Query to the web app", () => {
+    const vfs = createSeededVFS([
+      "apps/web/package.json",
+      "apps/server/package.json",
+      "packages/api/package.json",
+    ]);
+
+    processApiDeps(
+      vfs,
+      makeConfig({
+        backend: "hono",
+        api: "apollo-server",
+        auth: "better-auth",
+        frontend: ["tanstack-router"],
+      }),
+    );
+
+    const api = getDeps(vfs, "packages/api/package.json");
+    const web = getDeps(vfs, "apps/web/package.json");
+
+    expectIncludesAll(api.deps, ["@apollo/server", "graphql", "better-auth"]);
+    expect(web.deps).toContain("@tanstack/react-query");
+    expect(web.devDeps).toContain("@tanstack/react-query-devtools");
+  });
 });

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -1906,6 +1906,34 @@ export const getDisabledReason = (
     }
   }
 
+  if (category === "api" && optionId === "apollo-server") {
+    const needsReactFrontend = currentStack.webFrontend.some((f) =>
+      ["nuxt", "svelte", "solid", "solid-start"].includes(f),
+    );
+    if (needsReactFrontend) {
+      const frontendName = currentStack.webFrontend.find((f) =>
+        ["nuxt", "svelte", "solid", "solid-start"].includes(f),
+      );
+      return `${frontendName} requires oRPC, not Apollo Server`;
+    }
+    if (
+      currentStack.webFrontend.includes("astro") &&
+      currentStack.astroIntegration !== "react" &&
+      currentStack.astroIntegration !== "none"
+    ) {
+      return `Astro with ${currentStack.astroIntegration} integration requires oRPC, not Apollo Server`;
+    }
+    if (currentStack.backend === "self") {
+      return "Apollo Server scaffolding currently requires a standalone TypeScript backend";
+    }
+    if (currentStack.nativeFrontend.length > 0) {
+      return "Apollo Server is currently available for web frontends, not React Native";
+    }
+    if (!["hono", "express", "fastify", "elysia"].includes(currentStack.backend)) {
+      return "Apollo Server currently supports Hono, Express, Fastify, and Elysia backends";
+    }
+  }
+
   if (category === "appPlatforms" && optionId === "nx" && currentStack.appPlatforms.includes("turborepo")) {
     return "Choose either Nx or Turborepo, not both";
   }
@@ -1921,9 +1949,13 @@ export const getDisabledReason = (
     if (!currentStack.webFrontend.includes("astro") && optionId !== "none") {
       return "Astro integration requires Astro frontend";
     }
-    // tRPC requires React integration
-    if (currentStack.api === "trpc" && optionId !== "react" && optionId !== "none") {
-      return "tRPC requires React integration with Astro";
+    // React-only APIs require React integration
+    if (
+      (currentStack.api === "trpc" || currentStack.api === "apollo-server") &&
+      optionId !== "react" &&
+      optionId !== "none"
+    ) {
+      return `${currentStack.api === "apollo-server" ? "Apollo Server" : "tRPC"} requires React integration with Astro`;
     }
   }
 
@@ -3252,7 +3284,16 @@ export function allowedApisForFrontends(
   const includesNative = frontends.some((frontend) =>
     ["native-bare", "native-uniwind", "native-unistyles"].includes(frontend),
   );
-  const base: API[] = ["trpc", "orpc", "ts-rest", "garph", "graphql-yoga", "openapi", "none"];
+  const base: API[] = [
+    "trpc",
+    "orpc",
+    "ts-rest",
+    "garph",
+    "graphql-yoga",
+    "apollo-server",
+    "openapi",
+    "none",
+  ];
 
   if (includesNative) {
     return ["trpc", "orpc", "ts-rest", "garph", "none"] as API[];
@@ -3278,6 +3319,7 @@ function getReactOnlyApiDisplayName(api: API) {
   if (api === "trpc") return "tRPC";
   if (api === "ts-rest") return "ts-rest";
   if (api === "openapi") return "OpenAPI";
+  if (api === "apollo-server") return "Apollo Server";
   return "garph";
 }
 
@@ -3297,7 +3339,8 @@ export function getApiFrontendCompatibilityIssue(
   const includesRedwood = frontends.includes("redwood");
   const includesFresh = frontends.includes("fresh");
   const includesSolidStart = frontends.includes("solid-start");
-  const isReactOnlyApi = api === "trpc" || api === "ts-rest" || api === "garph";
+  const isReactOnlyApi =
+    api === "trpc" || api === "ts-rest" || api === "garph" || api === "apollo-server";
 
   if ((includesNuxt || includesSvelte || includesSolid || includesSolidStart) && isReactOnlyApi) {
     const incompatibleFrontend = includesNuxt

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -752,27 +752,28 @@ export const analyzeStackCompatibility = (
   // ============================================
 
   if (nextStack.backend !== "convex" && nextStack.backend !== "none") {
-    // Nuxt, Svelte, Solid, SolidStart require oRPC (not tRPC)
+    // Nuxt, Svelte, Solid, SolidStart require oRPC for React-only API clients.
     const needsOrpc = nextStack.webFrontend.some((f) =>
       ["nuxt", "svelte", "solid", "solid-start"].includes(f),
     );
-    if (needsOrpc && nextStack.api === "trpc") {
+    if (needsOrpc && (nextStack.api === "trpc" || nextStack.api === "apollo-server")) {
       nextStack.api = "orpc";
       changed = true;
       changes.push({ category: "api", message: "API set to 'oRPC' (required for this frontend)" });
     }
 
-    // Astro with non-React integration requires oRPC
+    // Astro with non-React integration requires oRPC for React-only API clients.
     if (
       nextStack.webFrontend.includes("astro") &&
       nextStack.astroIntegration !== "react" &&
-      nextStack.api === "trpc"
+      (nextStack.api === "trpc" || nextStack.api === "apollo-server")
     ) {
+      const apiName = nextStack.api === "apollo-server" ? "Apollo Server" : "tRPC";
       nextStack.api = "orpc";
       changed = true;
       changes.push({
         category: "api",
-        message: "API set to 'oRPC' (tRPC requires React integration with Astro)",
+        message: `API set to 'oRPC' (${apiName} requires React integration with Astro)`,
       });
     }
   }
@@ -1916,12 +1917,8 @@ export const getDisabledReason = (
       );
       return `${frontendName} requires oRPC, not Apollo Server`;
     }
-    if (
-      currentStack.webFrontend.includes("astro") &&
-      currentStack.astroIntegration !== "react" &&
-      currentStack.astroIntegration !== "none"
-    ) {
-      return `Astro with ${currentStack.astroIntegration} integration requires oRPC, not Apollo Server`;
+    if (currentStack.webFrontend.includes("astro") && currentStack.astroIntegration !== "react") {
+      return "Apollo Server requires React integration with Astro";
     }
     if (currentStack.backend === "self") {
       return "Apollo Server scaffolding currently requires a standalone TypeScript backend";
@@ -1951,11 +1948,19 @@ export const getDisabledReason = (
     }
     // React-only APIs require React integration
     if (
-      (currentStack.api === "trpc" || currentStack.api === "apollo-server") &&
+      currentStack.webFrontend.includes("astro") &&
+      currentStack.api === "apollo-server" &&
+      optionId !== "react"
+    ) {
+      return "Apollo Server requires React integration with Astro";
+    }
+    if (
+      currentStack.webFrontend.includes("astro") &&
+      currentStack.api === "trpc" &&
       optionId !== "react" &&
       optionId !== "none"
     ) {
-      return `${currentStack.api === "apollo-server" ? "Apollo Server" : "tRPC"} requires React integration with Astro`;
+      return "tRPC requires React integration with Astro";
     }
   }
 
@@ -3308,7 +3313,7 @@ export function allowedApisForFrontends(
     return ["orpc", "graphql-yoga", "openapi", "none"] as API[];
   }
 
-  if (includesAstro && astroIntegration && astroIntegration !== "react") {
+  if (includesAstro && astroIntegration !== "react") {
     return ["orpc", "graphql-yoga", "openapi", "none"] as API[];
   }
 
@@ -3409,13 +3414,13 @@ export function getApiFrontendCompatibilityIssue(
     };
   }
 
-  if (includesAstro && astroIntegration && astroIntegration !== "react" && isReactOnlyApi) {
+  if (includesAstro && astroIntegration !== "react" && isReactOnlyApi) {
     return {
       code: "ASTRO_API_REQUIRES_REACT_INTEGRATION",
       message: `${getReactOnlyApiDisplayName(api)} API requires React integration with Astro.`,
       category: "api",
       optionId: api,
-      provided: { api, "astro-integration": astroIntegration },
+      provided: { api, "astro-integration": astroIntegration ?? "none" },
       suggestions: [
         "Use --api orpc (works with all Astro integrations)",
         "Use --api none",

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -857,7 +857,13 @@ const CATEGORY_VALUE_IDS: Record<OptionCategory, readonly string[]> = {
 };
 
 const EXACT_LABEL_OVERRIDES: Partial<Record<OptionCategory, Partial<Record<string, string>>>> = {
-  api: { trpc: "tRPC", orpc: "oRPC", "graphql-yoga": "GraphQL Yoga", openapi: "OpenAPI" },
+  api: {
+    trpc: "tRPC",
+    orpc: "oRPC",
+    "graphql-yoga": "GraphQL Yoga",
+    "apollo-server": "Apollo Server",
+    openapi: "OpenAPI",
+  },
   webFrontend: {
     next: "Next.js",
     vinext: "Vinext",

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -197,7 +197,7 @@ export const DatabaseSetupSchema = z
   .describe("Database hosting setup");
 
 export const APISchema = z
-  .enum(["trpc", "orpc", "ts-rest", "garph", "graphql-yoga", "openapi", "none"])
+  .enum(["trpc", "orpc", "ts-rest", "garph", "graphql-yoga", "apollo-server", "openapi", "none"])
   .describe("API type");
 
 export const AuthSchema = z

--- a/packages/types/src/stack-graph.ts
+++ b/packages/types/src/stack-graph.ts
@@ -207,6 +207,14 @@ const TYPESCRIPT_TRPC_INCOMPATIBLE_FRONTENDS = new Set([
   "solid",
   "solid-start",
 ]);
+const TYPESCRIPT_APOLLO_SERVER_COMPATIBLE_FRONTENDS = new Set([
+  "tanstack-router",
+  "react-router",
+  "react-vite",
+  "tanstack-start",
+  "next",
+  "vinext",
+]);
 const BETTER_AUTH_UNSUPPORTED_ORM_TOOLS = new Set(["typeorm", "mikroorm", "sequelize"]);
 const ELIXIR_ECTO_REQUIRED_TOOLS = new Set(["absinthe", "phx-gen-auth"]);
 const ELIXIR_ECTO_SQL_REQUIRED_TOOLS = new Set(["oban"]);
@@ -1849,6 +1857,23 @@ function getStackPartCompatibilityIssue(
         role: part.role,
         toolId: part.toolId,
         message: `'trpc' cannot be selected with the '${frontendTool}' frontend.`,
+      });
+    }
+  }
+
+  if (
+    part.ecosystem === "typescript" &&
+    part.role === "api" &&
+    part.toolId === "apollo-server"
+  ) {
+    const frontendTool = context.primaryToolIdsByRole?.frontend;
+    if (frontendTool && !TYPESCRIPT_APOLLO_SERVER_COMPATIBLE_FRONTENDS.has(frontendTool)) {
+      return createStackGraphIssue({
+        code: "INCOMPATIBLE_GRAPH_SELECTION",
+        partId: part.id,
+        role: part.role,
+        toolId: part.toolId,
+        message: `'apollo-server' requires a React frontend and cannot be selected with the '${frontendTool}' frontend.`,
       });
     }
   }

--- a/packages/types/test/compatibility.test.ts
+++ b/packages/types/test/compatibility.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   analyzeStackCompatibility,
+  allowedApisForFrontends,
   evaluateCompatibility,
   getAIFrontendCompatibilityIssue,
   getApiFrontendCompatibilityIssue,
@@ -37,6 +38,61 @@ describe("compatibility issue helpers", () => {
 
   it("allows frontend-agnostic API options", () => {
     expect(getApiFrontendCompatibilityIssue("orpc", ["svelte"])).toBeUndefined();
+  });
+
+  it("treats Apollo Server as a React-only API option", () => {
+    const issue = getApiFrontendCompatibilityIssue("apollo-server", ["svelte"]);
+
+    expect(issue).toMatchObject({
+      code: "API_REQUIRES_REACT_FRONTEND",
+      message: "Apollo Server API requires React-based frontends.",
+      category: "api",
+      optionId: "apollo-server",
+      provided: { api: "apollo-server", frontend: "svelte" },
+    });
+    expect(allowedApisForFrontends(["tanstack-router"])).toContain("apollo-server");
+    expect(allowedApisForFrontends(["svelte"])).not.toContain("apollo-server");
+  });
+
+  it("disables Apollo Server for unsupported backend and frontend selections", () => {
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          backend: "self",
+          nativeFrontend: [],
+          webFrontend: ["tanstack-router"],
+        },
+        "api",
+        "apollo-server",
+      ),
+    ).toBe("Apollo Server scaffolding currently requires a standalone TypeScript backend");
+
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          backend: "hono",
+          nativeFrontend: [],
+          webFrontend: ["svelte"],
+        },
+        "api",
+        "apollo-server",
+      ),
+    ).toBe("svelte requires oRPC, not Apollo Server");
+
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          backend: "hono",
+          nativeFrontend: [],
+          webFrontend: ["tanstack-router"],
+        },
+        "api",
+        "apollo-server",
+      ),
+    ).toBeNull();
   });
 
   it("returns structured TanStack AI frontend issues", () => {

--- a/packages/types/test/compatibility.test.ts
+++ b/packages/types/test/compatibility.test.ts
@@ -52,6 +52,17 @@ describe("compatibility issue helpers", () => {
     });
     expect(allowedApisForFrontends(["tanstack-router"])).toContain("apollo-server");
     expect(allowedApisForFrontends(["svelte"])).not.toContain("apollo-server");
+    expect(allowedApisForFrontends(["astro"])).not.toContain("apollo-server");
+    expect(allowedApisForFrontends(["astro"], "none")).not.toContain("apollo-server");
+    expect(allowedApisForFrontends(["astro"], "react")).toContain("apollo-server");
+
+    expect(getApiFrontendCompatibilityIssue("apollo-server", ["astro"], "none")).toMatchObject({
+      code: "ASTRO_API_REQUIRES_REACT_INTEGRATION",
+      message: "Apollo Server API requires React integration with Astro.",
+      category: "api",
+      optionId: "apollo-server",
+      provided: { api: "apollo-server", "astro-integration": "none" },
+    });
   });
 
   it("disables Apollo Server for unsupported backend and frontend selections", () => {
@@ -87,12 +98,79 @@ describe("compatibility issue helpers", () => {
           ...DEFAULT_STACK_SELECTION,
           backend: "hono",
           nativeFrontend: [],
+          webFrontend: ["astro"],
+          astroIntegration: "none",
+        },
+        "api",
+        "apollo-server",
+      ),
+    ).toBe("Apollo Server requires React integration with Astro");
+
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          api: "apollo-server",
+          backend: "hono",
+          nativeFrontend: [],
+          webFrontend: ["astro"],
+          astroIntegration: "none",
+        },
+        "astroIntegration",
+        "none",
+      ),
+    ).toBe("Apollo Server requires React integration with Astro");
+
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          backend: "hono",
+          nativeFrontend: [],
+          webFrontend: ["astro"],
+          astroIntegration: "react",
+        },
+        "api",
+        "apollo-server",
+      ),
+    ).toBeNull();
+
+    expect(
+      getDisabledReason(
+        {
+          ...DEFAULT_STACK_SELECTION,
+          backend: "hono",
+          nativeFrontend: [],
           webFrontend: ["tanstack-router"],
         },
         "api",
         "apollo-server",
       ),
     ).toBeNull();
+  });
+
+  it("adjusts retained Apollo Server API selections for incompatible frontends", () => {
+    const svelteResult = analyzeStackCompatibility({
+      ...DEFAULT_STACK_SELECTION,
+      backend: "hono",
+      nativeFrontend: [],
+      webFrontend: ["svelte"],
+      api: "apollo-server",
+    });
+    const astroResult = analyzeStackCompatibility({
+      ...DEFAULT_STACK_SELECTION,
+      backend: "hono",
+      nativeFrontend: [],
+      webFrontend: ["astro"],
+      astroIntegration: "none",
+      api: "apollo-server",
+    });
+
+    expect(svelteResult.adjustedStack.api).toBe("orpc");
+    expect(astroResult.adjustedStack).toMatchObject({
+      api: "orpc",
+      astroIntegration: "none",
+    });
   });
 
   it("returns structured TanStack AI frontend issues", () => {

--- a/packages/types/test/stack-graph.test.ts
+++ b/packages/types/test/stack-graph.test.ts
@@ -149,6 +149,17 @@ function compareLegacyConfigToStackParts(
   return diagnostics;
 }
 
+function getTypeScriptApiOptionsForFrontend(frontend: string) {
+  return getStackPartOptions({
+    role: "api",
+    ecosystem: "typescript",
+    ownerRole: "backend",
+    ownerEcosystem: "typescript",
+    ownerToolId: "hono",
+    primaryToolIdsByRole: { frontend, backend: "hono" },
+  });
+}
+
 describe("stack graph", () => {
   it("parses repeated part bindings and lowers them to legacy compatibility fields", () => {
     const stackParts = parseStackPartSpecs([
@@ -322,6 +333,13 @@ describe("stack graph", () => {
     expect(djangoOptions).toContain("django-ninja");
   });
 
+  it("filters Apollo Server API options by frontend graph context", () => {
+    expect(getTypeScriptApiOptionsForFrontend("tanstack-router")).toContain("apollo-server");
+    expect(getTypeScriptApiOptionsForFrontend("svelte")).not.toContain("apollo-server");
+    expect(getTypeScriptApiOptionsForFrontend("solid")).not.toContain("apollo-server");
+    expect(getTypeScriptApiOptionsForFrontend("astro")).not.toContain("apollo-server");
+  });
+
   it("filters Elixir capability options by owner and generated support", () => {
     const phoenixRealtimeOptions = getStackPartOptions({
       role: "realtime",
@@ -469,6 +487,16 @@ describe("stack graph", () => {
       "backend:typescript:hono",
       "backend.api:typescript:trpc",
     ]);
+    const apolloSvelteParts = parseStackPartSpecs([
+      "frontend:typescript:svelte",
+      "backend:typescript:hono",
+      "backend.api:typescript:apollo-server",
+    ]);
+    const apolloAstroParts = parseStackPartSpecs([
+      "frontend:typescript:astro",
+      "backend:typescript:hono",
+      "backend.api:typescript:apollo-server",
+    ]);
     const betterAuthParts = parseStackPartSpecs([
       "backend:typescript:hono",
       "backend.orm:typescript:typeorm",
@@ -478,6 +506,20 @@ describe("stack graph", () => {
 
     expect(validateStackParts(trpcParts).issues.map((issue) => issue.code)).toContain(
       "INCOMPATIBLE_GRAPH_SELECTION",
+    );
+    expect(validateStackParts(apolloSvelteParts).issues).toContainEqual(
+      expect.objectContaining({
+        code: "INCOMPATIBLE_GRAPH_SELECTION",
+        role: "api",
+        toolId: "apollo-server",
+      }),
+    );
+    expect(validateStackParts(apolloAstroParts).issues).toContainEqual(
+      expect.objectContaining({
+        code: "INCOMPATIBLE_GRAPH_SELECTION",
+        role: "api",
+        toolId: "apollo-server",
+      }),
     );
     expect(validateStackParts(betterAuthParts).issues.map((issue) => issue.code)).toContain(
       "INCOMPATIBLE_GRAPH_SELECTION",


### PR DESCRIPTION
## Summary
- Add Apollo Server as a TypeScript API option across schema, CLI prompts, builder metadata, and compatibility rules.
- Add Apollo package/template wiring for standalone Hono, Express, Fastify, and Elysia backends with React GraphQL helpers.
- Add API, dependency, compatibility, snapshot, and scaffold validation coverage.

## Verification
- `~/.bun/bin/bun test apps/cli/test/api.test.ts`
- `~/.bun/bin/bun run test:release`
- `~/.bun/bin/bun run --cwd apps/cli lint`
- `~/.bun/bin/bun run --cwd apps/web lint`
- `~/.bun/bin/bun run --cwd packages/types lint`
- `~/.bun/bin/bun run --cwd packages/template-generator lint`
- `~/.bun/bin/bun run --filter=create-better-fullstack build`
- `~/.bun/bin/bun test apps/cli/test/template-validation.test.ts`
- `~/.bun/bin/bun test apps/cli/test/template-snapshots.test.ts`
- Fresh scaffold install/typecheck for Apollo Server + Hono + TanStack Router + Better Auth
