### PR TITLE
ScaffBench 2.1: P2 — command discipline from the tool trajectory

### DIFF
--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -8,6 +8,7 @@ import {
   canonicalCommand,
   classifyOutcome,
   deriveFailureTags,
+  extractToolUses,
   findProjectDir,
   parseArgs,
   parseClaudeResult,
@@ -16,6 +17,7 @@ import {
   scoreArtifact,
   scoreBts,
   scoreProject,
+  scoreToolCompliance,
   SCAFFBENCH_2_1_SPECS,
   typecheckGate,
   validationPassed,
@@ -784,5 +786,71 @@ describe("ScaffBench 2.1 acceptance matching precision (Codex #258)", () => {
     const [cell] = aggregateResults([wired, noProject]).leaderboard;
 
     expect(cell?.acceptancePercent).toBe(50); // (100 + 0) / 2, not 100
+  });
+});
+
+describe("ScaffBench 2.1 command discipline from trajectory (P2)", () => {
+  const streamJson = (...events: object[]) =>
+    `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+  const claudeOutput = (stdout: string): any => ({
+    command: "claude",
+    exitCode: 0,
+    timedOut: false,
+    spawnError: false,
+    durationMs: 1,
+    stdout,
+    stderr: "",
+    stdoutTail: "",
+    stderrTail: "",
+  });
+  const bashUse = (command: string) => ({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Bash", input: { command } }] },
+  });
+  const mcpUse = (name: string) => ({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name, input: {} }] },
+  });
+  const resultEvent = {
+    type: "result",
+    subtype: "success",
+    total_cost_usd: 1.2,
+    usage: { output_tokens: 3000 },
+    session_id: "abc",
+  };
+
+  it("parses the result line and tool_use events from a stream-json transcript", () => {
+    const out = streamJson(bashUse("bun create better-fullstack@2.1.1 app --dry-run"), resultEvent);
+    expect(parseClaudeResult(out)).toMatchObject({ total_cost_usd: 1.2, session_id: "abc" });
+    const uses = extractToolUses(out);
+    expect(uses).toHaveLength(1);
+    expect(uses[0]).toMatchObject({ name: "Bash" });
+    expect(uses[0]?.command).toContain("--dry-run");
+  });
+
+  it("scores the CLI path on actual bun-create + dry-run tool calls", async () => {
+    const out = streamJson(
+      bashUse("bun create better-fullstack@2.1.1 app --dry-run"),
+      bashUse("bun create better-fullstack@2.1.1 app --no-install"),
+      resultEvent,
+    );
+    expect(await scoreToolCompliance("cli", null, claudeOutput(out))).toMatchObject({
+      score: 3,
+      total: 3,
+    });
+  });
+
+  it("fails a prompt-only run that shells out to the BF CLI", async () => {
+    const out = streamJson(bashUse("bun create better-fullstack@2.1.1 app"), resultEvent);
+    const tc = await scoreToolCompliance("prompt", null, claudeOutput(out));
+    expect(tc.checks.find((check) => check.id === "no-bf-tool")?.status).toBe("fail");
+  });
+
+  it("passes the MCP path when bfs_create_project is actually called", async () => {
+    const out = streamJson(mcpUse("mcp__better-fullstack__bfs_create_project"), resultEvent);
+    expect(await scoreToolCompliance("mcp", null, claudeOutput(out))).toMatchObject({
+      score: 2,
+      total: 2,
+    });
   });
 });

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -1459,8 +1459,13 @@ async function runClaude(input: {
       "--model",
       input.model,
       ...effortArgs,
+      // stream-json (requires --verbose) emits the full tool_use trajectory, so
+      // command discipline can be scored on actual tool calls rather than greps
+      // of the final result envelope. The final {"type":"result"} line carries
+      // the same cost/usage/session fields as --output-format json.
       "--output-format",
-      "json",
+      "stream-json",
+      "--verbose",
       "--permission-mode",
       "bypassPermissions",
       "--no-session-persistence",
@@ -1540,6 +1545,17 @@ function tail(value: string, max = 4_000) {
 }
 
 export function parseClaudeResult(stdout: string): any | null {
+  // stream-json: the final {"type":"result",...} line carries cost/usage/session.
+  const lines = stdout.trim().split("\n");
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const candidate = lines[i]?.trim() ?? "";
+    if (candidate.startsWith("{") && candidate.includes('"type":"result"')) {
+      try {
+        return JSON.parse(candidate);
+      } catch {}
+    }
+  }
+  // Fallback for --output-format json (single object) or noisy output.
   try {
     return JSON.parse(stdout);
   } catch {
@@ -2281,66 +2297,95 @@ async function walk(dir: string, visit: (filePath: string) => Promise<void>) {
   }
 }
 
-async function scoreToolCompliance(
+/** Extract the agent's tool calls from a stream-json transcript (assistant
+ * `tool_use` blocks). Returns [] for non-stream output, so callers degrade to
+ * the bts.jsonc safety net rather than crashing. */
+export function extractToolUses(stdout: string): { name: string; command?: string }[] {
+  const uses: { name: string; command?: string }[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    let event: any;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const content = event?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type === "tool_use" && typeof block.name === "string") {
+        const command = typeof block.input?.command === "string" ? block.input.command : undefined;
+        uses.push({ name: block.name, command });
+      }
+    }
+  }
+  return uses;
+}
+
+export async function scoreToolCompliance(
   pathMode: CreationPath,
   projectDir: string | null,
   claude: CommandResult,
 ): Promise<ToolCompliance> {
-  const transcript = `${claude.stdout}\n${claude.stderr}`.toLowerCase();
-  const checks: CommandDisciplineCheck[] = [];
+  const toolUses = extractToolUses(claude.stdout);
   const hasBtsConfig = projectDir ? existsSync(path.join(projectDir, "bts.jsonc")) : false;
 
+  // Grounded in the actual tool trajectory, not a grep of the result envelope.
+  const usedBfsCreate = toolUses.some((use) => /bfs_create_project/i.test(use.name));
+  const usedAnyBfsTool = toolUses.some((use) => /bfs_/i.test(use.name));
+  const bashCommands = toolUses
+    .filter((use) => /(^|_)bash$/i.test(use.name))
+    .map((use) => (use.command ?? "").toLowerCase());
+  const ranBfsCli = bashCommands.some((cmd) =>
+    /create\s+better-fullstack|create-better-fullstack/.test(cmd),
+  );
+  const ranDryRun = bashCommands.some((cmd) => cmd.includes("--dry-run"));
+
+  const checks: CommandDisciplineCheck[] = [];
   if (pathMode === "prompt") {
     checks.push({
       id: "no-bf-config",
       status: hasBtsConfig ? "fail" : "pass",
-      detail: hasBtsConfig
-        ? "prompt-only produced bts.jsonc"
-        : "prompt-only did not produce bts.jsonc",
+      detail: "prompt-only must not produce bts.jsonc",
     });
     checks.push({
-      id: "no-bf-tool-reference",
-      status:
-        transcript.includes("bfs_create_project") ||
-        transcript.includes("bun create better-fullstack") ||
-        transcript.includes("create-better-fullstack")
-          ? "fail"
-          : "pass",
-      detail: "prompt-only transcript should not show Better-Fullstack tool usage",
+      id: "no-bf-tool",
+      status: usedAnyBfsTool || ranBfsCli ? "fail" : "pass",
+      detail: "prompt-only must not call a Better-Fullstack MCP tool or CLI",
     });
   } else if (pathMode === "cli") {
     checks.push({
       id: "used-cli",
-      status:
-        transcript.includes("bun create better-fullstack") || hasBtsConfig ? "pass" : "unknown",
-      detail: "CLI path should use bun create better-fullstack@latest",
+      status: ranBfsCli || hasBtsConfig ? "pass" : "fail",
+      detail: "CLI path must run bun create better-fullstack",
     });
     checks.push({
       id: "dry-run-first",
-      status: transcript.includes("--dry-run") ? "pass" : "unknown",
-      detail: "CLI path should dry-run before writing",
+      status: ranDryRun ? "pass" : "fail",
+      detail: "CLI path must dry-run before writing",
     });
     checks.push({
       id: "no-mcp",
-      status: transcript.includes("bfs_create_project") ? "fail" : "pass",
-      detail: "CLI path should not use MCP tools",
+      status: usedBfsCreate ? "fail" : "pass",
+      detail: "CLI path must not use MCP creation",
     });
   } else {
     checks.push({
       id: "used-mcp",
-      status: transcript.includes("bfs_create_project") || hasBtsConfig ? "pass" : "unknown",
-      detail: "MCP path should use Better-Fullstack MCP creation",
+      status: usedBfsCreate || hasBtsConfig ? "pass" : "fail",
+      detail: "MCP path must call bfs_create_project",
     });
     checks.push({
       id: "no-cli-create",
-      status: transcript.includes("bun create better-fullstack") ? "fail" : "pass",
-      detail: "MCP path should not use CLI creation",
+      status: ranBfsCli ? "fail" : "pass",
+      detail: "MCP path must not run bun create better-fullstack",
     });
   }
 
-  const scored = checks.filter((check) => check.status !== "unknown" && check.status !== "skipped");
-  const score = scored.filter((check) => check.status === "pass").length;
-  return { score, total: scored.length || checks.length, checks };
+  // Every check is now definitive (pass/fail) — none are dropped from the score.
+  const score = checks.filter((check) => check.status === "pass").length;
+  return { score, total: checks.length, checks };
 }
 
 export function validationPassed(result: RunResult) {


### PR DESCRIPTION
## Summary

The command-discipline metric was near-vacuous — it grepped the final result envelope and dropped `unknown` checks from the denominator. Now it scores on the **actual tool trajectory**.

- `runClaude` uses `--output-format stream-json --verbose` to surface the `tool_use` stream.
- `extractToolUses()` parses assistant `tool_use` blocks; `scoreToolCompliance()` scores on real calls (a Bash `bun create better-fullstack`, a `bfs_create_project` MCP tool, `--dry-run`). Every check is now **definitive pass/fail** — none dropped, and `hasBtsConfig` is only a safety-net, not the primary signal.
- `parseClaudeResult()` finds the final `{"type":"result"}` line (same cost/usage/session fields) and **falls back** to the old single-object format, so it degrades gracefully.

## Validation
- `bun test scripts/scaffbench-v2-lib.test.ts` — **37 pass** (+4: parse result + tool_use from a stream; CLI dry-run+create → 3/3; prompt shelling to the CLI fails `no-bf-tool`; MCP `bfs_create_project` → 2/2). Type-check unchanged.

## ⚠️ Real-run spot-check
This changes the **live Claude invocation format**. The parser is robust (finds `type:result`, falls back), but CI can't run Claude — please confirm cost/tokens/session are extracted correctly from `stream-json` on the first real benchmark run before publishing numbers.

## Benchmark precedent
DeepSWE / SWE-agent / Terminal-Bench score tool use from the action log, not the final message.