### PR TITLE
chore(release): 2.0.4

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Scaffold production-ready fullstack apps in seconds. Pick your stack from 425 options — the CLI wires everything together.",
   "keywords": [
     "algolia",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -80,6 +80,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.0.3"
+    "create-better-fullstack": "^2.0.4"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -62,7 +62,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.0.3",
+    "@better-fullstack/types": "^2.0.4",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",


### PR DESCRIPTION
## Release v2.0.4

This PR bumps the publishable Better Fullstack packages to `2.0.4`.

### Changes
- Updated `create-better-fullstack` to v2.0.4
- Updated `create-bfs` to v2.0.4
- Updated `@better-fullstack/types` to v2.0.4
- Updated `@better-fullstack/template-generator` to v2.0.4

### Verification
- `bun install`
- `bun run build:cli`
- pre-commit `lint` hook passed with existing warnings

---
Created from the release bump flow.