### PR TITLE
fix(generator): populate database package.json in graph --part mode

### DIFF
--- a/apps/cli/test/cross-ecosystem-graph.test.ts
+++ b/apps/cli/test/cross-ecosystem-graph.test.ts
@@ -393,4 +393,49 @@ describe("Cross-ecosystem graph generation", () => {
       "policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()",
     );
   });
+
+  it("populates the database package with drizzle deps and scripts in graph mode", async () => {
+    const result = await createVirtual({
+      projectName: "graph-db",
+      frontend: [],
+      backend: "none",
+      api: "none",
+      runtime: "none",
+      stackParts: graphParts([
+        "frontend:typescript:next",
+        "backend:typescript:hono",
+        "backend.database:typescript:sqlite",
+        "backend.orm:typescript:drizzle",
+      ]),
+    });
+
+    expect(result.success).toBe(true);
+    const root = result.tree!.root;
+
+    const dbPackage = JSON.parse(fileContent(root, "packages/db/package.json")) as {
+      scripts?: Record<string, string>;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    // Regression: graph mode previously ran the database post-processing against
+    // the raw graph config (database/orm live in stackParts there), leaving the
+    // database package without any drizzle deps or scripts.
+    expect(dbPackage.dependencies?.["drizzle-orm"]).toBeDefined();
+    expect(dbPackage.dependencies?.["@libsql/client"]).toBeDefined();
+    expect(dbPackage.dependencies?.libsql).toBeDefined();
+    expect(dbPackage.devDependencies?.["drizzle-kit"]).toBeDefined();
+    expect(dbPackage.scripts?.["db:push"]).toBe("drizzle-kit push");
+    expect(dbPackage.scripts?.["db:generate"]).toBe("drizzle-kit generate");
+    expect(dbPackage.scripts?.["db:studio"]).toBe("drizzle-kit studio");
+    expect(dbPackage.scripts?.["db:migrate"]).toBe("drizzle-kit migrate");
+    expect(dbPackage.scripts?.["db:local"]).toBe("turso dev --db-file local.db");
+
+    // The catalog refs the database package relies on must be registered at root.
+    const rootPackage = JSON.parse(fileContent(root, "package.json")) as {
+      workspaces?: { catalog?: Record<string, string> };
+    };
+    expect(rootPackage.workspaces?.catalog?.["@libsql/client"]).toBeDefined();
+    expect(rootPackage.workspaces?.catalog?.libsql).toBeDefined();
+  });
 });

--- a/packages/template-generator/src/generator.ts
+++ b/packages/template-generator/src/generator.ts
@@ -8,8 +8,9 @@ import {
 import type { GeneratorOptions, GeneratorResult, VirtualFileTree } from "./types";
 
 import { VirtualFileSystem } from "./core/virtual-fs";
-import { processCatalogs, processPackageConfigs } from "./post-process";
+import { processCatalogs, processPackageConfigs, updateDbPackageJson } from "./post-process";
 import {
+  processDatabaseDeps,
   processDependencies,
   processReadme,
   processAuthPlugins,
@@ -154,6 +155,12 @@ async function processGraphTemplates(
       dbConfig.database === "redis"
     ) {
       await processDbTemplates(vfs, templates, dbConfig, databaseTargetPath);
+      // The shared post-process pass below runs against the raw graph config,
+      // where database/orm live in stackParts instead of the legacy fields, so it
+      // skips the database package. Populate its deps + scripts here using the
+      // resolved dbConfig so part-mode matches solo mode.
+      processDatabaseDeps(vfs, dbConfig, databaseTargetPath);
+      updateDbPackageJson(vfs, dbConfig, databaseTargetPath);
     }
     if (!vfs.directoryExists(databaseTargetPath)) {
       vfs.writeFile(

--- a/packages/template-generator/src/post-process/index.ts
+++ b/packages/template-generator/src/post-process/index.ts
@@ -1,2 +1,2 @@
 export { processCatalogs } from "./catalogs";
-export { processPackageConfigs } from "./package-configs";
+export { processPackageConfigs, updateDbPackageJson } from "./package-configs";

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -304,8 +304,13 @@ function getWorkspaceTool(addons: ProjectConfig["addons"]): WorkspaceTool {
   return null;
 }
 
-function updateDbPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): void {
-  const pkgJson = vfs.readJson<PackageJson>("packages/db/package.json");
+export function updateDbPackageJson(
+  vfs: VirtualFileSystem,
+  config: ProjectConfig,
+  dbDir = "packages/db",
+): void {
+  const dbPkgPath = `${dbDir}/package.json`;
+  const pkgJson = vfs.readJson<PackageJson>(dbPkgPath);
   if (!pkgJson) return;
 
   pkgJson.name = `@${config.projectName}/db`;
@@ -345,7 +350,7 @@ function updateDbPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): voi
     scripts["db:down"] = "docker compose down";
   }
 
-  vfs.writeJson("packages/db/package.json", pkgJson);
+  vfs.writeJson(dbPkgPath, pkgJson);
 }
 
 function updateAuthPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): void {

--- a/packages/template-generator/src/processors/db-deps.ts
+++ b/packages/template-generator/src/processors/db-deps.ts
@@ -4,12 +4,16 @@ import type { VirtualFileSystem } from "../core/virtual-fs";
 
 import { addPackageDependency, type AvailableDependencies } from "../utils/add-deps";
 
-export function processDatabaseDeps(vfs: VirtualFileSystem, config: ProjectConfig): void {
+export function processDatabaseDeps(
+  vfs: VirtualFileSystem,
+  config: ProjectConfig,
+  dbPackageDir = "packages/db",
+): void {
   const { database, orm, backend } = config;
 
   if (backend === "convex" || database === "none") return;
 
-  const dbPkgPath = "packages/db/package.json";
+  const dbPkgPath = `${dbPackageDir}/package.json`;
   const webPkgPath = "apps/web/package.json";
 
   if (!vfs.exists(dbPkgPath)) return;


### PR DESCRIPTION
## Problem

In multi-ecosystem graph (`--part`) generation, the database package
(`packages/db`) was created from its base template but never received the
ORM dependencies or `db:*` scripts. For a sqlite + drizzle stack it ended up
effectively empty — no `drizzle-orm`/`drizzle-kit`/`@libsql/client`/`libsql`
and `"scripts": {}`. This was silent because nothing imports the package, but
`bun run db:push` / `db:generate` / `db:studio` did not work. Solo mode
generated the same package correctly.

### Root cause

`processGraphTemplates` generates the database files via `processDbTemplates`
using a resolved `dbConfig` (correct `database`/`orm`), but the database
package's deps + scripts are produced by `processDatabaseDeps` (db-deps) and
`updateDbPackageJson` (package-configs). In the graph path those only run as
part of the final shared post-process pass, which is invoked with the **raw
graph config** — there `database`/`orm` live in `stackParts`, not the legacy
top-level fields, so both processors short-circuit (`database === "none"`) and
leave the database package untouched. (The earlier `tsConfig` pass runs before
the db package exists, so it is a no-op too.)

## Fix

Populate the database package inside the graph database block, right after its
templates are generated, using the already-resolved `dbConfig` and target path
— exactly the data solo mode uses. `processDatabaseDeps` and
`updateDbPackageJson` now accept the target package directory (defaulting to
`packages/db`), so solo behavior is byte-identical and the standalone database
part is filled in correctly.

Files:
- `packages/template-generator/src/generator.ts` — call the db deps + scripts processors in the graph db block
- `packages/template-generator/src/processors/db-deps.ts` — optional `dbPackageDir` param
- `packages/template-generator/src/post-process/package-configs.ts` — export + optional `dbDir` param on `updateDbPackageJson`
- `packages/template-generator/src/post-process/index.ts` — export `updateDbPackageJson`
- `apps/cli/test/cross-ecosystem-graph.test.ts` — regression test

## Before / after (`packages/db/package.json`, graph sqlite + drizzle)

Before:
```json
{
  "name": "@app/db",
  "scripts": {},
  "devDependencies": { "typescript": "^6.0.3", "@app/config": "workspace:*" },
  "dependencies": { "dotenv": "^17.4.2", "zod": "^4.4.3", "@app/env": "workspace:*" }
}
```

After:
```json
{
  "name": "@app/db",
  "scripts": {
    "db:local": "turso dev --db-file local.db",
    "db:push": "drizzle-kit push",
    "db:generate": "drizzle-kit generate",
    "db:studio": "drizzle-kit studio",
    "db:migrate": "drizzle-kit migrate"
  },
  "devDependencies": { "drizzle-kit": "^0.31.10", "typescript": "^6.0.3", "@app/config": "workspace:*" },
  "dependencies": {
    "drizzle-orm": "^0.45.2",
    "@libsql/client": "catalog:",
    "libsql": "catalog:",
    "dotenv": "^17.4.2",
    "zod": "^4.4.3",
    "@app/env": "workspace:*"
  }
}
```

The required `catalog:` versions (`@libsql/client`, `libsql`) are registered in
the root catalog, and the root `db:*` scripts already filter to the package.
Verified across combos: sqlite+drizzle, postgres+drizzle (`pg`/`@types/pg`, no
`db:local`), sqlite+prisma (`@prisma/client`/adapter + prisma scripts +
`postinstall`), with and without a frontend/backend part.

## Verification

- Type-check (template-generator src + tests, cli): pass
- `turbo lint` (template-generator, cli): pass
- `bun run test:release`: pass — 87 snapshots unchanged (solo output identical; the change only affects the graph path, which is not snapshotted)
- New regression test in `cross-ecosystem-graph.test.ts`: pass
