### PR TITLE
chore(release): 2.1.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.0.4",
+  "version": "2.1.1",
   "description": "Scaffold production-ready fullstack apps in seconds. Pick your stack from 425 options — the CLI wires everything together.",
   "keywords": [
     "algolia",
@@ -128,8 +128,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@better-fullstack/template-generator": "^2.0.3",
-    "@better-fullstack/types": "^2.0.3",
+    "@better-fullstack/template-generator": "^2.1.1",
+    "@better-fullstack/types": "^2.1.1",
     "@clack/core": "^0.5.0",
     "@clack/prompts": "^1.6.0",
     "@orpc/server": "^1.14.6",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.0.4",
+  "version": "2.1.1",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -80,6 +80,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.0.4"
+    "create-better-fullstack": "^2.1.1"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.0.4",
+  "version": "2.1.1",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -62,7 +62,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.0.4",
+    "@better-fullstack/types": "^2.1.1",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.0.4",
+  "version": "2.1.1",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",


### PR DESCRIPTION
## Release v2.1.1

This PR corrects the release bump to a version above the currently published npm `2.1.0` packages.

### Why
- The attempted `2.0.4` release failed because npm already has `2.1.0` published and refused to apply `latest` to a lower version.

### Changes
- Updated `create-better-fullstack` to v2.1.1
- Updated `create-bfs` to v2.1.1
- Updated `@better-fullstack/types` to v2.1.1
- Updated `@better-fullstack/template-generator` to v2.1.1
- Updated internal package dependency ranges to `^2.1.1`

### Verification
- `bun install`
- `bun run build:cli`
- pre-commit `lint` hook passed with existing warnings
