### PR TITLE
ScaffBench 2.1: fix scoped-prefix acceptance matching (Codex #261)

### DIFF
--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -854,3 +854,20 @@ describe("ScaffBench 2.1 command discipline from trajectory (P2)", () => {
     });
   });
 });
+
+describe("ScaffBench 2.1 acceptance scoped-prefix (Codex #261)", () => {
+  it("matches a scoped-prefix pattern like @auth/ against @auth/core", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sb21-authjs-"));
+    try {
+      await writeFile(
+        join(dir, "package.json"),
+        JSON.stringify({ dependencies: { "@auth/core": "*", "@auth/drizzle-adapter": "*" } }),
+      );
+      const { acceptance } = await scoreProject(aiSpec, dir, "natural");
+      // Auth.js via @auth/core must satisfy the auth capability (not be a miss).
+      expect(acceptance?.misses).not.toContain("auth");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -2045,7 +2045,10 @@ function acceptancePatternMatch(
   if (pattern.startsWith(".")) {
     return files.some((file) => file === pattern || file.includes(`${pattern}/`));
   }
-  return deps.some((dep) => dep === pattern || dep.startsWith(`${pattern}/`));
+  // A pattern already ending in "/" is an explicit scope prefix (e.g. "@auth/"
+  // → "@auth/core"); don't append a second slash.
+  const prefix = pattern.endsWith("/") ? pattern : `${pattern}/`;
+  return deps.some((dep) => dep === pattern || dep.startsWith(prefix));
 }
 
 export function scoreBts(spec: BenchmarkSpec, raw: string): StackScore {


### PR DESCRIPTION
Addresses the Codex P2 on #261: `acceptancePatternMatch` appended a slash to every pattern, so `@auth/` tested for `@auth//` and missed valid Auth.js packages (`@auth/core`, `@auth/drizzle-adapter`). A pattern already ending in `/` is now used as-is as the scope prefix. +1 test (38 pass).