### PR TITLE
feat(cli): add telemetry notice and bfs telemetry toggle command

### DIFF
--- a/apps/cli/src/commands/telemetry.ts
+++ b/apps/cli/src/commands/telemetry.ts
@@ -1,0 +1,106 @@
+import { intro, log } from "@clack/prompts";
+import pc from "picocolors";
+
+import { hasTelemetryEnvOverride, isTelemetryEnabled } from "../utils/analytics";
+import { renderTitle } from "../utils/render-title";
+import { getPersistedTelemetryPreference, setTelemetryPreference } from "../utils/telemetry-settings";
+
+export type TelemetryAction = "status" | "enable" | "disable";
+
+export type TelemetryCommandInput = {
+  action: TelemetryAction;
+  json: boolean;
+};
+
+const COLLECTED = [
+  "Selected stack options (frontend, backend, database, ORM, auth, API, etc.)",
+  "CLI version, Node.js version, and OS platform",
+];
+
+const NOT_COLLECTED = [
+  "Project names, directory paths, or file contents",
+  "Personal or otherwise identifying information",
+];
+
+type TelemetrySource = "env" | "preference" | "default";
+
+function resolveSource(persisted: boolean | undefined): TelemetrySource {
+  if (hasTelemetryEnvOverride()) return "env";
+  if (persisted !== undefined) return "preference";
+  return "default";
+}
+
+function describeSource(source: TelemetrySource): string {
+  switch (source) {
+    case "env":
+      return "environment variable (BTS_TELEMETRY_DISABLED)";
+    case "preference":
+      return "saved preference (create-better-fullstack telemetry enable/disable)";
+    default:
+      return "default";
+  }
+}
+
+export async function telemetryHandler(input: TelemetryCommandInput): Promise<void> {
+  if (input.action === "enable") {
+    await setTelemetryPreference(true);
+    log.success(pc.green("Telemetry enabled. Thanks for helping improve Better Fullstack."));
+    return;
+  }
+
+  if (input.action === "disable") {
+    await setTelemetryPreference(false);
+    log.success(pc.green("Telemetry disabled. No anonymous usage data will be sent."));
+    return;
+  }
+
+  // status
+  const enabled = await isTelemetryEnabled();
+  const persisted = await getPersistedTelemetryPreference();
+  const source = resolveSource(persisted);
+
+  if (input.json) {
+    console.log(
+      JSON.stringify(
+        {
+          enabled,
+          source,
+          persisted: persisted ?? null,
+          envOverride: hasTelemetryEnvOverride(),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  renderTitle();
+  intro(pc.magenta("Telemetry"));
+
+  log.message(
+    `${pc.bold("Status:")} ${enabled ? pc.green("enabled") : pc.yellow("disabled")} ${pc.dim(
+      `(${describeSource(source)})`,
+    )}`,
+  );
+
+  log.message("");
+  log.message(pc.bold("What is sent when enabled:"));
+  for (const item of COLLECTED) {
+    log.message(`  ${pc.green("+")} ${item}`);
+  }
+
+  log.message(pc.bold("What is never sent:"));
+  for (const item of NOT_COLLECTED) {
+    log.message(`  ${pc.red("-")} ${item}`);
+  }
+
+  log.message("");
+  log.message(
+    pc.dim(
+      `Change anytime: ${pc.cyan("create-better-fullstack telemetry enable")} / ` +
+        `${pc.cyan("create-better-fullstack telemetry disable")} ` +
+        `(or set ${pc.cyan("BTS_TELEMETRY_DISABLED=1")}).`,
+    ),
+  );
+}

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -10,7 +10,7 @@ import { getDefaultConfig } from "../../constants";
 import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
 import { getVersionChannelChoice } from "../../prompts/version-channel";
-import { trackProjectCreation } from "../../utils/analytics";
+import { maybeShowTelemetryNotice, trackProjectCreation } from "../../utils/analytics";
 import { resolveCreateConfigBase } from "../../utils/config-source";
 import { isSilent, runWithContextAsync } from "../../utils/context";
 import { displayConfig } from "../../utils/display-config";
@@ -118,6 +118,10 @@ export async function createProjectHandler(
         renderTitle();
       }
       if (!isSilent()) intro(pc.magenta("Creating a new Better Fullstack project"));
+
+      // One-time notice about anonymous telemetry (self-gated: interactive only,
+      // skipped once a preference is persisted or an env override is set).
+      await maybeShowTelemetryNotice();
 
       if (!isSilent() && input.yolo) {
         consola.fatal("YOLO mode enabled - skipping checks. Things may break!");

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,7 +1,7 @@
 // Lean public entry: re-exports the CLI (run.ts) and the programmatic API.
 // The bin entry (cli.ts) imports ./run.js directly so plain CLI startup
 // never pays the cost of loading the embedded templates bundle below.
-export { router, createBtsCli, create, sponsors, docs, builder, add, history } from "./run";
+export { router, createBtsCli, create, sponsors, docs, builder, add, history, telemetry } from "./run";
 
 import type { ProjectConfig } from "./types";
 

--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -5,6 +5,7 @@ import { createCli } from "trpc-cli";
 import z from "zod";
 
 import { historyHandler } from "./commands/history";
+import { telemetryHandler } from "./commands/telemetry";
 import { CreateCommandInputSchema } from "./create-command-input";
 import type { AddResult } from "./helpers/core/add-handler";
 import { createProjectHandler } from "./helpers/core/command-handlers";
@@ -265,6 +266,27 @@ export const router = os.router({
     .handler(async ({ input }) => {
       await historyHandler(input);
     }),
+  telemetry: os
+    .meta({
+      description:
+        "View or change anonymous usage telemetry collection (status | enable | disable)",
+    })
+    .input(
+      z.tuple([
+        z
+          .enum(["status", "enable", "disable"])
+          .optional()
+          .default("status")
+          .describe("Action to perform: status (default), enable, or disable"),
+        z.object({
+          json: z.boolean().optional().default(false).describe("Output status as JSON"),
+        }),
+      ]),
+    )
+    .handler(async ({ input }) => {
+      const [action, options] = input;
+      await telemetryHandler({ action, json: options.json });
+    }),
   "update-deps": os
     .meta({ description: "Check and update dependency versions in add-deps.ts" })
     .input(
@@ -386,4 +408,11 @@ export async function history(options?: { limit?: number; clear?: boolean; json?
     clear: options?.clear ?? false,
     json: options?.json ?? false,
   });
+}
+
+export async function telemetry(
+  action: "status" | "enable" | "disable" = "status",
+  options?: { json?: boolean },
+) {
+  return caller.telemetry([action, { json: options?.json ?? false }]);
 }

--- a/apps/cli/src/utils/analytics.ts
+++ b/apps/cli/src/utils/analytics.ts
@@ -1,21 +1,89 @@
+import { log } from "@clack/prompts";
+import pc from "picocolors";
+
 import type { ProjectConfig } from "../types";
 
 import { getLatestCLIVersion } from "./get-latest-cli-version";
+import { canPromptInteractively } from "./prompt-environment";
+import {
+  getPersistedTelemetryPreference,
+  hasTelemetryNoticeBeenShown,
+  markTelemetryNoticeShown,
+} from "./telemetry-settings";
 
 const CONVEX_INGEST_URL = process.env.CONVEX_INGEST_URL;
 
-function isTelemetryEnabled() {
+/**
+ * Whether telemetry is explicitly overridden at runtime.
+ *
+ * Only `BTS_TELEMETRY_DISABLED` is a runtime override: `BTS_TELEMETRY` is inlined
+ * by the bundler at build time (see tsdown.config.ts) and therefore acts as a
+ * build-time default, not a runtime switch.
+ */
+export function hasTelemetryEnvOverride(): boolean {
+  return process.env.BTS_TELEMETRY_DISABLED !== undefined;
+}
+
+/**
+ * Resolve whether telemetry is enabled.
+ *
+ * Precedence: runtime env override (`BTS_TELEMETRY_DISABLED`) > persisted
+ * preference > default. The default honors the build-time `BTS_TELEMETRY` flag
+ * (inlined by the bundler, "0" by default) and falls back to enabled when the
+ * flag is unset (e.g. running from source).
+ *
+ * `BTS_TELEMETRY` is intentionally evaluated last: the bundler replaces it with
+ * a literal, so an early `!== undefined` check would always short-circuit and
+ * make the persisted preference unreachable in the shipped CLI.
+ */
+export async function isTelemetryEnabled(): Promise<boolean> {
   const disabled = process.env.BTS_TELEMETRY_DISABLED;
   if (disabled !== undefined) {
     return disabled !== "1";
   }
 
-  const enabled = process.env.BTS_TELEMETRY;
-  if (enabled !== undefined) {
-    return enabled === "1";
+  const persisted = await getPersistedTelemetryPreference();
+  if (persisted !== undefined) {
+    return persisted;
   }
 
-  return true;
+  const buildDefault = process.env.BTS_TELEMETRY;
+  return buildDefault === undefined ? true : buildDefault === "1";
+}
+
+/**
+ * Print a one-time notice describing the anonymous telemetry the CLI collects
+ * and how to opt out, then remember that it was shown so it never repeats.
+ *
+ * No-ops when telemetry is explicitly configured via env var, when a persisted
+ * preference already exists, when the notice was already shown, when telemetry
+ * is disabled by the build default, or when the CLI is not running interactively
+ * (CI / silent / non-TTY).
+ */
+export async function maybeShowTelemetryNotice(): Promise<void> {
+  if (hasTelemetryEnvOverride()) return;
+  if (!canPromptInteractively()) return;
+
+  const persisted = await getPersistedTelemetryPreference();
+  if (persisted !== undefined) return;
+
+  if (await hasTelemetryNoticeBeenShown()) return;
+
+  // Nothing to disclose if telemetry is off by default for this build.
+  if (!(await isTelemetryEnabled())) return;
+
+  log.info(
+    `${pc.bold("Anonymous usage telemetry is enabled.")}\n` +
+      `${pc.dim("We collect your selected stack options (e.g. frontend, backend, database),")}\n` +
+      `${pc.dim("plus CLI version, Node.js version, and OS platform — never project names,")}\n` +
+      `${pc.dim("file paths, or any personal data.")}\n` +
+      `Opt out anytime with ${pc.cyan("create-better-fullstack telemetry disable")} ` +
+      `or ${pc.cyan("BTS_TELEMETRY_DISABLED=1")}.`,
+  );
+
+  try {
+    await markTelemetryNoticeShown();
+  } catch {}
 }
 
 async function sendConvexEvent(payload: Record<string, unknown>) {
@@ -33,7 +101,7 @@ async function sendConvexEvent(payload: Record<string, unknown>) {
 }
 
 export async function trackProjectCreation(config: ProjectConfig, disableAnalytics = false) {
-  if (!isTelemetryEnabled() || disableAnalytics) return;
+  if (disableAnalytics || !(await isTelemetryEnabled())) return;
 
   const {
     projectName: _projectName,

--- a/apps/cli/src/utils/telemetry-settings.ts
+++ b/apps/cli/src/utils/telemetry-settings.ts
@@ -1,0 +1,80 @@
+import envPaths from "env-paths";
+import fs from "fs-extra";
+import path from "node:path";
+
+// Reuses the same config dir as project-history.ts so all CLI state lives together.
+const paths = envPaths("better-fullstack", { suffix: "" });
+const SETTINGS_FILE = "telemetry.json";
+
+export type TelemetrySettings = {
+  version: number;
+  // Explicit persisted opt-in/opt-out. `undefined` means the user never chose.
+  enabled?: boolean;
+  // Whether the one-time first-run notice has already been displayed.
+  noticeShown: boolean;
+};
+
+function getSettingsPath(): string {
+  return path.join(paths.data, SETTINGS_FILE);
+}
+
+function emptySettings(): TelemetrySettings {
+  return { version: 1, noticeShown: false };
+}
+
+export async function readTelemetrySettings(): Promise<TelemetrySettings> {
+  const settingsPath = getSettingsPath();
+
+  if (!(await fs.pathExists(settingsPath))) {
+    return emptySettings();
+  }
+
+  try {
+    const data = (await fs.readJson(settingsPath)) as Partial<TelemetrySettings> | null;
+    if (!data || typeof data !== "object") {
+      return emptySettings();
+    }
+    return {
+      version: typeof data.version === "number" ? data.version : 1,
+      enabled: typeof data.enabled === "boolean" ? data.enabled : undefined,
+      noticeShown: data.noticeShown === true,
+    };
+  } catch {
+    return emptySettings();
+  }
+}
+
+async function writeTelemetrySettings(settings: TelemetrySettings): Promise<void> {
+  await fs.ensureDir(paths.data);
+  await fs.writeJson(getSettingsPath(), settings, { spaces: 2 });
+}
+
+/**
+ * The user's explicit persisted preference, or `undefined` when they never chose.
+ */
+export async function getPersistedTelemetryPreference(): Promise<boolean | undefined> {
+  const settings = await readTelemetrySettings();
+  return settings.enabled;
+}
+
+/**
+ * Persist an explicit opt-in/opt-out. Choosing a preference also marks the
+ * first-run notice as shown so it never appears afterwards.
+ */
+export async function setTelemetryPreference(enabled: boolean): Promise<void> {
+  const settings = await readTelemetrySettings();
+  settings.enabled = enabled;
+  settings.noticeShown = true;
+  await writeTelemetrySettings(settings);
+}
+
+export async function hasTelemetryNoticeBeenShown(): Promise<boolean> {
+  const settings = await readTelemetrySettings();
+  return settings.noticeShown;
+}
+
+export async function markTelemetryNoticeShown(): Promise<void> {
+  const settings = await readTelemetrySettings();
+  settings.noticeShown = true;
+  await writeTelemetrySettings(settings);
+}

--- a/apps/cli/test/add-history-commands.test.ts
+++ b/apps/cli/test/add-history-commands.test.ts
@@ -357,3 +357,95 @@ describe("CLI history command", () => {
     expect(parsedHistory[0]?.reproducibleCommand).toBe(expectedCommand);
   });
 });
+
+function telemetrySettingsPath(homeDir: string): string {
+  if (process.platform === "darwin") {
+    return join(homeDir, "Library", "Application Support", "better-fullstack", "telemetry.json");
+  }
+  // Linux/others: XDG_DATA_HOME is set to <homeDir>/.local/share below.
+  return join(homeDir, ".local", "share", "better-fullstack", "telemetry.json");
+}
+
+describe("CLI telemetry command", () => {
+  it("reports status, persists enable/disable, and honors env override precedence", async () => {
+    const root = await makeTempRoot("bfs-telemetry-test-");
+    const homeDir = join(root, "home");
+    await mkdir(homeDir, { recursive: true });
+
+    const sharedEnv = {
+      HOME: homeDir,
+      XDG_CONFIG_HOME: join(homeDir, ".config"),
+      XDG_DATA_HOME: join(homeDir, ".local", "share"),
+    };
+
+    // Default (no preference, no env override): enabled, source "default".
+    const statusDefault = await runCli(["telemetry", "status", "--json"], {
+      cwd: root,
+      env: sharedEnv,
+    });
+    expect(statusDefault.exitCode).toBe(0);
+    const parsedDefault = JSON.parse(cliOutput(statusDefault)) as {
+      enabled: boolean;
+      source: string;
+      persisted: boolean | null;
+    };
+    expect(parsedDefault.enabled).toBe(true);
+    expect(parsedDefault.source).toBe("default");
+    expect(parsedDefault.persisted).toBeNull();
+
+    // Disable persists the preference to disk.
+    const disableResult = await runCli(["telemetry", "disable"], { cwd: root, env: sharedEnv });
+    expect(disableResult.exitCode).toBe(0);
+    expect(cliOutput(disableResult)).toContain("Telemetry disabled");
+
+    const settingsPath = telemetrySettingsPath(homeDir);
+    const persisted = JSON.parse(await readFile(settingsPath, "utf8")) as {
+      enabled?: boolean;
+      noticeShown?: boolean;
+    };
+    expect(persisted.enabled).toBe(false);
+    expect(persisted.noticeShown).toBe(true);
+
+    // A fresh process reads the persisted preference.
+    const statusDisabled = await runCli(["telemetry", "status", "--json"], {
+      cwd: root,
+      env: sharedEnv,
+    });
+    const parsedDisabled = JSON.parse(cliOutput(statusDisabled)) as {
+      enabled: boolean;
+      source: string;
+      persisted: boolean | null;
+    };
+    expect(parsedDisabled.enabled).toBe(false);
+    expect(parsedDisabled.source).toBe("preference");
+    expect(parsedDisabled.persisted).toBe(false);
+
+    // Re-enable.
+    const enableResult = await runCli(["telemetry", "enable"], { cwd: root, env: sharedEnv });
+    expect(enableResult.exitCode).toBe(0);
+    expect(cliOutput(enableResult)).toContain("Telemetry enabled");
+
+    const statusEnabled = await runCli(["telemetry", "status", "--json"], {
+      cwd: root,
+      env: sharedEnv,
+    });
+    const parsedEnabled = JSON.parse(cliOutput(statusEnabled)) as {
+      enabled: boolean;
+      source: string;
+    };
+    expect(parsedEnabled.enabled).toBe(true);
+    expect(parsedEnabled.source).toBe("preference");
+
+    // Env override beats the persisted (enabled) preference.
+    const statusEnvOverride = await runCli(["telemetry", "status", "--json"], {
+      cwd: root,
+      env: { ...sharedEnv, BTS_TELEMETRY_DISABLED: "1" },
+    });
+    const parsedEnvOverride = JSON.parse(cliOutput(statusEnvOverride)) as {
+      enabled: boolean;
+      source: string;
+    };
+    expect(parsedEnvOverride.enabled).toBe(false);
+    expect(parsedEnvOverride.source).toBe("env");
+  });
+});


### PR DESCRIPTION
## Problem

CLI telemetry was a silent opt-out controlled only by the `BTS_TELEMETRY_DISABLED` / `BTS_TELEMETRY` environment variables (`apps/cli/src/utils/analytics.ts`). There was no first-run notice, no way to persist a preference, and no user-facing command — so users had no clear, discoverable way to see what is collected or to opt out for good.

## Fix

- **Persisted preference** — new `apps/cli/src/utils/telemetry-settings.ts` stores the opt-in/opt-out flag and the first-run-notice flag in `telemetry.json`, reusing the same config dir pattern as `project-history.ts` (`env-paths` data dir).
- **Precedence in `isTelemetryEnabled()`** — runtime env override (`BTS_TELEMETRY_DISABLED`) > persisted preference > build-time default. `BTS_TELEMETRY` is inlined by the bundler (the `env` define in `tsdown.config.ts`), so it is treated as the build-time default and evaluated **last**; evaluating it early via `!== undefined` would always short-circuit and dead-code the persisted-preference branch in the shipped binary. Disabled behavior is unchanged.
- **First-run notice** — printed once on the first interactive `create` run (skipped in CI / silent / non-TTY, when a preference is already set, when an env override is present, or when telemetry is off by the build default). It records that it was shown so it never repeats.
- **`telemetry` command** — `status` (shows current state, source, and exactly what is/ is not sent; supports `--json`), `enable`, and `disable`. Registered in `apps/cli/src/run.ts` mirroring the existing `history` command, with a matching programmatic export.

No changes to what data is collected, and no changes to the build's telemetry baking.

## Verification

Scoped to the `create-better-fullstack` package (where all changes live):

- `check-types` — PASS
- `lint` (oxlint + tsc + builder-sync) — PASS
- `test` — PASS (added a focused test in `apps/cli/test/add-history-commands.test.ts` covering enable/disable/status, on-disk persistence, and env-override precedence)
- `build` — PASS

Also verified against the **built** bundle that `telemetry enable` now overrides the build default and that `BTS_TELEMETRY_DISABLED` wins over a persisted preference (this is the exact path that was dead-coded before the precedence fix).