### PR TITLE
test: guard stripe apiVersion and drizzle mysql connection literals

### DIFF
--- a/apps/cli/test/api-literal-drift.test.ts
+++ b/apps/cli/test/api-literal-drift.test.ts
@@ -1,0 +1,79 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "bun:test";
+
+/**
+ * API-literal drift guard.
+ *
+ * These templates embed third-party API literals directly in generated code.
+ * When the underlying SDK changes its expected shape, these literals must be
+ * bumped *intentionally* — a silent drift produces projects that compile but
+ * talk to the wrong API surface.
+ *
+ * Each expected value below is asserted against the literal currently shipped
+ * in the template. If you deliberately bump a literal (e.g. a Stripe API
+ * version), update the matching constant here in the same change so the guard
+ * stays meaningful. The test FAILS if a literal changes without that update.
+ */
+
+const TEMPLATES_DIR = resolve(
+  import.meta.dir,
+  "..",
+  "..",
+  "..",
+  "packages",
+  "template-generator",
+  "templates",
+);
+
+const STRIPE_LIB_TEMPLATE = resolve(
+  TEMPLATES_DIR,
+  "payments",
+  "stripe",
+  "server",
+  "base",
+  "src",
+  "lib",
+  "stripe.ts.hbs",
+);
+
+const DRIZZLE_MYSQL_TEMPLATE = resolve(
+  TEMPLATES_DIR,
+  "db",
+  "drizzle",
+  "mysql",
+  "src",
+  "index.ts.hbs",
+);
+
+// Bumping this requires an intentional template change (see file header).
+const EXPECTED_STRIPE_API_VERSION = "2024-12-18";
+
+// Drizzle's mysql2 driver expects a flat connection string plus `mode`.
+// The old, broken shape was `connection: { uri: env.DATABASE_URL }`.
+const EXPECTED_DRIZZLE_MYSQL_CONNECTION = "connection: env.DATABASE_URL";
+const EXPECTED_DRIZZLE_MYSQL_MODE = /mode:\s*"default"/;
+const FORBIDDEN_DRIZZLE_MYSQL_URI_FORM = /connection:\s*\{\s*uri\s*:/;
+
+describe("API-literal drift guard", () => {
+  it("keeps the Stripe apiVersion literal pinned", async () => {
+    const source = await readFile(STRIPE_LIB_TEMPLATE, "utf8");
+    const match = source.match(/apiVersion:\s*"([^"]+)"/);
+
+    expect(match).not.toBeNull();
+    // Equality (not substring) so any change to the literal fails the guard.
+    expect(match?.[1]).toBe(EXPECTED_STRIPE_API_VERSION);
+  });
+
+  it("keeps the Drizzle MySQL connection in the flat `mode`-based shape", async () => {
+    const source = await readFile(DRIZZLE_MYSQL_TEMPLATE, "utf8");
+
+    // New shape must be present...
+    expect(source).toContain(EXPECTED_DRIZZLE_MYSQL_CONNECTION);
+    expect(source).toMatch(EXPECTED_DRIZZLE_MYSQL_MODE);
+
+    // ...and the regressed object/`uri` shape must NOT come back.
+    expect(source).not.toMatch(FORBIDDEN_DRIZZLE_MYSQL_URI_FORM);
+    expect(source).not.toContain("uri:");
+  });
+});


### PR DESCRIPTION
## What

Adds a small, focused regression test (`apps/cli/test/api-literal-drift.test.ts`) that pins two in-code API literals embedded in templates, so they cannot drift silently. This is a Tier 2 quality item: these literals compile fine even when wrong, so a silent change produces projects that talk to the wrong API surface.

The test reads the `.hbs` files directly from disk and asserts their contents against clearly-named constants (with a header comment noting that an intentional literal bump must update the matching constant in the same change).

## Drift it catches

1. **Stripe `apiVersion`** in `packages/template-generator/templates/payments/stripe/server/base/src/lib/stripe.ts.hbs`. The value is extracted via regex and compared by equality, so any change to the version string fails the guard. Currently pinned to `2024-12-18`.
2. **Drizzle MySQL connection shape** in `packages/template-generator/templates/db/drizzle/mysql/src/index.ts.hbs`. Asserts the flat `connection: env.DATABASE_URL` + `mode: "default"` form is present and that the old, broken `connection: { uri: ... }` object form does not return.

## Verification

- `bun install`
- `bun test apps/cli/test/api-literal-drift.test.ts` -> 2 pass, 0 fail
- `check-types` (apps/cli, after building workspace deps) -> pass
- `lint` (apps/cli) -> pass
- Confirmed the guard genuinely fails: temporarily changing the Stripe `apiVersion`, and temporarily reverting the Drizzle MySQL connection to the `{ uri: ... }` form, each made the test fail. Both reverted.

Test-only change. No template or runtime code is modified.