### PR TITLE
ScaffBench 2.1: P1 — per-spec macro stats, pass@k/pass^k, n-gated CI

### DIFF
--- a/docs/plans/planned/scaffbench-2.1-readiness.md
+++ b/docs/plans/planned/scaffbench-2.1-readiness.md
@@ -106,7 +106,14 @@ Secondary diagnostic signals:
 - command discipline and tool-path compliance
 - failure taxonomy tags
 - average cost, output tokens, and wall time
-- Wilson 95% interval for repeated pass rates
+
+Reliability is reported per spec, not pooled:
+- `Macro` — mean of per-spec pass rates (each spec is one unit, so heterogeneous
+  specs are not collapsed into a single binomial)
+- `pass@k` — specs solved on at least one repeat; `pass^k` — specs solved on
+  every repeat (consistency)
+- Wilson 95% interval, shown only when a cell has at least 8 scored runs (below
+  that it reads `n<8`, because e.g. 3/3 and 0/3 intervals overlap)
 
 ## Failure Tags
 

--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -462,3 +462,50 @@ describe("ScaffBench 2.1 run outcomes", () => {
     });
   });
 });
+
+describe("ScaffBench 2.1 statistical reporting", () => {
+  const passing = () => ({
+    projectExists: true,
+    steps: {
+      install: { command: "bun install", exitCode: 0, timedOut: false, durationMs: 1, stdoutTail: "", stderrTail: "" },
+    },
+  });
+  const failing = () => ({
+    projectExists: true,
+    steps: {
+      build: { command: "bun run build", exitCode: 1, timedOut: false, durationMs: 1, stdoutTail: "", stderrTail: "" },
+    },
+  });
+
+  it("macro-averages per spec and reports pass@k / pass^k instead of one pooled binomial", () => {
+    const runs = [
+      makeRun({ id: "a1", specId: "spec-a", trial: 1, validation: passing() }),
+      makeRun({ id: "a2", specId: "spec-a", trial: 2, validation: passing() }),
+      makeRun({ id: "b1", specId: "spec-b", trial: 1, validation: passing() }),
+      makeRun({ id: "b2", specId: "spec-b", trial: 2, validation: failing() }),
+    ];
+
+    const [cell] = aggregateResults(runs).leaderboard;
+
+    expect(cell).toMatchObject({
+      scoredRuns: 4,
+      passCount: 3,
+      passRate: 75, // pooled
+      macroPassRate: 75, // mean of per-spec rates (100 + 50) / 2
+      specCount: 2,
+      passAnySpecs: 2, // both specs pass at least once (pass@k)
+      passAllSpecs: 1, // only spec-a passes every repeat (pass^k)
+      ciReportable: false, // 4 < MIN_CI_RUNS
+    });
+  });
+
+  it("only reports the Wilson CI once a cell reaches the minimum sample size", () => {
+    const runs = Array.from({ length: 8 }, (_, i) =>
+      makeRun({ id: `r${i}`, specId: `spec-${i % 2}`, trial: i, validation: passing() }),
+    );
+
+    const [cell] = aggregateResults(runs).leaderboard;
+
+    expect(cell).toMatchObject({ scoredRuns: 8, ciReportable: true });
+  });
+});

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -175,6 +175,17 @@ type SummaryAggregate = {
   passCount: number;
   passRate: number;
   passCi95: { low: number; high: number };
+  /** True when scoredRuns >= MIN_CI_RUNS, so the Wilson interval is worth showing. */
+  ciReportable: boolean;
+  /** Distinct specs contributing to this cell. */
+  specCount: number;
+  /** Mean of per-spec pass rates — a macro-average that treats each spec as one
+   * unit instead of pooling heterogeneous-difficulty specs into one binomial. */
+  macroPassRate: number;
+  /** pass@k: specs solved on at least one of their repeats. */
+  passAnySpecs: number;
+  /** pass^k: specs solved on every one of their repeats (consistency). */
+  passAllSpecs: number;
   stackPercent: number;
   faithfulnessPercent?: number;
   commandDisciplinePercent: number;
@@ -207,6 +218,9 @@ type ProjectIndex = {
 };
 
 const HARNESS_VERSION = "2.1.0";
+// Below this many scored runs a Wilson interval is too wide to be informative
+// (e.g. at n=3, 3/3 → [44,100] overlaps 0/3 → [0,56]); the report suppresses it.
+const MIN_CI_RUNS = 8;
 const DEFAULT_EFFORTS: readonly Effort[] = ["low", "medium", "high"];
 const DEFAULT_PATHS: readonly CreationPath[] = ["mcp", "cli", "prompt"];
 const CLAUDE_TIMEOUT_MS = 15 * 60_000;
@@ -2165,6 +2179,26 @@ function aggregateBy(
       const inconclusiveCount = group.length - scored.length;
       const passCount = scored.filter(validationPassed).length;
       const ci = wilsonInterval(passCount, scored.length);
+
+      // Per-spec macro statistics: treat each spec as a unit rather than pooling
+      // heterogeneous-difficulty specs into one binomial (which understates
+      // variance). pass@k / pass^k summarise reliability across repeats.
+      const bySpec = new Map<string, { scored: number; pass: number }>();
+      for (const result of scored) {
+        const entry = bySpec.get(result.specId) ?? { scored: 0, pass: 0 };
+        entry.scored += 1;
+        if (validationPassed(result)) entry.pass += 1;
+        bySpec.set(result.specId, entry);
+      }
+      const specEntries = [...bySpec.values()];
+      const macroPassRate = average(
+        specEntries.map((entry) => (entry.scored > 0 ? (entry.pass / entry.scored) * 100 : 0)),
+      );
+      const passAllSpecs = specEntries.filter(
+        (entry) => entry.scored > 0 && entry.pass === entry.scored,
+      ).length;
+      const passAnySpecs = specEntries.filter((entry) => entry.pass > 0).length;
+
       return {
         key,
         specId: key.startsWith(first.specId) ? first.specId : undefined,
@@ -2178,6 +2212,11 @@ function aggregateBy(
         passCount,
         passRate: scored.length > 0 ? Math.round((passCount / scored.length) * 100) : 0,
         passCi95: ci,
+        ciReportable: scored.length >= MIN_CI_RUNS,
+        specCount: specEntries.length,
+        macroPassRate,
+        passAnySpecs,
+        passAllSpecs,
         stackPercent: average(group.map((result) => result.stackScore.percent)),
         faithfulnessPercent: maybeAverage(
           group.map((result) => result.generatorFaithfulness?.percent),
@@ -2294,7 +2333,12 @@ export function renderMarkdown(summary: ScaffbenchSummary) {
         aggregate.path,
         `${aggregate.passCount}/${aggregate.scoredRuns}`,
         aggregate.inconclusiveCount > 0 ? `${aggregate.inconclusiveCount}/${aggregate.runs}` : "0",
-        `${aggregate.passRate}% (${aggregate.passCi95.low}-${aggregate.passCi95.high})`,
+        `${aggregate.macroPassRate}%`,
+        `${aggregate.passAnySpecs}/${aggregate.specCount}`,
+        `${aggregate.passAllSpecs}/${aggregate.specCount}`,
+        aggregate.ciReportable
+          ? `${aggregate.passRate}% (${aggregate.passCi95.low}-${aggregate.passCi95.high})`
+          : `n<${MIN_CI_RUNS}`,
         `${aggregate.stackPercent}%`,
         aggregate.faithfulnessPercent != null ? `${aggregate.faithfulnessPercent}%` : "—",
         `${aggregate.commandDisciplinePercent}%`,
@@ -2323,8 +2367,14 @@ budget, or a crash with no output) are excluded from the denominator. "Wired
 libs" is scored from the generated artifact (deps + imports + files);
 "Faithful" is the assisted-path bts.jsonc-vs-requested diagnostic.
 
-| Model | Effort | Effective reasoning | Path | Pass@1 | Inconclusive | Pass rate CI95 | Wired libs | Faithful | Command discipline | Avg time | Avg output tokens | Avg cost | Failure tags |
-| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+Reliability is reported per spec, not pooled: "Macro" is the mean of per-spec
+pass rates; "pass@k" counts specs solved on at least one repeat and "pass^k"
+specs solved on every repeat. The Wilson "CI95" is shown only when a cell has
+≥ ${MIN_CI_RUNS} scored runs (below that it reads \`n<${MIN_CI_RUNS}\`, since e.g. 3/3 and 0/3
+intervals overlap and the interval is not informative).
+
+| Model | Effort | Effective reasoning | Path | Pass@1 | Inconclusive | Macro | pass@k | pass^k | CI95 | Wired libs | Faithful | Command discipline | Avg time | Avg output tokens | Avg cost | Failure tags |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 ${aggregateRows}
 
 ## Runs


### PR DESCRIPTION
## Summary

First P1 item from the ScaffBench 2.1 methodology review. **Stacked on #253** (base = `ibrahim/scaffbench-2.1-p0-hardening`); review/merge #253 first, then this retargets to `Development`.

Fixes the statistical-reporting gap: the leaderboard previously pooled all specs × repeats into **one** Wilson interval, which
1. violates the single-`p` assumption across deliberately different-difficulty specs (overdispersion → interval too narrow), and
2. at the publishable `--repeats 3` is statistically inert — 3/3 → `[44,100]` overlaps 0/3 → `[0,56]`, so a perfect path and an always-failing path are indistinguishable.

### Changes
`aggregateBy` now also computes **per-spec macro statistics** (each spec is one unit, not pooled):
- **`macroPassRate`** — mean of per-spec pass rates
- **`passAnySpecs` (pass@k)** — specs solved on ≥1 repeat
- **`passAllSpecs` (pass^k)** — specs solved on every repeat (consistency)
- **`ciReportable`** — `scoredRuns >= MIN_CI_RUNS` (8); below that the rendered Wilson CI reads `n<8` instead of a misleading interval.

The leaderboard render gains **Macro / pass@k / pass^k** columns and gates the CI on sample size.

### Benchmark precedent
HumanEval reports pass@k at a sample size chosen for low variance; SWE-bench / DeepSWE macro-average over a fixed instance set rather than collapsing heterogeneous tasks into one binomial proportion.

## Validation
- `bun test scripts/scaffbench-v2-lib.test.ts` — **19 pass** (+2: macro vs pooled with pass@k/pass^k; CI gating at the n threshold).
- `bun run scaffbench:2.1:matrix` — leaderboard render verified (column/separator integrity).
- Type-check introduces no new errors (back to the pre-existing baseline).
- Readiness doc scoring-signals section updated.

## Roadmap context
Remaining P1 (subsequent PRs): discovery lane + per-capability acceptance sets, markers-measure-use, fixed per-spec validation contract + per-gate scorecard, headroom/held-out specs, hermeticity + reproducibility metadata.