### PR TITLE
chore(release): 2.1.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Scaffold production-ready fullstack apps in seconds. Pick your stack from 425 options — the CLI wires everything together.",
   "keywords": [
     "algolia",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -80,6 +80,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.1.1"
+    "create-better-fullstack": "^2.1.2"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -62,7 +62,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.1.1",
+    "@better-fullstack/types": "^2.1.2",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",


### PR DESCRIPTION
## Release v2.1.2

Patch release. Only user-facing change to the published packages is the MikroORM SQLite template fix; the rest of the merged work (ScaffBench 2 leaderboard/blog, Deno CI pin) is website + CI only.

### Bumps
- `create-better-fullstack` → 2.1.2
- `create-bfs` → 2.1.2
- `@better-fullstack/types` → 2.1.2
- `@better-fullstack/template-generator` → 2.1.2

### Notable fix
- fix(templates): MikroORM SQLite uses v7 `@mikro-orm/sqlite` driver (was v6 `@mikro-orm/better-sqlite` against v7 core)

Merging triggers the Release workflow → publishes all four packages to npm + GitHub Packages.