### PR TITLE
ScaffBench 2.1: P0 hardening (de-leak, artifact scoring, infra-inconclusive outcomes, honest labeling, solvability gate)

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -22,6 +22,10 @@ on:
         description: "Run deep smoke tests for the AI search benchmark template"
         type: boolean
         default: true
+      run_solvability:
+        description: "Run ScaffBench per-spec solvability gate (all ecosystems)"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -345,6 +349,55 @@ jobs:
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7
+
+  scaffbench-solvability:
+    name: ScaffBench Spec Solvability
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_solvability) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Show toolchains
+        run: |
+          echo "cargo:  $(cargo --version 2>&1 || echo MISSING)"
+          echo "go:     $(go version 2>&1 || echo MISSING)"
+          echo "uv:     $(uv --version 2>&1 || echo MISSING)"
+          echo "dotnet: $(dotnet --version 2>&1 || echo MISSING)"
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.bun/install/cache
+          key: solvability-${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: solvability-${{ runner.os }}-bun-
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Packages
+        run: |
+          bun run --cwd packages/types build
+          bun run --cwd packages/template-generator build
+          bun run --cwd apps/cli build
+
+      - name: Run Spec Solvability Gate
+        run: bun test apps/cli/test/e2e/scaffbench-solvability.test.ts --timeout 1200000
 
   playwright:
     name: Playwright Web Builder Tests

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -372,12 +372,18 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      - name: Install protoc
+        # The rust-leptos-axum spec uses Tonic/gRPC, whose prost build script
+        # compiles .proto files with protoc at `cargo check` time.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Show toolchains
         run: |
           echo "cargo:  $(cargo --version 2>&1 || echo MISSING)"
           echo "go:     $(go version 2>&1 || echo MISSING)"
           echo "uv:     $(uv --version 2>&1 || echo MISSING)"
           echo "dotnet: $(dotnet --version 2>&1 || echo MISSING)"
+          echo "protoc: $(protoc --version 2>&1 || echo MISSING)"
 
       - uses: actions/cache@v4
         with:

--- a/apps/cli/test/e2e/scaffbench-solvability.test.ts
+++ b/apps/cli/test/e2e/scaffbench-solvability.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  parseArgs,
+  SCAFFBENCH_2_1_SPECS,
+  validateProject,
+  type BenchmarkSpec,
+} from "../../../../scripts/scaffbench-v2-lib";
+import { scaffoldWithCLIBinary } from "./e2e-utils";
+
+/**
+ * ScaffBench 2.1 per-spec solvability gate.
+ *
+ * For each benchmark spec, scaffold a project from the spec's OWN canonical
+ * flags (not a hand-maintained preset that can drift) and assert the expected
+ * stack actually installs/builds/type-checks. If a spec is not solvable, a
+ * Better-Fullstack generator regression would otherwise be silently charged to
+ * the model in the benchmark — this gate catches that. Reuses the harness's
+ * `validateProject` so the gate matches the benchmark's own validation exactly.
+ */
+
+const SMOKE_DIR = join(import.meta.dir, "..", "..", ".smoke-scaffbench-solvability");
+const CLI_BINARY_PATH = join(import.meta.dir, "..", "..", "dist", "cli.mjs");
+const SCAFFOLD_TIMEOUT_MS = 300_000;
+const TEST_TIMEOUT_MS = 1_200_000;
+
+// Toolchains a spec needs (beyond bun/node) to be validated in this environment.
+const SPEC_TOOLCHAINS: Record<string, string[]> = {
+  "ai-search-workbench": [],
+  "rust-leptos-axum": ["cargo"],
+  "python-ingestion-api": ["uv"],
+  "go-realtime-api": ["go"],
+  "multi-dotnet-ops": ["dotnet"],
+};
+
+// Steps that must pass for a stack to count as "solvable". Lint/format/test/
+// doctor/route are advisory and not part of the solvability contract.
+const ADVISORY_STEPS = new Set(["lint", "format", "test", "doctor", "route"]);
+
+const EXPECTED_FILE_BY_FAMILY: Record<string, string> = {
+  typescript: "package.json",
+  "multi-ecosystem": "package.json",
+  rust: "Cargo.toml",
+  python: "pyproject.toml",
+  go: "go.mod",
+};
+
+function selectSpecs(): BenchmarkSpec[] {
+  const filter = process.env.SCAFFBENCH_SOLVABILITY_SPECS?.split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return SCAFFBENCH_2_1_SPECS.filter((spec) => !filter?.length || filter.includes(spec.id));
+}
+
+describe("ScaffBench 2.1 spec solvability", () => {
+  beforeAll(async () => {
+    await rm(SMOKE_DIR, { recursive: true, force: true });
+    await mkdir(SMOKE_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    if (!process.env.CI) {
+      await rm(SMOKE_DIR, { recursive: true, force: true });
+    }
+  });
+
+  for (const spec of selectSpecs()) {
+    const missing = (SPEC_TOOLCHAINS[spec.id] ?? []).filter((tool) => !Bun.which(tool));
+    const register = missing.length > 0 ? it.skip : it;
+
+    if (missing.length > 0) {
+      console.warn(
+        `[scaffbench-solvability] SKIP ${spec.id}: missing toolchain(s) ${missing.join(", ")}`,
+      );
+    }
+
+    register(
+      `scaffolds and validates the ${spec.id} stack from its own canonical flags`,
+      async () => {
+        const projectDir = join(SMOKE_DIR, spec.id);
+        const expectedFile = EXPECTED_FILE_BY_FAMILY[spec.family];
+
+        const scaffold = await scaffoldWithCLIBinary(projectDir, [...spec.canonicalFlags], {
+          cliPath: CLI_BINARY_PATH,
+          timeout: SCAFFOLD_TIMEOUT_MS,
+          expectedFiles: expectedFile ? [expectedFile] : [],
+        });
+        expect(scaffold.ok, `scaffold failed for ${spec.id}: ${scaffold.stderrTail ?? ""}`).toBe(
+          true,
+        );
+
+        // parseArgs([]) yields safe defaults (qualityGate/doctor/route all off),
+        // so validateProject runs only install + build + type-check + native.
+        const options = parseArgs([]);
+        const validation = await validateProject(spec, projectDir, options);
+
+        const failures = Object.entries(validation.steps)
+          .filter(([name, step]) => step && !ADVISORY_STEPS.has(name))
+          .filter(([, step]) => step!.exitCode !== 0 || step!.timedOut)
+          .map(([name, step]) => ({
+            name,
+            command: step!.command,
+            exitCode: step!.exitCode,
+            timedOut: step!.timedOut,
+            spawnError: step!.spawnError ?? false,
+            stderrTail: step!.stderrTail?.slice(-1000),
+          }));
+
+        expect(
+          failures,
+          `solvability validation failed for ${spec.id}:\n${JSON.stringify(failures, null, 2)}`,
+        ).toEqual([]);
+      },
+      TEST_TIMEOUT_MS,
+    );
+  }
+});

--- a/docs/plans/planned/scaffbench-2.1-readiness.md
+++ b/docs/plans/planned/scaffbench-2.1-readiness.md
@@ -152,6 +152,19 @@ The harness emits stable failure tags:
   127 (a broken `build`/`test` script) stays a `model-failure`, as does a generation timeout (cf.
   SWE-bench).
 
+## Per-spec solvability gate
+
+`apps/cli/test/e2e/scaffbench-solvability.test.ts` scaffolds each spec from its
+**own `canonicalFlags`** (not a hand-maintained preset that can drift) and runs
+the harness's `validateProject` to assert the expected stack installs / builds /
+type-checks. This guarantees a Better-Fullstack generator regression surfaces
+here rather than being silently charged to the model in the benchmark. It is
+toolchain-gated (a spec is skipped, with a logged warning, when its toolchain is
+absent) and runs as the scheduled / `workflow_dispatch` `scaffbench-solvability`
+CI job across all five ecosystems — it does not block per-PR checks. Run a
+single ecosystem locally with
+`SCAFFBENCH_SOLVABILITY_SPECS=<id> bun run scaffbench:solvability`.
+
 ## Notes
 
 - `--route-check` is implemented as an opt-in lane only. Do not use it for default runs unless the

--- a/docs/plans/planned/scaffbench-2.1-readiness.md
+++ b/docs/plans/planned/scaffbench-2.1-readiness.md
@@ -93,9 +93,16 @@ Primary quality signal:
 
 - validation pass/fail across install, build, typecheck, native checks, and optional quality gates
 
-Secondary diagnostic signals:
+Right-library scoring is artifact-grounded for every path:
 
-- right-library score from `bts.jsonc` or strict dependency/source/file markers
+- `Wired libs` (primary) scores the libraries actually present in the generated
+  tree (dependencies + source imports + required files) via strict markers.
+- `Faithful` (assisted-path diagnostic) scores whether `bts.jsonc` echoes the
+  requested stack. A 100% faithful but sub-100% wired run is tagged
+  `stack-unwired` — the signature of a generator that recorded a library it
+  never wired.
+
+Secondary diagnostic signals:
 - command discipline and tool-path compliance
 - failure taxonomy tags
 - average cost, output tokens, and wall time
@@ -122,6 +129,7 @@ The harness emits stable failure tags:
 - `validation-failed`
 - `budget-exhausted`
 - `toolchain-missing`
+- `stack-unwired`
 
 ## Scope and run-outcome semantics (post-2.1 hardening)
 

--- a/docs/plans/planned/scaffbench-2.1-readiness.md
+++ b/docs/plans/planned/scaffbench-2.1-readiness.md
@@ -165,6 +165,14 @@ CI job across all five ecosystems — it does not block per-PR checks. Run a
 single ecosystem locally with
 `SCAFFBENCH_SOLVABILITY_SPECS=<id> bun run scaffbench:solvability`.
 
+Build dependencies beyond the language toolchain: `rust-leptos-axum` uses
+Tonic/gRPC, whose build script compiles `.proto` files with `protoc` at
+`cargo check` time, so `protobuf-compiler` must be installed (the CI job does
+this). The first full CI run validated `ai-search-workbench`, `python-ingestion-api`,
+`go-realtime-api`, and `multi-dotnet-ops`; `rust-leptos-axum` surfaced the missing
+`protoc` build dependency — exactly the kind of environment gap this gate exists
+to catch.
+
 ## Notes
 
 - `--route-check` is implemented as an opt-in lane only. Do not use it for default runs unless the

--- a/docs/plans/planned/scaffbench-2.1-readiness.md
+++ b/docs/plans/planned/scaffbench-2.1-readiness.md
@@ -140,11 +140,17 @@ The harness emits stable failure tags:
 - **CLI prompt no longer embeds the canonical command.** The agent must map requirements to flags
   itself; the full flag list is retained only in `canonical-command.txt`/`spec.json` for grading, so
   the CLI lane measures requirement→flag mapping rather than copy-fidelity.
+- **Agents run in an isolated workspace.** The agent's working directory is a temp dir disjoint from
+  the grading tree, so the answer key (`canonical-command.txt`, `spec.json`, `summary.json`, sibling
+  runs) is unreadable from the agent cwd via path traversal. The generated source is archived back
+  under `runs/<id>/<project>` (excluding `node_modules`/build dirs) after scoring.
 - **Three-way run outcome.** Each run is `success`, `model-failure`, or `infra-inconclusive`.
-  Infra-inconclusive runs (missing toolchain → `toolchain-missing`, validation-step timeout,
-  exhausted token budget → `budget-exhausted`, or a crash with no output) are excluded from the
-  pass-rate denominator and surfaced in a dedicated `Inconclusive` column. A generation timeout is
-  intentionally a `model-failure`, not inconclusive (cf. SWE-bench).
+  Infra-inconclusive runs are excluded from the pass-rate denominator and surfaced in a dedicated
+  `Inconclusive` column: a validation-step timeout, an exhausted token budget (`budget-exhausted`),
+  a crash with no output, or `toolchain-missing` — raised only when the validator binary itself
+  cannot be spawned (e.g. `cargo`/`uv`/`go`/`dotnet` absent). A generated script that runs and exits
+  127 (a broken `build`/`test` script) stays a `model-failure`, as does a generation timeout (cf.
+  SWE-bench).
 
 ## Notes
 

--- a/docs/plans/planned/scaffbench-2.1-readiness.md
+++ b/docs/plans/planned/scaffbench-2.1-readiness.md
@@ -120,6 +120,23 @@ The harness emits stable failure tags:
 - `doctor-failed`
 - `route-failed`
 - `validation-failed`
+- `budget-exhausted`
+- `toolchain-missing`
+
+## Scope and run-outcome semantics (post-2.1 hardening)
+
+- **Single-agent ablation, not a cross-vendor leaderboard.** The harness drives one agent (Claude
+  Code); every row is one model family across creation paths and reasoning effort. The rendered
+  summary heading and metadata say so explicitly. Cross-vendor comparison requires a second agent
+  adapter and is out of scope until then.
+- **CLI prompt no longer embeds the canonical command.** The agent must map requirements to flags
+  itself; the full flag list is retained only in `canonical-command.txt`/`spec.json` for grading, so
+  the CLI lane measures requirement→flag mapping rather than copy-fidelity.
+- **Three-way run outcome.** Each run is `success`, `model-failure`, or `infra-inconclusive`.
+  Infra-inconclusive runs (missing toolchain → `toolchain-missing`, validation-step timeout,
+  exhausted token budget → `budget-exhausted`, or a crash with no output) are excluded from the
+  pass-rate denominator and surfaced in a dedicated `Inconclusive` column. A generation timeout is
+  intentionally a `model-failure`, not inconclusive (cf. SWE-bench).
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "upstream-gap-report": "bun run scripts/upstream-gap-report.ts --markdown",
     "scaffbench:2.1": "bun run scripts/scaffbench-v2.ts --specs core --repeats 3 --quality-gate --doctor-check",
     "scaffbench:2.1:matrix": "bun run scripts/scaffbench-v2.ts --write-matrix-only --out-dir testing/.tmp-scaffbench-21",
+    "scaffbench:solvability": "bun test apps/cli/test/e2e/scaffbench-solvability.test.ts --timeout 1200000",
     "test:smoke": "bun run testing/smoke-test.ts",
     "test:smoke:strict": "bun run testing/smoke-test.ts --preset all --dev-check --strict",
     "test:smoke:pr-core": "bun run testing/smoke-test.ts --preset pr-core --dev-check --strict --output testing/.smoke-output/core",

--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   aggregateResults,
@@ -8,7 +11,9 @@ import {
   parseArgs,
   promptFor,
   runCommand,
+  scoreArtifact,
   scoreBts,
+  scoreProject,
   SCAFFBENCH_2_1_SPECS,
   validationPassed,
   type RunResult,
@@ -302,6 +307,60 @@ describe("ScaffBench 2.1 scoring", () => {
       passRate: 50,
       failureTags: { "install-failed": 1, "validation-failed": 1 },
     });
+  });
+});
+
+describe("ScaffBench 2.1 artifact-grounded scoring", () => {
+  it("scores libraries wired in the generated artifact, not just declared", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sb21-artifact-"));
+    try {
+      await writeFile(
+        join(dir, "package.json"),
+        JSON.stringify({ dependencies: { hono: "^4", "@qdrant/js-client-rest": "^1" } }),
+      );
+      const spec = {
+        ...aiSpec,
+        strictMarkers: [
+          { id: "backend:hono", deps: ["hono"] },
+          { id: "vectorDb:qdrant", deps: ["@qdrant/js-client-rest"] },
+          { id: "search:opensearch", deps: ["@opensearch-project/opensearch"] },
+          { id: "forbidden:stripe", forbiddenDeps: ["stripe"] },
+        ],
+      };
+
+      const score = await scoreArtifact(spec, dir);
+
+      // hono + qdrant wired, stripe correctly absent => 3; opensearch missing.
+      expect(score).toMatchObject({ matched: 3, total: 4 });
+      expect(score.misses).toEqual(["search:opensearch"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("separates artifact from faithfulness and flags a claimed-but-unwired stack", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sb21-unwired-"));
+    try {
+      // bts.jsonc records the full requested stack => 100% faithful...
+      await writeFile(
+        join(dir, "bts.jsonc"),
+        JSON.stringify({
+          ...Object.fromEntries(Object.entries(aiSpec.expectedConfig ?? {})),
+          addons: aiSpec.expectedAddons,
+        }),
+      );
+      // ...but the emitted tree wires almost nothing => low artifact score.
+      await writeFile(join(dir, "package.json"), JSON.stringify({ dependencies: { hono: "^4" } }));
+
+      const { artifact, faithfulness } = await scoreProject(aiSpec, dir);
+      expect(faithfulness?.percent).toBe(100);
+      expect(artifact.percent).toBeLessThan(100);
+
+      const run = makeRun({ stackScore: artifact, generatorFaithfulness: faithfulness });
+      expect(deriveFailureTags(run)).toContain("stack-unwired");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   aggregateResults,
   canonicalCommand,
+  classifyOutcome,
   deriveFailureTags,
   parseArgs,
   promptFor,
@@ -112,6 +113,16 @@ describe("ScaffBench 2.1 harness config", () => {
     expect(promptOnly).toContain(aiSpec.naturalPrompt);
     expect(mcpPrompt).toContain("bfs_get_guidance");
     expect(mcpPrompt).toContain("bfs_create_project");
+  });
+
+  it("does not leak the canonical command (answer key) into agent-facing prompts", () => {
+    const cliPrompt = promptFor(aiSpec, "cli", "/tmp/run", "workbench", "explicit");
+
+    // The agent must map requirements to flags itself; the full flag list is
+    // kept only in canonical-command.txt / spec.json for grading.
+    expect(cliPrompt).not.toContain(canonicalCommand(aiSpec, "workbench"));
+    expect(cliPrompt).not.toContain("--vector-db");
+    expect(cliPrompt).not.toContain("--shadcn-base");
   });
 
   it("records missing spawned tools as failed commands", async () => {
@@ -290,6 +301,74 @@ describe("ScaffBench 2.1 scoring", () => {
       passCount: 1,
       passRate: 50,
       failureTags: { "install-failed": 1, "validation-failed": 1 },
+    });
+  });
+});
+
+describe("ScaffBench 2.1 run outcomes", () => {
+  function stepResult(command: string, exitCode: number, timedOut = false) {
+    return { command, exitCode, timedOut, durationMs: 1, stdoutTail: "", stderrTail: "" };
+  }
+
+  it("classifies a clean validation pass as success", () => {
+    expect(classifyOutcome(makeRun())).toBe("success");
+  });
+
+  it("classifies a missing toolchain (exit 127) as infra-inconclusive and does not tag a build break", () => {
+    const run = makeRun({
+      validation: {
+        projectExists: true,
+        steps: { cargoCheck: stepResult("cargo check", 127) },
+      },
+    });
+
+    expect(classifyOutcome(run)).toBe("infra-inconclusive");
+    const tags = deriveFailureTags(run);
+    expect(tags).toContain("toolchain-missing");
+    expect(tags).not.toContain("build-failed");
+  });
+
+  it("classifies an exhausted token budget as infra-inconclusive", () => {
+    const run = makeRun({
+      claude: { exitCode: 1, timedOut: false, durationMs: 60_000, terminalReason: "max_budget_exhausted" },
+      validation: { projectExists: false, steps: {} },
+    });
+
+    expect(classifyOutcome(run)).toBe("infra-inconclusive");
+    expect(deriveFailureTags(run)).toContain("budget-exhausted");
+  });
+
+  it("keeps a real build failure as a model-failure, not inconclusive", () => {
+    const run = makeRun({
+      validation: {
+        projectExists: true,
+        steps: { install: stepResult("bun install", 0), build: stepResult("bun run build", 1) },
+      },
+    });
+
+    expect(classifyOutcome(run)).toBe("model-failure");
+  });
+
+  it("excludes infra-inconclusive runs from the pass-rate denominator", () => {
+    const ok = makeRun();
+    const inconclusive = makeRun({
+      id: "ai-search-workbench-claude-opus-4-8-high-mcp-r02",
+      trial: 2,
+      validation: {
+        projectExists: true,
+        steps: { install: stepResult("uv sync", 127) },
+      },
+    });
+
+    const aggregates = aggregateResults([ok, inconclusive]).leaderboard;
+
+    expect(aggregates).toHaveLength(1);
+    expect(aggregates[0]).toMatchObject({
+      runs: 2,
+      scoredRuns: 1,
+      inconclusiveCount: 1,
+      passCount: 1,
+      passRate: 100,
     });
   });
 });

--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -135,6 +135,7 @@ describe("ScaffBench 2.1 harness config", () => {
 
     expect(result.exitCode).toBe(127);
     expect(result.timedOut).toBe(false);
+    expect(result.spawnError).toBe(true);
     expect(result.stderr).toContain("scaffbench-missing-binary-for-test");
   });
 });
@@ -365,19 +366,31 @@ describe("ScaffBench 2.1 artifact-grounded scoring", () => {
 });
 
 describe("ScaffBench 2.1 run outcomes", () => {
-  function stepResult(command: string, exitCode: number, timedOut = false) {
-    return { command, exitCode, timedOut, durationMs: 1, stdoutTail: "", stderrTail: "" };
+  function stepResult(
+    command: string,
+    exitCode: number,
+    opts: { timedOut?: boolean; spawnError?: boolean } = {},
+  ) {
+    return {
+      command,
+      exitCode,
+      timedOut: opts.timedOut ?? false,
+      spawnError: opts.spawnError ?? false,
+      durationMs: 1,
+      stdoutTail: "",
+      stderrTail: "",
+    };
   }
 
   it("classifies a clean validation pass as success", () => {
     expect(classifyOutcome(makeRun())).toBe("success");
   });
 
-  it("classifies a missing toolchain (exit 127) as infra-inconclusive and does not tag a build break", () => {
+  it("classifies an un-spawnable validator binary as infra-inconclusive, not a build break", () => {
     const run = makeRun({
       validation: {
         projectExists: true,
-        steps: { cargoCheck: stepResult("cargo check", 127) },
+        steps: { cargoCheck: stepResult("cargo check", 127, { spawnError: true }) },
       },
     });
 
@@ -385,6 +398,24 @@ describe("ScaffBench 2.1 run outcomes", () => {
     const tags = deriveFailureTags(run);
     expect(tags).toContain("toolchain-missing");
     expect(tags).not.toContain("build-failed");
+  });
+
+  it("treats a child process exiting 127 (broken generated script) as a model-failure", () => {
+    const run = makeRun({
+      validation: {
+        projectExists: true,
+        steps: {
+          install: stepResult("bun install", 0),
+          // bun ran fine; the generated `build` script referenced a missing bin.
+          build: stepResult("bun run build", 127),
+        },
+      },
+    });
+
+    expect(classifyOutcome(run)).toBe("model-failure");
+    const tags = deriveFailureTags(run);
+    expect(tags).toContain("build-failed");
+    expect(tags).not.toContain("toolchain-missing");
   });
 
   it("classifies an exhausted token budget as infra-inconclusive", () => {
@@ -415,7 +446,7 @@ describe("ScaffBench 2.1 run outcomes", () => {
       trial: 2,
       validation: {
         projectExists: true,
-        steps: { install: stepResult("uv sync", 127) },
+        steps: { install: stepResult("uv sync", 127, { spawnError: true }) },
       },
     });
 

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -1388,7 +1388,7 @@ async function archiveProjectSource(srcDir: string, destDir: string) {
   });
 }
 
-async function validateProject(
+export async function validateProject(
   spec: BenchmarkSpec,
   projectDir: string | null,
   options: ScaffbenchOptions,

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -24,7 +24,8 @@ export type FailureTag =
   | "validation-failed"
   | "build-failed"
   | "budget-exhausted"
-  | "toolchain-missing";
+  | "toolchain-missing"
+  | "stack-unwired";
 
 export type RunOutcome = "success" | "model-failure" | "infra-inconclusive";
 
@@ -131,7 +132,10 @@ export type RunResult = {
     terminalReason?: string;
   };
   validation: ProjectValidation;
+  /** Primary "right libs" signal: libraries actually wired in the generated tree. */
   stackScore: StackScore;
+  /** Assisted-path diagnostic: whether bts.jsonc echoes the requested stack. */
+  generatorFaithfulness?: StackScore;
   toolCompliance: ToolCompliance;
   failureTags: FailureTag[];
 };
@@ -167,6 +171,7 @@ type SummaryAggregate = {
   passRate: number;
   passCi95: { low: number; high: number };
   stackPercent: number;
+  faithfulnessPercent?: number;
   commandDisciplinePercent: number;
   avgDurationMs: number;
   avgOutputTokens?: number;
@@ -1065,7 +1070,9 @@ export async function runScaffbench(options: ScaffbenchOptions, log = console.lo
           const validation = options.skipValidation
             ? { projectExists: projectDir !== null, steps: {} }
             : await validateProject(spec, projectDir, options);
-          const stackScore = projectDir ? await scoreProject(spec, projectDir) : emptyScore(spec);
+          const scored = projectDir
+            ? await scoreProject(spec, projectDir)
+            : { artifact: emptyArtifactScore(spec), faithfulness: undefined };
           const toolCompliance = await scoreToolCompliance(pathMode, projectDir, claude);
           const result: RunResult = {
             id,
@@ -1091,7 +1098,8 @@ export async function runScaffbench(options: ScaffbenchOptions, log = console.lo
               terminalReason: parsed?.terminal_reason,
             },
             validation,
-            stackScore,
+            stackScore: scored.artifact,
+            generatorFaithfulness: scored.faithfulness,
             toolCompliance,
             failureTags: [],
           };
@@ -1641,12 +1649,35 @@ async function readPackageScripts(packageJsonPath: string) {
   }
 }
 
-export async function scoreProject(spec: BenchmarkSpec, projectDir: string) {
-  const btsPath = path.join(projectDir, "bts.jsonc");
-  if (existsSync(btsPath)) {
-    return scoreBts(spec, await readFile(btsPath, "utf8"));
-  }
+/**
+ * Score the libraries actually wired into the generated tree (dependency
+ * declarations + source imports + required files). This is the primary
+ * "right libs" signal for EVERY creation path, so a broken or empty generated
+ * package (e.g. a db package that declares nothing and is imported nowhere) no
+ * longer earns full stack credit on the strength of bts.jsonc alone.
+ */
+export async function scoreArtifact(spec: BenchmarkSpec, projectDir: string): Promise<StackScore> {
   return scoreMarkers(spec, await collectProjectIndex(projectDir));
+}
+
+/**
+ * Two complementary stack signals:
+ * - `artifact`: what is actually wired in the emitted project (primary).
+ * - `faithfulness`: assisted paths only — whether Better-Fullstack's own
+ *   bts.jsonc echoes the requested stack. A generator-honesty diagnostic, not
+ *   the capability metric. A high faithfulness with a low artifact score is the
+ *   signature of a generator that recorded a library it never wired.
+ */
+export async function scoreProject(
+  spec: BenchmarkSpec,
+  projectDir: string,
+): Promise<{ artifact: StackScore; faithfulness?: StackScore }> {
+  const artifact = await scoreArtifact(spec, projectDir);
+  const btsPath = path.join(projectDir, "bts.jsonc");
+  const faithfulness = existsSync(btsPath)
+    ? scoreBts(spec, await readFile(btsPath, "utf8"))
+    : undefined;
+  return { artifact, faithfulness };
 }
 
 export function scoreBts(spec: BenchmarkSpec, raw: string): StackScore {
@@ -1772,6 +1803,15 @@ function scoreFromCounts(matched: number, total: number, misses: string[]): Stac
     total,
     percent: total > 0 ? Math.round((matched / total) * 100) : 0,
     misses,
+  };
+}
+
+function emptyArtifactScore(spec: BenchmarkSpec): StackScore {
+  return {
+    matched: 0,
+    total: spec.strictMarkers.length,
+    percent: 0,
+    misses: ["project not found or unscorable"],
   };
 }
 
@@ -1996,6 +2036,15 @@ export function deriveFailureTags(result: RunResult): FailureTag[] {
   if (isBudgetExhausted(result.claude.terminalReason)) tags.add("budget-exhausted");
   if (!result.validation.projectExists) tags.add("project-not-found");
   if (result.stackScore.matched < result.stackScore.total) tags.add("stack-mismatch");
+  // bts.jsonc records the full stack but the artifact does not wire it (e.g. an
+  // empty generated package): the generator claimed more than it produced.
+  if (
+    result.generatorFaithfulness &&
+    result.generatorFaithfulness.percent === 100 &&
+    result.stackScore.percent < 100
+  ) {
+    tags.add("stack-unwired");
+  }
   if (result.toolCompliance.checks.some((check) => check.status === "fail")) {
     tags.add("tool-violation");
     tags.add("command-discipline");
@@ -2066,6 +2115,9 @@ function aggregateBy(
         passRate: scored.length > 0 ? Math.round((passCount / scored.length) * 100) : 0,
         passCi95: ci,
         stackPercent: average(group.map((result) => result.stackScore.percent)),
+        faithfulnessPercent: maybeAverage(
+          group.map((result) => result.generatorFaithfulness?.percent),
+        ),
         commandDisciplinePercent: average(
           group.map((result) =>
             result.toolCompliance.total > 0
@@ -2157,6 +2209,9 @@ export function renderMarkdown(summary: ScaffbenchSummary) {
         result.claude.totalCostUsd?.toFixed(3) ?? "",
         result.stackScore.percent,
         `${result.stackScore.matched}/${result.stackScore.total}`,
+        result.generatorFaithfulness
+          ? `${result.generatorFaithfulness.matched}/${result.generatorFaithfulness.total}`
+          : "—",
         result.validation.install?.exitCode ?? "",
         result.validation.build?.exitCode ?? "",
         result.validation.checkTypes?.exitCode ?? "",
@@ -2177,6 +2232,7 @@ export function renderMarkdown(summary: ScaffbenchSummary) {
         aggregate.inconclusiveCount > 0 ? `${aggregate.inconclusiveCount}/${aggregate.runs}` : "0",
         `${aggregate.passRate}% (${aggregate.passCi95.low}-${aggregate.passCi95.high})`,
         `${aggregate.stackPercent}%`,
+        aggregate.faithfulnessPercent != null ? `${aggregate.faithfulnessPercent}%` : "—",
         `${aggregate.commandDisciplinePercent}%`,
         formatSeconds(aggregate.avgDurationMs),
         aggregate.avgOutputTokens ?? "",
@@ -2199,16 +2255,18 @@ Prompt style: ${summary.options.promptStyle}
 This is an ablation across creation paths and reasoning effort for one agent
 (Claude Code), not a cross-vendor leaderboard. Pass rate is over *scored* runs:
 infra-inconclusive runs (missing toolchain, validation timeout, exhausted token
-budget, or a crash with no output) are excluded from the denominator.
+budget, or a crash with no output) are excluded from the denominator. "Wired
+libs" is scored from the generated artifact (deps + imports + files);
+"Faithful" is the assisted-path bts.jsonc-vs-requested diagnostic.
 
-| Model | Effort | Effective reasoning | Path | Pass@1 | Inconclusive | Pass rate CI95 | Right libs | Command discipline | Avg time | Avg output tokens | Avg cost | Failure tags |
-| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Model | Effort | Effective reasoning | Path | Pass@1 | Inconclusive | Pass rate CI95 | Wired libs | Faithful | Command discipline | Avg time | Avg output tokens | Avg cost | Failure tags |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 ${aggregateRows}
 
 ## Runs
 
-| Spec | Trial | Effort | Effective reasoning | Model | Path | Validation | Failure tags | Claude exit | Time | Output tokens | Cost | Right libs % | Right libs | Install | Build | Typecheck | Lint | Test |
-| --- | ---: | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Spec | Trial | Effort | Effective reasoning | Model | Path | Validation | Failure tags | Claude exit | Time | Output tokens | Cost | Wired % | Wired | Faithful | Install | Build | Typecheck | Lint | Test |
+| --- | ---: | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 ${rows}
 `;
 }

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -22,7 +22,11 @@ export type FailureTag =
   | "tool-violation"
   | "typecheck-failed"
   | "validation-failed"
-  | "build-failed";
+  | "build-failed"
+  | "budget-exhausted"
+  | "toolchain-missing";
+
+export type RunOutcome = "success" | "model-failure" | "infra-inconclusive";
 
 export type StrictMarker = {
   id: string;
@@ -157,6 +161,8 @@ type SummaryAggregate = {
   effectiveReasoning?: string;
   path: CreationPath;
   runs: number;
+  scoredRuns: number;
+  inconclusiveCount: number;
   passCount: number;
   passRate: number;
   passCi95: { low: number; high: number };
@@ -979,11 +985,8 @@ Create the project from scratch by writing the files and manifests needed for a 
 
 Creation mode: Better-Fullstack CLI mention.
 Do not use MCP tools. Use the Better-Fullstack CLI via \`bun create better-fullstack@latest\`.
-Map the requirements to explicit non-interactive CLI flags. Run the command with \`--dry-run\` first, then run the same scaffold command for real without \`--dry-run\`.
-Use \`--no-install --no-git --disable-analytics\`.
-
-Canonical command shape for this spec:
-\`${canonicalCommand(spec, projectName)}\``;
+Map the requirements to explicit non-interactive CLI flags yourself; inspect \`--help\` if you are unsure of a flag name or value. Run the command with \`--dry-run\` first, then run the same scaffold command for real without \`--dry-run\`.
+Use \`--no-install --no-git --disable-analytics\`.`;
   }
 
   return `${base}
@@ -1947,10 +1950,50 @@ export function validationPassed(result: RunResult) {
   return steps.every((step) => step.exitCode === 0 && !step.timedOut);
 }
 
+function isBudgetExhausted(terminalReason: string | undefined) {
+  return terminalReason ? /budget|cost[_-]?limit|max[_-]?cost|spend/i.test(terminalReason) : false;
+}
+
+/**
+ * Three-way run outcome so the headline pass rate reflects model capability,
+ * not the test machine. An "infra-inconclusive" run is one where the harness or
+ * environment — not the model — prevented a clean measurement (a missing
+ * toolchain binary, a validation step that timed out, an exhausted token
+ * budget, or a generation that crashed without producing anything). These are
+ * excluded from the pass-rate denominator by `aggregateBy`.
+ */
+export function classifyOutcome(result: RunResult): RunOutcome {
+  if (isInfraInconclusive(result)) return "infra-inconclusive";
+  return validationPassed(result) ? "success" : "model-failure";
+}
+
+function isInfraInconclusive(result: RunResult): boolean {
+  // NOTE: a generation timeout (claude.timedOut) is intentionally NOT here — an
+  // agent that cannot finish within the generous gen budget is a real failure
+  // (cf. SWE-bench, which scores agent-loop timeouts as unresolved). Only
+  // environment/harness problems below are excluded from the pass denominator.
+  if (isBudgetExhausted(result.claude.terminalReason)) return true;
+  // claude crashed/blipped (e.g. MCP startup failure) without producing anything
+  if (
+    result.claude.exitCode !== 0 &&
+    !result.validation.projectExists &&
+    !result.claude.outputTokens
+  ) {
+    return true;
+  }
+  for (const step of Object.values(result.validation.steps)) {
+    if (!step) continue;
+    if (step.timedOut) return true;
+    if (step.exitCode === 127) return true; // missing toolchain binary
+  }
+  return false;
+}
+
 export function deriveFailureTags(result: RunResult): FailureTag[] {
   const tags = new Set<FailureTag>();
   if (result.claude.timedOut) tags.add("claude-timeout");
   if (result.claude.exitCode !== 0) tags.add("claude-error");
+  if (isBudgetExhausted(result.claude.terminalReason)) tags.add("budget-exhausted");
   if (!result.validation.projectExists) tags.add("project-not-found");
   if (result.stackScore.matched < result.stackScore.total) tags.add("stack-mismatch");
   if (result.toolCompliance.checks.some((check) => check.status === "fail")) {
@@ -1961,6 +2004,13 @@ export function deriveFailureTags(result: RunResult): FailureTag[] {
   for (const [name, step] of Object.entries(result.validation.steps)) {
     if (!step || (step.exitCode === 0 && !step.timedOut)) continue;
     tags.add("validation-failed");
+    if (step.exitCode === 127) {
+      // Missing toolchain binary (e.g. cargo/uv/go/dotnet not on PATH): an
+      // environment problem, not a model-authored build break. Tag it as such
+      // and skip the step-specific failure tags below.
+      tags.add("toolchain-missing");
+      continue;
+    }
     if (name.includes("install") || name.includes("restore")) tags.add("install-failed");
     if (name.includes("build") || name.includes("cargoCheck")) tags.add("build-failed");
     if (name.includes("typecheck")) tags.add("typecheck-failed");
@@ -1998,8 +2048,10 @@ function aggregateBy(
   return [...groups.entries()]
     .map(([key, group]) => {
       const first = group[0];
-      const passCount = group.filter(validationPassed).length;
-      const ci = wilsonInterval(passCount, group.length);
+      const scored = group.filter((result) => classifyOutcome(result) !== "infra-inconclusive");
+      const inconclusiveCount = group.length - scored.length;
+      const passCount = scored.filter(validationPassed).length;
+      const ci = wilsonInterval(passCount, scored.length);
       return {
         key,
         specId: key.startsWith(first.specId) ? first.specId : undefined,
@@ -2008,8 +2060,10 @@ function aggregateBy(
         effectiveReasoning: first.effectiveReasoning,
         path: first.path,
         runs: group.length,
+        scoredRuns: scored.length,
+        inconclusiveCount,
         passCount,
-        passRate: Math.round((passCount / group.length) * 100),
+        passRate: scored.length > 0 ? Math.round((passCount / scored.length) * 100) : 0,
         passCi95: ci,
         stackPercent: average(group.map((result) => result.stackScore.percent)),
         commandDisciplinePercent: average(
@@ -2095,7 +2149,7 @@ export function renderMarkdown(summary: ScaffbenchSummary) {
         result.effectiveReasoning ?? "",
         result.model,
         result.path,
-        validationPassed(result) ? "pass" : "fail",
+        formatOutcome(classifyOutcome(result)),
         result.failureTags.join(", "),
         result.claude.exitCode ?? "null",
         formatSeconds(result.claude.durationMs),
@@ -2119,7 +2173,8 @@ export function renderMarkdown(summary: ScaffbenchSummary) {
         aggregate.effort,
         aggregate.effectiveReasoning ?? "",
         aggregate.path,
-        `${aggregate.passCount}/${aggregate.runs}`,
+        `${aggregate.passCount}/${aggregate.scoredRuns}`,
+        aggregate.inconclusiveCount > 0 ? `${aggregate.inconclusiveCount}/${aggregate.runs}` : "0",
         `${aggregate.passRate}% (${aggregate.passCi95.low}-${aggregate.passCi95.high})`,
         `${aggregate.stackPercent}%`,
         `${aggregate.commandDisciplinePercent}%`,
@@ -2134,14 +2189,20 @@ export function renderMarkdown(summary: ScaffbenchSummary) {
   return `# ScaffBench 2.1 Run
 
 Harness: ${summary.harnessVersion}
+Agent: Claude Code (single agent; single model family per row)
 Specs: ${summary.specs.map((spec) => spec.id).join(", ")}
 Repeats: ${summary.options.repeats}
 Prompt style: ${summary.options.promptStyle}
 
-## Leaderboard
+## Path × effort summary
 
-| Model | Effort | Effective reasoning | Path | Pass@1 | Pass rate CI95 | Right libs | Command discipline | Avg time | Avg output tokens | Avg cost | Failure tags |
-| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+This is an ablation across creation paths and reasoning effort for one agent
+(Claude Code), not a cross-vendor leaderboard. Pass rate is over *scored* runs:
+infra-inconclusive runs (missing toolchain, validation timeout, exhausted token
+budget, or a crash with no output) are excluded from the denominator.
+
+| Model | Effort | Effective reasoning | Path | Pass@1 | Inconclusive | Pass rate CI95 | Right libs | Command discipline | Avg time | Avg output tokens | Avg cost | Failure tags |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 ${aggregateRows}
 
 ## Runs
@@ -2150,6 +2211,12 @@ ${aggregateRows}
 | --- | ---: | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 ${rows}
 `;
+}
+
+function formatOutcome(outcome: RunOutcome) {
+  if (outcome === "success") return "pass";
+  if (outcome === "infra-inconclusive") return "inconclusive";
+  return "fail";
 }
 
 function formatFailureTags(tags: Record<string, number>) {

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 export type CreationPath = "mcp" | "cli" | "prompt";
@@ -66,6 +67,10 @@ export type StepResult = {
   command: string;
   exitCode: number | null;
   timedOut: boolean;
+  /** True when the command binary itself could not be spawned (ENOENT) — an
+   * environment problem, distinct from a child process that ran and exited
+   * non-zero (e.g. a generated `bun run build` whose script is broken). */
+  spawnError?: boolean;
   durationMs: number;
   stdoutTail: string;
   stderrTail: string;
@@ -1029,6 +1034,12 @@ export async function runScaffbench(options: ScaffbenchOptions, log = console.lo
   const metadata = await collectMetadata(options);
   const results = await readExistingResults(options.outDir);
 
+  // Agents run in an isolated workspace tree, disjoint from the grading tree
+  // (canonical-command.txt / spec.json / summary.json / sibling runs), so a
+  // CLI or MCP run cannot read the answer key out of its own working directory.
+  const workspaceRoot = path.join(os.tmpdir(), "scaffbench21-work", path.basename(options.outDir));
+  await mkdir(workspaceRoot, { recursive: true });
+
   for (const spec of specs) {
     for (const effort of options.efforts) {
       for (const pathMode of options.paths) {
@@ -1036,6 +1047,7 @@ export async function runScaffbench(options: ScaffbenchOptions, log = console.lo
           const projectName = buildProjectName(spec, pathMode, effort, trial, options.repeats);
           const id = buildRunId(spec, options.model, effort, pathMode, trial, options.repeats);
           const runDir = path.join(options.outDir, "runs", id);
+          const workDir = path.join(workspaceRoot, id);
           await mkdir(runDir, { recursive: true });
 
           if (results.some((result) => result.id === id)) {
@@ -1043,7 +1055,10 @@ export async function runScaffbench(options: ScaffbenchOptions, log = console.lo
             continue;
           }
 
-          const prompt = promptFor(spec, pathMode, runDir, projectName, options.promptStyle);
+          await rm(workDir, { recursive: true, force: true }).catch(() => {});
+          await mkdir(workDir, { recursive: true });
+
+          const prompt = promptFor(spec, pathMode, workDir, projectName, options.promptStyle);
           await writeFile(path.join(runDir, "prompt.txt"), prompt);
           await writeFile(
             path.join(runDir, "canonical-command.txt"),
@@ -1053,7 +1068,7 @@ export async function runScaffbench(options: ScaffbenchOptions, log = console.lo
           log(`RUN ${id}`);
           const started = Date.now();
           const claude = await runClaude({
-            cwd: runDir,
+            cwd: workDir,
             prompt,
             model: options.model,
             effort,
@@ -1066,14 +1081,35 @@ export async function runScaffbench(options: ScaffbenchOptions, log = console.lo
           await writeFile(path.join(runDir, "claude.stderr.log"), claude.stderr);
 
           const parsed = parseClaudeResult(claude.stdout);
-          const projectDir = await findProjectDir(runDir, projectName);
+          const generatedDir = await findProjectDir(workDir, projectName);
           const validation = options.skipValidation
-            ? { projectExists: projectDir !== null, steps: {} }
-            : await validateProject(spec, projectDir, options);
-          const scored = projectDir
-            ? await scoreProject(spec, projectDir)
+            ? { projectExists: generatedDir !== null, steps: {} }
+            : await validateProject(spec, generatedDir, options);
+          const scored = generatedDir
+            ? await scoreProject(spec, generatedDir)
             : { artifact: emptyArtifactScore(spec), faithfulness: undefined };
-          const toolCompliance = await scoreToolCompliance(pathMode, projectDir, claude);
+          const toolCompliance = await scoreToolCompliance(pathMode, generatedDir, claude);
+
+          // Archive the generated source under the grading tree, then drop the
+          // isolated workspace, so run artifacts stay durable without leaving
+          // the answer key reachable from the agent's working directory.
+          let projectDir = generatedDir;
+          if (generatedDir) {
+            const archivedDir = path.join(runDir, projectName);
+            try {
+              await archiveProjectSource(generatedDir, archivedDir);
+              projectDir = archivedDir;
+            } catch (error) {
+              log(
+                `WARN archive failed for ${id}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+            }
+          }
+          if (!generatedDir || projectDir !== generatedDir) {
+            await rm(workDir, { recursive: true, force: true }).catch(() => {});
+          }
           const result: RunResult = {
             id,
             specId: spec.id,
@@ -1248,6 +1284,7 @@ export async function runCommand(
   let stdout = "";
   let stderr = "";
   let timedOut = false;
+  let spawnError = false;
   const timer = setTimeout(() => {
     timedOut = true;
     child.kill("SIGTERM");
@@ -1270,6 +1307,7 @@ export async function runCommand(
     };
 
     child.on("error", (error) => {
+      spawnError = true;
       stderr += `${stderr ? "\n" : ""}${error.name}: ${error.message}`;
       finish(127);
     });
@@ -1281,6 +1319,7 @@ export async function runCommand(
     command: [command, ...args].map(quoteArg).join(" "),
     exitCode,
     timedOut,
+    spawnError,
     durationMs: Date.now() - started,
     stdout,
     stderr,
@@ -1323,6 +1362,30 @@ async function findProjectDir(runDir: string, projectName: string) {
   const dirs = entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith("."));
   if (dirs.length === 1) return path.join(runDir, dirs[0].name);
   return null;
+}
+
+/** Copy the generated project source (excluding heavy build/dependency dirs)
+ * from the isolated workspace into the durable grading tree. */
+async function archiveProjectSource(srcDir: string, destDir: string) {
+  const skip = new Set([
+    "node_modules",
+    ".git",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    "coverage",
+    "target",
+    ".venv",
+    "bin",
+    "obj",
+  ]);
+  await rm(destDir, { recursive: true, force: true });
+  await cp(srcDir, destDir, {
+    recursive: true,
+    force: true,
+    filter: (source) => !skip.has(path.basename(source)),
+  });
 }
 
 async function validateProject(
@@ -2024,7 +2087,7 @@ function isInfraInconclusive(result: RunResult): boolean {
   for (const step of Object.values(result.validation.steps)) {
     if (!step) continue;
     if (step.timedOut) return true;
-    if (step.exitCode === 127) return true; // missing toolchain binary
+    if (step.spawnError) return true; // validator binary itself could not be spawned
   }
   return false;
 }
@@ -2053,10 +2116,11 @@ export function deriveFailureTags(result: RunResult): FailureTag[] {
   for (const [name, step] of Object.entries(result.validation.steps)) {
     if (!step || (step.exitCode === 0 && !step.timedOut)) continue;
     tags.add("validation-failed");
-    if (step.exitCode === 127) {
-      // Missing toolchain binary (e.g. cargo/uv/go/dotnet not on PATH): an
-      // environment problem, not a model-authored build break. Tag it as such
-      // and skip the step-specific failure tags below.
+    if (step.spawnError) {
+      // The validator binary itself could not be spawned (e.g. cargo/uv/go/dotnet
+      // not on PATH): an environment problem, not a model-authored break. A child
+      // process that ran and exited 127 (e.g. a generated `bun run build` whose
+      // script references a missing bin) is NOT this — it falls through below.
       tags.add("toolchain-missing");
       continue;
     }


### PR DESCRIPTION
## Summary

Follow-up to #252. Implements **all five P0 items** from the ScaffBench 2.1 methodology review (benchmarked against Artificial Analysis / SWE-bench Verified / DeepSWE / Terminal-Bench / LiveBench practice), plus the two Codex review fixes.

| Item | What landed |
|---|---|
| **P0-1 de-leak** | CLI prompt no longer embeds the canonical command; agents also run in an **isolated temp workspace** disjoint from the grading tree, so `canonical-command.txt`/`spec.json`/`summary.json`/sibling runs are unreadable via path traversal. Generated source is archived back under `runs/<id>/` after scoring. |
| **P0-2 artifact scoring** | `scoreProject` returns **Wired libs** (markers over the real generated tree — primary, all paths) + **Faithful** (`bts.jsonc` echo — assisted diagnostic). New `stack-unwired` tag catches a generator that records a library it never wired. Calibrated against a real BF-generated MCP artifact. |
| **P0-3 solvability gate** | `scaffbench-solvability.test.ts` scaffolds each spec from its **own** `canonicalFlags` and asserts install/build/type-check via the harness's `validateProject`, so a generator regression surfaces here instead of being charged to the model. Scheduled/dispatch CI job across all 5 ecosystems (not a per-PR blocker). |
| **P0-4 outcome taxonomy** | `{success, model-failure, infra-inconclusive}`; infra-inconclusive (un-spawnable toolchain → `toolchain-missing`, validation timeout, budget cap → `budget-exhausted`, empty crash) excluded from the pass denominator (`Inconclusive` column). Generation timeout stays a model-failure (SWE-bench). |
| **P0-5 honest labeling** | "Leaderboard" → "Path × effort summary" with an explicit single-agent / not-cross-vendor caveat. |

### Codex review fixes
- **Answer key in agent cwd** → agents now run in an isolated workspace disjoint from the grading tree (see P0-1).
- **Every exit 127 treated as infra** → `runCommand` sets `spawnError` only on spawn-ENOENT; a child process exiting 127 (broken generated script) stays a `model-failure` with its build tag. Distinct regression test added.

## Validation
- `bun test scripts/scaffbench-v2-lib.test.ts` — **17 pass** (covers de-leak, artifact-vs-faithfulness + `stack-unwired`, spawn-127 vs child-127, denominator exclusion, budget/toolchain tags).
- Solvability gate validated locally: `ai-search-workbench` passes end-to-end in ~16s; dotnet spec correctly skips when the toolchain is absent. The 5-ecosystem matrix runs in the new scheduled `scaffbench-solvability` CI job.
- `bun run scaffbench:2.1:matrix` render verified; type-check introduces no new errors; readiness doc updated throughout.

## Notes
- The solvability job is **scheduled / workflow_dispatch only** (a heavy 5-ecosystem sweep), so it is skipped on `pull_request` and does not block this PR's checks. A first full run is being kicked manually.
- P0-2 changes the assisted "right libs" denominator (24 bts → 21 markers); for a correct project both read ~100%, but published 2.1 numbers should use the Wired/Faithful split.