### PR TITLE
ScaffBench 2.1: P1 — typecheck can't be dodged (tsc --noEmit fallback)

### DIFF
--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -17,6 +17,7 @@ import {
   scoreBts,
   scoreProject,
   SCAFFBENCH_2_1_SPECS,
+  typecheckGate,
   validationPassed,
   type RunResult,
 } from "./scaffbench-v2-lib";
@@ -665,6 +666,15 @@ describe("ScaffBench 2.1 discovery lane", () => {
     expect(explicitAi).toContain("Important scoring rule");
     // rust has no acceptance sets yet → it is NOT a discovery spec, notes stay
     expect(naturalRust).toContain("Important scoring rule");
+  });
+
+  it("falls back to tsc --noEmit so typecheck cannot be dodged", () => {
+    expect(typecheckGate({ "check-types": "tsc" }, true)).toBe("check-types");
+    expect(typecheckGate({ typecheck: "tsc" }, true)).toBe("typecheck");
+    // no script but a tsconfig exists → must still type-check
+    expect(typecheckGate({}, true)).toBe("tsc");
+    // genuinely nothing to type-check
+    expect(typecheckGate({}, false)).toBeNull();
   });
 
   it("credits an accepted alternative library (pgvector for semantic search)", async () => {

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -1571,14 +1571,19 @@ async function validateBunProject(projectDir: string, options: ScaffbenchOptions
     steps.build = toStep(
       await runCommand(bun, ["run", "build"], projectDir, VALIDATION_TIMEOUT_MS),
     );
-  const typeScriptScript = scripts["check-types"]
-    ? "check-types"
-    : scripts.typecheck
-      ? "typecheck"
-      : null;
-  if (typeScriptScript) {
+  const gate = typecheckGate(scripts, existsSync(path.join(projectDir, "tsconfig.json")));
+  if (gate === "tsc") {
+    // No typecheck script shipped: fall back to a direct `tsc --noEmit` so a TS
+    // project cannot dodge type-checking simply by omitting the script.
+    const bunx = existsSync(`${process.env.HOME}/.bun/bin/bunx`)
+      ? `${process.env.HOME}/.bun/bin/bunx`
+      : "bunx";
     steps.typecheck = toStep(
-      await runCommand(bun, ["run", typeScriptScript], projectDir, VALIDATION_TIMEOUT_MS),
+      await runCommand(bunx, ["tsc", "--noEmit"], projectDir, VALIDATION_TIMEOUT_MS),
+    );
+  } else if (gate) {
+    steps.typecheck = toStep(
+      await runCommand(bun, ["run", gate], projectDir, VALIDATION_TIMEOUT_MS),
     );
   }
   if (options.qualityGate || scripts.lint) {
@@ -1833,6 +1838,20 @@ async function readPackageScripts(packageJsonPath: string) {
   } catch {
     return {};
   }
+}
+
+/** Decide how a TS project is type-checked: prefer its own script, else fall
+ * back to a direct `tsc --noEmit` when a tsconfig exists, so a project cannot
+ * dodge type-checking by omitting the script. Returns null when there is
+ * genuinely nothing to type-check (no script and no tsconfig). */
+export function typecheckGate(
+  scripts: Record<string, string>,
+  hasTsconfig: boolean,
+): "check-types" | "typecheck" | "tsc" | null {
+  if (scripts["check-types"]) return "check-types";
+  if (scripts.typecheck) return "typecheck";
+  if (hasTsconfig) return "tsc";
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase — **stacked on #258**. Closes the "validation can be dodged" gap: a TS project shipping no `check-types`/`typecheck` script was never type-checked yet still passed (and sparser projects faced fewer gates, penalizing completeness).

`typecheckGate()` prefers the project's own script, else falls back to a direct **`tsc --noEmit`** when a `tsconfig.json` exists; returns `null` only when there's genuinely nothing to type-check. `validateBunProject` uses it. The solvable specs ship `check-types`, so the gate is unchanged for them — the fallback only bites a project that omitted the script.

## Validation
- `bun test scripts/scaffbench-v2-lib.test.ts` — **29 pass** (+1: gate selection across check-types / typecheck / tsc-fallback / none).
- Type-check unchanged. The fallback path is exercised by the scheduled solvability gate.

## Benchmark precedent
SWE-bench's PASS_TO_PASS criterion can't be dodged by omitting tests; the success bar is fixed by the benchmark, not by what the candidate happens to include.