### PR TITLE
feat(cli): support create --from-history and --config

### DIFF
--- a/apps/cli/src/create-command-input.ts
+++ b/apps/cli/src/create-command-input.ts
@@ -138,6 +138,16 @@ import {
 
 export const CreateCommandOptionsSchema = z.object({
   template: TemplateSchema.optional().describe("Use a predefined template"),
+  fromHistory: z
+    .number()
+    .optional()
+    .describe(
+      "Replay the stack of the Nth most-recent project from history (1 = most recent)",
+    ),
+  config: z
+    .string()
+    .optional()
+    .describe("Path to a bts.jsonc/JSON config file to use as the base stack"),
   yes: z.boolean().optional().default(false).describe("Use default configuration"),
   yolo: z
     .boolean()

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -11,6 +11,7 @@ import { gatherConfig } from "../../prompts/config-prompts";
 import { getProjectName } from "../../prompts/project-name";
 import { getVersionChannelChoice } from "../../prompts/version-channel";
 import { trackProjectCreation } from "../../utils/analytics";
+import { resolveCreateConfigBase } from "../../utils/config-source";
 import { isSilent, runWithContextAsync } from "../../utils/context";
 import { displayConfig } from "../../utils/display-config";
 import { CLIError, UserCancelledError } from "../../utils/errors";
@@ -85,8 +86,17 @@ function getYesBaseConfig(flagConfig: Partial<ProjectConfig>): ProjectConfig {
   };
 }
 
-function shouldPromptForVersionChannel(input: CreateInput & { projectName?: string }): boolean {
-  if (input.yes || input.part?.length || input.versionChannel !== undefined || isSilent()) {
+function shouldPromptForVersionChannel(
+  input: CreateInput & { projectName?: string },
+  hasConfigBase: boolean,
+): boolean {
+  if (
+    input.yes ||
+    input.part?.length ||
+    hasConfigBase ||
+    input.versionChannel !== undefined ||
+    isSilent()
+  ) {
     return false;
   }
 
@@ -94,7 +104,7 @@ function shouldPromptForVersionChannel(input: CreateInput & { projectName?: stri
 }
 
 export async function createProjectHandler(
-  input: CreateInput & { projectName?: string },
+  input: CreateInput & { projectName?: string; fromHistory?: number; config?: string },
   options: CreateHandlerOptions = {},
 ) {
   const { silent = false } = options;
@@ -113,10 +123,25 @@ export async function createProjectHandler(
         consola.fatal("YOLO mode enabled - skipping checks. Things may break!");
       }
 
+      const configBase = await resolveCreateConfigBase(input);
+      const hasConfigBase = configBase !== undefined;
+      if (hasConfigBase && !isSilent()) {
+        log.info(
+          pc.cyan(
+            input.config
+              ? `Using stack from config file: ${input.config}`
+              : `Using stack from history entry #${input.fromHistory}`,
+          ),
+        );
+      }
+
+      // A config base (from history or a file) supplies a complete stack, so we
+      // skip the interactive project-name prompt just like --yes does.
+      const useDefaultsForName = Boolean(input.yes) || hasConfigBase;
       let currentPathInput: string;
-      if (input.yes && input.projectName) {
+      if (useDefaultsForName && input.projectName) {
         currentPathInput = input.projectName;
-      } else if (input.yes) {
+      } else if (useDefaultsForName) {
         const defaultConfig = getDefaultConfig();
         let defaultName: string = defaultConfig.relativePath;
         let counter = 1;
@@ -132,9 +157,9 @@ export async function createProjectHandler(
         currentPathInput = await getProjectName(input.projectName);
       }
 
-      const versionChannel = shouldPromptForVersionChannel(input)
+      const versionChannel = shouldPromptForVersionChannel(input, hasConfigBase)
         ? await getVersionChannelChoice()
-        : (input.versionChannel ?? "stable");
+        : (input.versionChannel ?? configBase?.versionChannel ?? "stable");
 
       let finalResolvedPath: string;
       let finalBaseName: string;
@@ -310,12 +335,24 @@ export async function createProjectHandler(
         currentPathInput = finalPathInput;
       }
 
-      const originalInput = {
-        ...input,
+      // Overlay any explicitly-passed flags on top of the config base so the
+      // user can override individual options from a replayed/loaded config.
+      const definedInput = Object.fromEntries(
+        Object.entries(input).filter(([, value]) => value !== undefined),
+      ) as typeof input;
+      const explicitInput = {
+        ...definedInput,
         projectDirectory: input.projectName,
       };
+      const originalInput = {
+        ...configBase,
+        ...explicitInput,
+      };
 
-      const providedFlags = getProvidedFlags(originalInput);
+      // Only flags the user explicitly passed count as "provided" for strict
+      // compatibility checks; config-base values are treated as defaults (the
+      // same leniency --yes uses for a trusted config).
+      const providedFlags = getProvidedFlags(explicitInput);
 
       let cliInput = originalInput;
 
@@ -348,7 +385,7 @@ export async function createProjectHandler(
       const { validatePreflightConfig } = await import("@better-fullstack/template-generator");
 
       let config: ProjectConfig;
-      if (cliInput.yes || cliInput.part?.length) {
+      if (cliInput.yes || cliInput.part?.length || hasConfigBase) {
         const flagConfig = processProvidedFlagsWithoutValidation(cliInput, finalBaseName);
 
         config = {

--- a/apps/cli/src/utils/bts-config.ts
+++ b/apps/cli/src/utils/bts-config.ts
@@ -240,7 +240,7 @@ function syncUpdatedStackParts(
   return next;
 }
 
-function buildBtsConfigForPersistence(
+export function buildBtsConfigForPersistence(
   projectConfig: ProjectConfig,
   metadata: Partial<BtsConfigMetadata> = {},
 ): BetterTStackConfig {
@@ -575,6 +575,42 @@ export async function readBtsConfig(projectDir: string) {
 
     if (errors.length > 0) {
       console.warn("Warning: Found errors parsing bts.jsonc:", errors);
+      return null;
+    }
+
+    return buildBtsConfigForPersistence(config as unknown as ProjectConfig, {
+      version: config.version,
+      createdAt: config.createdAt,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function readBtsConfigFromFile(filePath: string) {
+  try {
+    const resolved = path.resolve(process.cwd(), filePath);
+
+    if (!(await fs.pathExists(resolved))) {
+      return null;
+    }
+
+    const stats = await fs.stat(resolved);
+    const configPath = stats.isDirectory() ? path.join(resolved, BTS_CONFIG_FILE) : resolved;
+
+    if (!(await fs.pathExists(configPath))) {
+      return null;
+    }
+
+    const configContent = await fs.readFile(configPath, "utf-8");
+
+    const errors: JSONC.ParseError[] = [];
+    const config = JSONC.parse(configContent, errors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    }) as BetterTStackConfig;
+
+    if (errors.length > 0 || config === undefined || typeof config !== "object") {
       return null;
     }
 

--- a/apps/cli/src/utils/config-source.ts
+++ b/apps/cli/src/utils/config-source.ts
@@ -1,0 +1,145 @@
+import type { BetterTStackConfig, CreateInput } from "../types";
+import type { ProjectHistoryEntry } from "./project-history";
+
+import { CreateInputSchema } from "../types";
+import { readBtsConfigFromFile } from "./bts-config";
+import { exitWithError } from "./errors";
+import { getHistoryCount, getHistoryEntry } from "./project-history";
+
+/**
+ * CreateInput flag keys that can be sourced from a stored config. `projectName`
+ * is excluded so a replayed config never reuses the original project name.
+ */
+const COPYABLE_CREATE_INPUT_KEYS = (
+  Object.keys(CreateInputSchema.shape) as (keyof CreateInput)[]
+).filter((key) => key !== "projectName");
+
+/**
+ * Projects a persisted Better-Fullstack config (bts.jsonc shape) onto the
+ * subset of `create` flags it can drive. Only defined values are copied so the
+ * result can be safely overlaid by explicitly-passed CLI flags.
+ */
+export function betterTStackConfigToCreateInput(
+  config: BetterTStackConfig,
+): Partial<CreateInput> {
+  const source = config as unknown as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+
+  for (const key of COPYABLE_CREATE_INPUT_KEYS) {
+    const value = source[key];
+    if (value !== undefined && value !== null) {
+      result[key] = value;
+    }
+  }
+
+  return result as Partial<CreateInput>;
+}
+
+/**
+ * Maps a legacy history entry (written before the full config snapshot existed)
+ * onto `create` flags using the limited stack summary it stored.
+ */
+function historyStackToCreateInput(
+  stack: ProjectHistoryEntry["stack"],
+): Partial<CreateInput> {
+  const result: Record<string, unknown> = {
+    frontend: stack.frontend,
+    backend: stack.backend,
+    database: stack.database,
+    orm: stack.orm,
+    runtime: stack.runtime,
+    auth: stack.auth,
+    payments: stack.payments,
+    api: stack.api,
+    addons: stack.addons,
+    examples: stack.examples,
+    dbSetup: stack.dbSetup,
+    packageManager: stack.packageManager,
+  };
+
+  return result as Partial<CreateInput>;
+}
+
+type ConfigSourceInput = {
+  fromHistory?: number;
+  config?: string;
+  yes?: boolean;
+  template?: string;
+  part?: string[];
+};
+
+/**
+ * Resolves the `--from-history` / `--config` flags into a base set of `create`
+ * flags. Returns `undefined` when neither flag is used. The two flags are
+ * mutually exclusive, and both are incompatible with `--yes`, `--template`, and
+ * `--part` (each of those also wants to own the full stack). On any user error
+ * this calls `exitWithError`, which exits the CLI (or throws a CLIError in
+ * silent/programmatic mode).
+ */
+export async function resolveCreateConfigBase(
+  input: ConfigSourceInput,
+): Promise<Partial<CreateInput> | undefined> {
+  const hasHistory = input.fromHistory !== undefined;
+  const hasConfig = input.config !== undefined && input.config !== "";
+
+  if (!hasHistory && !hasConfig) {
+    return undefined;
+  }
+
+  if (hasHistory && hasConfig) {
+    exitWithError(
+      "Cannot combine --from-history with --config. Pass only one config source.",
+    );
+  }
+
+  const sourceFlag = hasHistory ? "--from-history" : "--config";
+
+  if (input.yes) {
+    exitWithError(
+      `Cannot combine --yes with ${sourceFlag}: the config already provides a complete stack. Remove --yes.`,
+    );
+  }
+
+  if (input.template && input.template !== "none") {
+    exitWithError(
+      `Cannot combine --template with ${sourceFlag}. Choose either a template or a saved config as the base.`,
+    );
+  }
+
+  if (input.part && input.part.length > 0) {
+    exitWithError(
+      `Cannot combine --part with ${sourceFlag}. Use stack parts or a saved config as the base, not both.`,
+    );
+  }
+
+  if (hasConfig) {
+    const loaded = await readBtsConfigFromFile(input.config!);
+    if (!loaded) {
+      exitWithError(
+        `Could not load config file: ${input.config}. Ensure the path points to a valid bts.jsonc/JSON config.`,
+      );
+    }
+    return betterTStackConfigToCreateInput(loaded);
+  }
+
+  const position = input.fromHistory!;
+  if (!Number.isInteger(position) || position < 1) {
+    exitWithError(
+      `Invalid --from-history value: ${position}. Provide a positive integer (1 = most recent).`,
+    );
+  }
+
+  const entry = await getHistoryEntry(position);
+  if (!entry) {
+    const count = await getHistoryCount();
+    const detail =
+      count === 0
+        ? " Project history is empty."
+        : ` History has ${count} ${count === 1 ? "entry" : "entries"} (use 1-${count}).`;
+    exitWithError(`No project history entry at position ${position}.${detail}`);
+  }
+
+  return entry.config
+    ? betterTStackConfigToCreateInput(entry.config)
+    : historyStackToCreateInput(entry.stack);
+}

--- a/apps/cli/src/utils/project-history.ts
+++ b/apps/cli/src/utils/project-history.ts
@@ -2,8 +2,9 @@ import envPaths from "env-paths";
 import fs from "fs-extra";
 import path from "node:path";
 
-import type { ProjectConfig } from "../types";
+import type { BetterTStackConfig, ProjectConfig } from "../types";
 
+import { buildBtsConfigForPersistence } from "./bts-config";
 import { getLatestCLIVersion } from "./get-latest-cli-version";
 
 const paths = envPaths("better-fullstack", { suffix: "" });
@@ -30,6 +31,12 @@ export type ProjectHistoryEntry = {
   };
   cliVersion: string;
   reproducibleCommand: string;
+  /**
+   * Full project configuration snapshot (same shape as bts.jsonc). Used to
+   * replay the exact stack via `create --from-history <n>`. Optional so older
+   * history entries written before this field existed still load.
+   */
+  config?: BetterTStackConfig;
 };
 
 type HistoryData = {
@@ -78,6 +85,13 @@ export async function addToHistory(
 ): Promise<void> {
   const history = await readHistory();
 
+  let configSnapshot: BetterTStackConfig | undefined;
+  try {
+    configSnapshot = buildBtsConfigForPersistence(config);
+  } catch {
+    configSnapshot = undefined;
+  }
+
   const entry: ProjectHistoryEntry = {
     id: generateId(),
     projectName: config.projectName,
@@ -99,6 +113,7 @@ export async function addToHistory(
     },
     cliVersion: getLatestCLIVersion(),
     reproducibleCommand,
+    ...(configSnapshot ? { config: configSnapshot } : {}),
   };
 
   history.entries.unshift(entry);
@@ -112,6 +127,23 @@ export async function addToHistory(
 export async function getHistory(limit = 10): Promise<ProjectHistoryEntry[]> {
   const history = await readHistory();
   return history.entries.slice(0, limit);
+}
+
+/**
+ * Returns the entry at a 1-based position (1 = most recent), or null when the
+ * position is out of range.
+ */
+export async function getHistoryEntry(position: number): Promise<ProjectHistoryEntry | null> {
+  if (!Number.isInteger(position) || position < 1) {
+    return null;
+  }
+  const history = await readHistory();
+  return history.entries[position - 1] ?? null;
+}
+
+export async function getHistoryCount(): Promise<number> {
+  const history = await readHistory();
+  return history.entries.length;
 }
 
 export async function clearHistory(): Promise<void> {

--- a/apps/cli/test/cli-builder-sync.test.ts
+++ b/apps/cli/test/cli-builder-sync.test.ts
@@ -37,6 +37,8 @@ const BUILDER_CATEGORY_TO_CLI_OPTION_KEY: Partial<
 const NON_BUILDER_CREATE_OPTION_KEYS = new Set([
   "ecosystem",
   "template",
+  "fromHistory",
+  "config",
   "yes",
   "yolo",
   "verbose",

--- a/apps/cli/test/create-config-source.test.ts
+++ b/apps/cli/test/create-config-source.test.ts
@@ -1,0 +1,288 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import * as JSONC from "jsonc-parser";
+
+const CLI_ENTRY = resolve(import.meta.dir, "..", "src", "cli.ts");
+const NATIVE_BUN = resolve(homedir(), ".bun", "bin", "bun");
+const BUN_EXECUTABLE = process.env.BFS_TEST_BUN_BIN || (existsSync(NATIVE_BUN) ? NATIVE_BUN : "bun");
+const TEMP_ROOTS: string[] = [];
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function makeTempRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  TEMP_ROOTS.push(root);
+  return root;
+}
+
+async function runCli(
+  args: string[],
+  options: {
+    cwd: string;
+    env?: Record<string, string>;
+  },
+) {
+  const maxAttempts = 5;
+  let attempt = 0;
+  let lastResult:
+    | {
+        exitCode: number;
+        stdout: string;
+        stderr: string;
+        all: string;
+      }
+    | undefined;
+
+  while (attempt < maxAttempts) {
+    const outputDir = await mkdtemp(join(tmpdir(), "bfs-cli-output-"));
+    TEMP_ROOTS.push(outputDir);
+    const stdoutPath = join(outputDir, "stdout.log");
+    const stderrPath = join(outputDir, "stderr.log");
+    const command = [
+      shellQuote(BUN_EXECUTABLE),
+      shellQuote(CLI_ENTRY),
+      ...args.map(shellQuote),
+      ">",
+      shellQuote(stdoutPath),
+      "2>",
+      shellQuote(stderrPath),
+    ].join(" ");
+    const result = await new Promise<{
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+      all: string;
+    }>((resolvePromise) => {
+      const subprocess = spawn("/bin/sh", ["-c", command], {
+        cwd: options.cwd,
+        env: {
+          ...process.env,
+          CI: "true",
+          ...options.env,
+        },
+        stdio: "ignore",
+      });
+
+      subprocess.on("close", async (code) => {
+        const [stdout, stderr] = await Promise.all([
+          readFile(stdoutPath, "utf8"),
+          readFile(stderrPath, "utf8"),
+        ]);
+        resolvePromise({
+          exitCode: code ?? 1,
+          stdout,
+          stderr,
+          all: `${stdout}${stderr}`,
+        });
+      });
+      subprocess.on("error", (error) => {
+        resolvePromise({
+          exitCode: 1,
+          stdout: "",
+          stderr: error.message,
+          all: error.message,
+        });
+      });
+    });
+
+    lastResult = result;
+    const transientModuleRace =
+      result.exitCode !== 0 &&
+      (result.stderr.includes("Cannot find module '@better-fullstack/types'") ||
+        result.stderr.includes("Cannot find module '@better-fullstack/template-generator'"));
+
+    if (!transientModuleRace) {
+      return result;
+    }
+
+    attempt++;
+    if (attempt < maxAttempts) {
+      await Bun.sleep(150 * attempt);
+    }
+  }
+
+  return lastResult!;
+}
+
+function cliOutput(result: Awaited<ReturnType<typeof runCli>>): string {
+  return result.all || result.stdout || result.stderr;
+}
+
+async function readJsoncFile(path: string): Promise<unknown> {
+  const raw = await readFile(path, "utf8");
+  const errors: JSONC.ParseError[] = [];
+  const parsed = JSONC.parse(raw, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (errors.length > 0) {
+    throw new Error(`Failed to parse JSONC: ${path}`);
+  }
+  return parsed;
+}
+
+type BtsConfigShape = {
+  ecosystem?: string;
+  frontend?: string[];
+  backend?: string;
+  database?: string;
+  orm?: string;
+};
+
+const NON_INSTALL_FLAGS = ["--no-install", "--no-git", "--disable-analytics"] as const;
+
+afterAll(async () => {
+  await Promise.all(TEMP_ROOTS.map((dir) => rm(dir, { recursive: true, force: true })));
+}, 30_000);
+
+describe("create --from-history", () => {
+  it(
+    "replays the stack of the selected history entry and errors on a bad index",
+    async () => {
+      const root = await makeTempRoot("bfs-from-history-test-");
+      const homeDir = join(root, "home");
+      await mkdir(homeDir, { recursive: true });
+
+      const sharedEnv = {
+        HOME: homeDir,
+        XDG_CONFIG_HOME: join(homeDir, ".config"),
+        XDG_DATA_HOME: join(homeDir, ".local", "share"),
+      };
+
+      // Oldest entry: a TypeScript default project.
+      const tsCreate = await runCli(["create", "ts-app", "--yes", ...NON_INSTALL_FLAGS], {
+        cwd: root,
+        env: sharedEnv,
+      });
+      expect(
+        tsCreate.exitCode,
+        `ts create failed\n${cliOutput(tsCreate)}`,
+      ).toBe(0);
+
+      // Newest entry: a React Native project (a clearly different ecosystem).
+      const nativeCreate = await runCli(
+        ["create", "native-app", "--yes", "--ecosystem", "react-native", ...NON_INSTALL_FLAGS],
+        { cwd: root, env: sharedEnv },
+      );
+      expect(
+        nativeCreate.exitCode,
+        `native create failed\n${cliOutput(nativeCreate)}`,
+      ).toBe(0);
+
+      // History is now [native-app, ts-app]. Use --dry-run to probe index
+      // resolution without mutating history (dry runs are not recorded).
+      const probeRecent = await runCli(
+        ["create", "probe-1", "--from-history", "1", "--dry-run", "--disable-analytics"],
+        { cwd: root, env: sharedEnv },
+      );
+      expect(
+        probeRecent.exitCode,
+        `probe 1 failed\n${cliOutput(probeRecent)}`,
+      ).toBe(0);
+      // Position 1 (most recent) is the React Native project.
+      expect(cliOutput(probeRecent)).toContain("react-native");
+
+      const probeOlder = await runCli(
+        ["create", "probe-2", "--from-history", "2", "--dry-run", "--disable-analytics"],
+        { cwd: root, env: sharedEnv },
+      );
+      expect(
+        probeOlder.exitCode,
+        `probe 2 failed\n${cliOutput(probeOlder)}`,
+      ).toBe(0);
+      // Position 2 is the older TypeScript project (a distinct entry).
+      expect(cliOutput(probeOlder)).not.toContain("react-native");
+
+      // A real replay of the most recent entry actually scaffolds it.
+      const replayRecent = await runCli(
+        ["create", "replay-recent", "--from-history", "1", ...NON_INSTALL_FLAGS],
+        { cwd: root, env: sharedEnv },
+      );
+      expect(
+        replayRecent.exitCode,
+        `replay 1 failed\n${cliOutput(replayRecent)}`,
+      ).toBe(0);
+      const recentConfig = (await readJsoncFile(
+        join(root, "replay-recent", "bts.jsonc"),
+      )) as BtsConfigShape;
+      expect(recentConfig.ecosystem).toBe("react-native");
+      expect(recentConfig.frontend).toContain("native-bare");
+
+      // Out-of-range index errors clearly without scaffolding.
+      const outOfRange = await runCli(
+        ["create", "replay-bad", "--from-history", "99", ...NON_INSTALL_FLAGS],
+        { cwd: root, env: sharedEnv },
+      );
+      expect(outOfRange.exitCode).not.toBe(0);
+      expect(cliOutput(outOfRange)).toContain("No project history entry at position 99");
+      expect(existsSync(join(root, "replay-bad", "bts.jsonc"))).toBe(false);
+    },
+    180_000,
+  );
+});
+
+describe("create --config", () => {
+  it(
+    "loads a bts.jsonc file as the base stack and errors on a missing file",
+    async () => {
+      const root = await makeTempRoot("bfs-from-config-test-");
+
+      const srcCreate = await runCli(["create", "cfg-src", "--yes", ...NON_INSTALL_FLAGS], {
+        cwd: root,
+      });
+      expect(
+        srcCreate.exitCode,
+        `source create failed\n${cliOutput(srcCreate)}`,
+      ).toBe(0);
+
+      const configPath = join(root, "cfg-src", "bts.jsonc");
+      const sourceConfig = (await readJsoncFile(configPath)) as BtsConfigShape;
+
+      const cfgReplay = await runCli(
+        ["create", "cfg-replay", "--config", configPath, ...NON_INSTALL_FLAGS],
+        { cwd: root },
+      );
+      expect(
+        cfgReplay.exitCode,
+        `config replay failed\n${cliOutput(cfgReplay)}`,
+      ).toBe(0);
+
+      const replayConfig = (await readJsoncFile(
+        join(root, "cfg-replay", "bts.jsonc"),
+      )) as BtsConfigShape;
+      expect(replayConfig.ecosystem).toBe(sourceConfig.ecosystem);
+      expect(replayConfig.frontend).toEqual(sourceConfig.frontend);
+      expect(replayConfig.backend).toBe(sourceConfig.backend);
+      expect(replayConfig.database).toBe(sourceConfig.database);
+      expect(replayConfig.orm).toBe(sourceConfig.orm);
+
+      const missing = await runCli(
+        ["create", "cfg-missing", "--config", join(root, "does-not-exist.jsonc"), ...NON_INSTALL_FLAGS],
+        { cwd: root },
+      );
+      expect(missing.exitCode).not.toBe(0);
+      expect(cliOutput(missing)).toContain("Could not load config file");
+    },
+    180_000,
+  );
+
+  it(
+    "rejects combining --from-history with --config",
+    async () => {
+      const root = await makeTempRoot("bfs-config-conflict-test-");
+      const result = await runCli(
+        ["create", "conflict", "--from-history", "1", "--config", "bts.jsonc", ...NON_INSTALL_FLAGS],
+        { cwd: root },
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(cliOutput(result)).toContain("Cannot combine --from-history with --config");
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
## Problem

The CLI records every scaffolded project in history (and writes a full `bts.jsonc` per project), but there was no way to *replay* a stored stack. Recreating a previous setup meant re-typing every flag by hand.

## Fix

Adds two `create` flags that seed the stack from a saved config:

- **`--from-history <n>`** — replay the Nth most-recent project from history (`1` = most recent).
- **`--config <path>`** — load a `bts.jsonc`/JSON config file and use it as the base.

Implementation:

- History entries now persist a full config snapshot (same shape as `bts.jsonc`) so replays are faithful across ecosystems; entries written before this change fall back to the limited stack summary they stored. Adds `getHistoryEntry(n)` / `getHistoryCount()` accessors.
- `bts-config` gains `readBtsConfigFromFile(path)` (accepts a file or a project directory) and exports `buildBtsConfigForPersistence`.
- A shared resolver (`utils/config-source.ts`) turns the loaded config into base `create` flags. **Precedence:** explicitly-passed flags override the loaded config; the config-base values are treated as defaults (the same leniency `--yes` uses for a trusted config), while explicit overrides are strictly validated. The loaded stack still runs through the existing validation/compatibility path before scaffolding.
- The two flags are **mutually exclusive** and are rejected alongside `--yes`, `--template`, and `--part` (each wants to own the full stack). Clear errors are raised for an out-of-range history index or a missing/invalid config file. Non-interactive throughout (no prompt hangs).

## Verification

- `bun install`
- `bun run check-types` (CLI) — pass
- `bun run lint` (CLI) — pass
- `bun run test` (CLI) — 3282 pass / 0 fail across 77 files
- `bun run build` (CLI) — pass (publint clean)

Added `apps/cli/test/create-config-source.test.ts` (mirrors `add-history-commands.test.ts`): `--from-history` resolves the correct entry by index and scaffolds it, `--config` loads a generated config file and reproduces its stack, plus error cases (out-of-range index, missing file, `--from-history` + `--config` conflict). Updated the `cli-builder-sync` allowlist to mark the two new operational flags as non-builder options.