### PR TITLE
ScaffBench 2.1: reporting & resolution robustness (addresses Codex #254)

### DIFF
--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,7 +8,9 @@ import {
   canonicalCommand,
   classifyOutcome,
   deriveFailureTags,
+  findProjectDir,
   parseArgs,
+  parseClaudeResult,
   promptFor,
   runCommand,
   scoreArtifact,
@@ -507,5 +509,83 @@ describe("ScaffBench 2.1 statistical reporting", () => {
     const [cell] = aggregateResults(runs).leaderboard;
 
     expect(cell).toMatchObject({ scoredRuns: 8, ciReportable: true });
+  });
+
+  it("does not count a partially-inconclusive spec as pass^k", () => {
+    const stepFail127 = {
+      command: "uv sync",
+      exitCode: 127,
+      timedOut: false,
+      spawnError: true,
+      durationMs: 1,
+      stdoutTail: "",
+      stderrTail: "",
+    };
+    const runs = [
+      makeRun({ id: "x1", specId: "spec-x", trial: 1, validation: passing() }),
+      makeRun({
+        id: "x2",
+        specId: "spec-x",
+        trial: 2,
+        validation: { projectExists: true, steps: { install: stepFail127 } },
+      }),
+    ];
+
+    const [cell] = aggregateResults(runs).leaderboard;
+
+    // 1 passing scored repeat + 1 infra-inconclusive: measured once, not "every repeat".
+    expect(cell).toMatchObject({
+      scoredRuns: 1,
+      inconclusiveCount: 1,
+      passAnySpecs: 1, // solved at least once
+      passAllSpecs: 0, // NOT solved on every repeat (one was unmeasured)
+      macroPassRate: 100, // the one measured repeat passed
+    });
+  });
+
+  it("reports sub-dollar average cost without integer rounding", () => {
+    const cheap = (id: string) =>
+      makeRun({
+        id,
+        claude: { exitCode: 0, timedOut: false, durationMs: 1000, totalCostUsd: 0.4 },
+        validation: passing(),
+      });
+
+    const [cell] = aggregateResults([cheap("c1"), cheap("c2")]).leaderboard;
+
+    expect(cell?.avgCostUsd).toBeCloseTo(0.4, 5);
+  });
+});
+
+describe("ScaffBench 2.1 resolution robustness", () => {
+  it("disambiguates the project directory by manifest when a stray dir exists", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "sb21-find-"));
+    try {
+      await mkdir(join(runDir, "scratch-notes"), { recursive: true });
+      await mkdir(join(runDir, "the-project"), { recursive: true });
+      await writeFile(join(runDir, "the-project", "package.json"), "{}");
+
+      expect(await findProjectDir(runDir, "missing-name")).toBe(join(runDir, "the-project"));
+    } finally {
+      await rm(runDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the exact project dir when present", async () => {
+    const runDir = await mkdtemp(join(tmpdir(), "sb21-find-"));
+    try {
+      await mkdir(join(runDir, "proj"), { recursive: true });
+      expect(await findProjectDir(runDir, "proj")).toBe(join(runDir, "proj"));
+    } finally {
+      await rm(runDir, { recursive: true, force: true });
+    }
+  });
+
+  it("extracts the Claude result JSON despite surrounding noise", () => {
+    expect(parseClaudeResult('warning: banner\n{"total_cost_usd":1.5}\n')).toMatchObject({
+      total_cost_usd: 1.5,
+    });
+    expect(parseClaudeResult('{"a":1}')).toMatchObject({ a: 1 });
+    expect(parseClaudeResult("no json here")).toBeNull();
   });
 });

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -1350,31 +1350,54 @@ function tail(value: string, max = 4_000) {
   return value.length <= max ? value : value.slice(-max);
 }
 
-function parseClaudeResult(stdout: string): any | null {
+export function parseClaudeResult(stdout: string): any | null {
   try {
     return JSON.parse(stdout);
   } catch {
+    // Tolerate leading/trailing non-JSON (banner lines, warnings) by extracting
+    // the outermost {...} span before giving up.
+    const start = stdout.indexOf("{");
+    const end = stdout.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(stdout.slice(start, end + 1));
+      } catch {}
+    }
     const line = stdout
       .trim()
       .split("\n")
       .reverse()
-      .find((candidate) => candidate.startsWith("{") && candidate.endsWith("}"));
+      .find((candidate) => candidate.trim().startsWith("{") && candidate.trim().endsWith("}"));
     if (!line) return null;
     try {
-      return JSON.parse(line);
+      return JSON.parse(line.trim());
     } catch {
       return null;
     }
   }
 }
 
-async function findProjectDir(runDir: string, projectName: string) {
+const PROJECT_MANIFESTS = ["package.json", "Cargo.toml", "go.mod", "pyproject.toml", "bts.jsonc"];
+
+export async function findProjectDir(runDir: string, projectName: string) {
   const expected = path.join(runDir, projectName);
   if (existsSync(expected)) return expected;
 
   const entries = await readdir(runDir, { withFileTypes: true });
-  const dirs = entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith("."));
-  if (dirs.length === 1) return path.join(runDir, dirs[0].name);
+  const dirs = entries.filter(
+    (entry) => entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules",
+  );
+  if (dirs.length === 1 && dirs[0]) return path.join(runDir, dirs[0].name);
+
+  // Multiple (or zero) candidate dirs: disambiguate by manifest presence so a
+  // stray directory the agent created does not shadow the real project, and an
+  // ambiguous tree resolves to null rather than a wrong guess.
+  const withManifest = dirs.filter((dir) =>
+    PROJECT_MANIFESTS.some((manifest) => existsSync(path.join(runDir, dir.name, manifest))),
+  );
+  if (withManifest.length === 1 && withManifest[0]) {
+    return path.join(runDir, withManifest[0].name);
+  }
   return null;
 }
 
@@ -2183,20 +2206,26 @@ function aggregateBy(
       // Per-spec macro statistics: treat each spec as a unit rather than pooling
       // heterogeneous-difficulty specs into one binomial (which understates
       // variance). pass@k / pass^k summarise reliability across repeats.
-      const bySpec = new Map<string, { scored: number; pass: number }>();
-      for (const result of scored) {
-        const entry = bySpec.get(result.specId) ?? { scored: 0, pass: 0 };
-        entry.scored += 1;
-        if (validationPassed(result)) entry.pass += 1;
+      // Track total repeats (from the full group) alongside scored/pass so that
+      // pass^k cannot be overstated: a spec with one passing scored repeat and
+      // the rest infra-inconclusive must NOT count as "passed every repeat".
+      const bySpec = new Map<string, { total: number; scored: number; pass: number }>();
+      for (const result of group) {
+        const entry = bySpec.get(result.specId) ?? { total: 0, scored: 0, pass: 0 };
+        entry.total += 1;
+        if (classifyOutcome(result) !== "infra-inconclusive") {
+          entry.scored += 1;
+          if (validationPassed(result)) entry.pass += 1;
+        }
         bySpec.set(result.specId, entry);
       }
       const specEntries = [...bySpec.values()];
-      const macroPassRate = average(
-        specEntries.map((entry) => (entry.scored > 0 ? (entry.pass / entry.scored) * 100 : 0)),
-      );
-      const passAllSpecs = specEntries.filter(
-        (entry) => entry.scored > 0 && entry.pass === entry.scored,
-      ).length;
+      // Macro pass rate averages only specs that were actually measured.
+      const measuredSpecs = specEntries.filter((entry) => entry.scored > 0);
+      const macroPassRate = average(measuredSpecs.map((entry) => (entry.pass / entry.scored) * 100));
+      // pass^k: passed on EVERY repeat (all repeats measured and passing).
+      const passAllSpecs = specEntries.filter((entry) => entry.pass === entry.total).length;
+      // pass@k: passed on at least one repeat.
       const passAnySpecs = specEntries.filter((entry) => entry.pass > 0).length;
 
       return {
@@ -2230,7 +2259,7 @@ function aggregateBy(
         ),
         avgDurationMs: average(group.map((result) => result.claude.durationMs)),
         avgOutputTokens: maybeAverage(group.map((result) => result.claude.outputTokens)),
-        avgCostUsd: maybeAverage(group.map((result) => result.claude.totalCostUsd)),
+        avgCostUsd: maybeAveragePrecise(group.map((result) => result.claude.totalCostUsd)),
         failureTags: countFailureTags(group),
       };
     })
@@ -2252,12 +2281,24 @@ function wilsonInterval(successes: number, total: number) {
 
 function average(values: readonly number[]) {
   if (values.length === 0) return 0;
-  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+  return Math.round(averagePrecise(values));
+}
+
+/** Unrounded mean — used for sub-unit quantities like USD cost, where rounding
+ * to a whole number before formatting would print a $0.40 mean as `0.000`. */
+function averagePrecise(values: readonly number[]) {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
 function maybeAverage(values: readonly (number | undefined)[]) {
   const present = values.filter((value): value is number => typeof value === "number");
   return present.length > 0 ? average(present) : undefined;
+}
+
+function maybeAveragePrecise(values: readonly (number | undefined)[]) {
+  const present = values.filter((value): value is number => typeof value === "number");
+  return present.length > 0 ? averagePrecise(present) : undefined;
 }
 
 function countFailureTags(group: readonly RunResult[]) {


### PR DESCRIPTION
## Summary

Phase 3 of the ScaffBench 2.1 roadmap — robustness/correctness fixes, including the **Codex P2 from #254**.

- **Codex #254 — `pass^k` overstatement**: `bySpec` was built only from scored runs, so a spec with one passing repeat and the rest infra-inconclusive scored `pass === scored` and was wrongly credited in `pass^k`. Now tracks total repeats from the full group; `passAllSpecs` requires `pass === total` (every repeat measured *and* passing), and `macroPassRate` averages only measured specs.
- **`avgCostUsd` rounding (P2)**: `average()` rounded to a whole number before `toFixed(3)`, so a $0.40 mean printed `0.000`. Cost now uses an unrounded `maybeAveragePrecise`.
- **`findProjectDir` hardening (P3)**: ignores `node_modules` and, when several dirs exist, disambiguates by manifest presence so a stray agent-created directory can't shadow the real project; ambiguous trees resolve to `null` instead of a wrong guess.
- **`parseClaudeResult` robustness (P3)**: extracts the outermost `{...}` span so banner/warning noise around the JSON result no longer nulls all run telemetry.

## Validation
- `bun test scripts/scaffbench-v2-lib.test.ts` — **24 pass** (+5: pass^k with an inconclusive repeat; sub-dollar avg cost; project-dir manifest disambiguation; exact-dir; JSON extraction from noise).
- Type-check net **−1** vs baseline (cleared a pre-existing nit, added none).
- `bun run scaffbench:2.1:matrix` render verified.