### PR TITLE
Fix Elixir Bypass smoke test

### DIFF
--- a/apps/cli/test/java-ecosystem.test.ts
+++ b/apps/cli/test/java-ecosystem.test.ts
@@ -178,6 +178,9 @@ describe("Java Ecosystem", () => {
 
       expect(pomContent).toContain("<artifactId>spring-boot-starter-webmvc</artifactId>");
       expect(pomContent).toContain("<artifactId>spring-boot-starter-webmvc-test</artifactId>");
+      expect(pomContent).toContain("<artifactId>jetty-bom</artifactId>");
+      expect(pomContent).toContain("<artifactId>jetty-ee10-bom</artifactId>");
+      expect(pomContent).toContain("<wiremock.jetty.version>12.0.30</wiremock.jetty.version>");
       expect(pomContent).toContain("<groupId>com.example</groupId>");
       expect(pomContent).toContain("<artifactId>java-pom-check</artifactId>");
       expect(pomContent).not.toContain("package.json");
@@ -758,6 +761,12 @@ describe("Java Ecosystem", () => {
       );
       expect(gradleContent).toContain('testImplementation("org.assertj:assertj-core:3.27.7")');
       expect(gradleContent).toContain('testImplementation("io.rest-assured:rest-assured:6.0.0")');
+      expect(gradleContent).toContain(
+        'testImplementation(enforcedPlatform("org.eclipse.jetty:jetty-bom:12.0.30"))',
+      );
+      expect(gradleContent).toContain(
+        'testImplementation(enforcedPlatform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.30"))',
+      );
       expect(gradleContent).toContain('testImplementation("org.wiremock:wiremock-jetty12:3.13.2")');
       expect(gradleContent).toContain('testImplementation("org.awaitility:awaitility:4.3.0")');
       expect(gradleContent).not.toContain("mockito-junit-jupiter");

--- a/apps/cli/test/virtual-generator-regressions.test.ts
+++ b/apps/cli/test/virtual-generator-regressions.test.ts
@@ -1077,6 +1077,32 @@ describe("Virtual Generator Regressions", () => {
     expect(readTextFromTree(result.tree!, "priv/repo/seeds.exs")).toBeUndefined();
   });
 
+  it("uses Req for Elixir Bypass tests instead of Erlang httpc", async () => {
+    const result = await createVirtual({
+      projectName: "elixir-bypass",
+      ecosystem: "elixir",
+      elixirWebFramework: "phoenix",
+      elixirOrm: "none",
+      elixirAuth: "none",
+      elixirApi: "none",
+      elixirRealtime: "none",
+      elixirJobs: "none",
+      elixirHttp: "none",
+      elixirJson: "jason",
+      elixirTesting: "bypass",
+    });
+
+    expect(result.success).toBe(true);
+
+    const mixProject = readTextFromTree(result.tree!, "mix.exs");
+    const bypassTest = readTextFromTree(result.tree!, "test/elixir_bypass/bypass_test.exs");
+
+    expect(mixProject).toContain("{:bypass");
+    expect(mixProject).toContain("{:req");
+    expect(bypassTest).toContain("Req.get(url)");
+    expect(bypassTest).not.toContain(":httpc");
+  });
+
   it("keeps Elixir Dockerfiles usable before mix.lock exists", async () => {
     const result = await createVirtual({
       projectName: "elixir-docker",

--- a/packages/template-generator/templates/elixir-base/mix.exs.hbs
+++ b/packages/template-generator/templates/elixir-base/mix.exs.hbs
@@ -74,7 +74,7 @@ defmodule {{elixirModuleName}}.MixProject do
 {{#if (eq elixirValidation "nimble-options")}}
       {:nimble_options, "~> 1.1"},
 {{/if}}
-{{#if (eq elixirHttp "req")}}
+{{#if (or (eq elixirHttp "req") (eq elixirTesting "bypass"))}}
       {:req, "~> 0.5"},
 {{/if}}
 {{#if (or (eq elixirHttp "finch") (eq elixirEmail "swoosh"))}}

--- a/packages/template-generator/templates/elixir-base/test/__elixirAppName__/bypass_test.exs.hbs
+++ b/packages/template-generator/templates/elixir-base/test/__elixirAppName__/bypass_test.exs.hbs
@@ -8,13 +8,10 @@ defmodule {{elixirModuleName}}.BypassTest do
       Plug.Conn.resp(conn, 200, ~s({"ok":true}))
     end)
 
-    {:ok, _} = Application.ensure_all_started(:inets)
-    url = ~c"http://localhost:#{bypass.port}/health"
+    url = "http://localhost:#{bypass.port}/health"
 
-    assert {:ok, response} = :httpc.request(:get, {url, []}, [], [])
-    assert elem(elem(response, 0), 1) == 200
-    body = elem(response, 2)
-
-    assert to_string(body) == ~s({"ok":true})
+    assert {:ok, response} = Req.get(url)
+    assert response.status == 200
+    assert response.body == ~s({"ok":true})
   end
 end

--- a/packages/template-generator/templates/java-base/build.gradle.kts.hbs
+++ b/packages/template-generator/templates/java-base/build.gradle.kts.hbs
@@ -152,6 +152,8 @@ dependencies {
 	testImplementation("io.rest-assured:rest-assured:6.0.0")
 {{/if}}
 {{#if hasJavaWireMock}}
+	testImplementation(enforcedPlatform("org.eclipse.jetty:jetty-bom:12.0.30"))
+	testImplementation(enforcedPlatform("org.eclipse.jetty.ee10:jetty-ee10-bom:12.0.30"))
 	testImplementation("org.wiremock:wiremock-jetty12:3.13.2")
 {{/if}}
 {{#if hasJavaAwaitility}}

--- a/packages/template-generator/templates/java-base/pom.xml.hbs
+++ b/packages/template-generator/templates/java-base/pom.xml.hbs
@@ -53,6 +53,7 @@
 {{/if}}
 {{#if hasJavaWireMock}}
 		<wiremock.version>3.13.2</wiremock.version>
+		<wiremock.jetty.version>12.0.30</wiremock.jetty.version>
 {{/if}}
 {{#if hasJavaAwaitility}}
 		<awaitility.version>4.3.0</awaitility.version>
@@ -139,6 +140,26 @@
 {{/if}}
 {{/if}}
 	</properties>
+{{#if (and isJavaSpringBoot hasJavaWireMock)}}
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-bom</artifactId>
+				<version>${wiremock.jetty.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty.ee10</groupId>
+				<artifactId>jetty-ee10-bom</artifactId>
+				<version>${wiremock.jetty.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+{{/if}}
 {{#if isJavaQuarkus}}
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- replace generated Elixir Bypass test usage of Erlang :httpc with Req
- include Req whenever Bypass testing is selected, even when the stack HTTP client is none
- add a virtual generator regression for the Bypass + no HTTP-client case

## Verification
- bun test apps/cli/test/virtual-generator-regressions.test.ts --timeout 120000
- generated a local Elixir Bypass project and ran mix deps.get && mix test (2 tests, 0 failures)
- bun run test:release
