### PR TITLE
fix(scaffbench): honest read-only quality gate + audit fixes (Findings 1,3,4,5)

### DIFF
--- a/apps/web/content/blog/scaffbench-2.mdx
+++ b/apps/web/content/blog/scaffbench-2.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ScaffBench 2: six models, five ecosystems, and whether the project actually builds"
+title: "ScaffBench 2: ten configs, five ecosystems, and whether the project actually builds"
 description: "ScaffBench 2 runs Opus, GPT-5.5, and free models through five hard fullstack specs and three creation paths, scoring whether the project actually builds."
 date: 2026-06-26
 authors:
@@ -30,8 +30,8 @@ told to use, how much it cost, and we fold all of it into a single composite **S
 the way the serious leaderboards (Artificial Analysis, SWE-bench, Aider) do it.
 
 We start with a deep look at one model — **Claude Opus 4.8** — then run the same matrix across
-**four Opus versions and GPT-5.5** (two reasoning efforts), driving the non-Claude model through a
-[Codex agent adapter](#six-models-tooling-is-the-great-equalizer). Here's what it found.
+**four Opus versions and GPT-5.5** (across several reasoning efforts) plus **two free models**, driving the non-Claude models through new
+[Codex and opencode/Kilo agent adapters](#six-models-tooling-is-the-great-equalizer). Here's what it found.
 
 ## What changed since ScaffBench 1
 
@@ -112,6 +112,17 @@ actually buys you:
   build, and type-check (plus native checks like `cargo check` / `go build`)? *Full* adds the
   quality gate: lint, format, and test. We report both, because they answer different questions:
   Core is "did the agent scaffold a working project," Full is "is that project also clean."
+</Callout>
+
+<Callout kind="warn">
+  **Full pass is being re-measured — the live leaderboard shows Core.** A self-audit found the
+  quality gate under-enforced for the TypeScript spec: a missing `lint`/`test` script counted as a
+  pass, and the format step ran `biome check --write` (which auto-fixes and always exits 0) instead
+  of a read-only check. So the *Full* numbers below overstate quality for the TS cells — for those
+  cells Full effectively equaled Core. We've corrected the harness to run read-only checks and to
+  treat a missing check as a non-pass, and we're re-measuring; the homepage leaderboard now shows
+  only the *Core* metric until those numbers are refreshed. The Core results — the headline — are
+  unaffected. (More in [the methodology note on our own errors](#how-scaffbench-2-borrows-from-the-best-leaderboards).)
 </Callout>
 
 Beyond pass/fail, every run is graded on three diagnostic axes:
@@ -268,7 +279,7 @@ Four things fall out of this:
 <Callout kind="info">
   **A note on GPT cost.** Codex reports token usage but not a dollar figure, so GPT-5.5 cost is
   *estimated* from usage × published OpenAI pricing ($5 / $0.50-cached / $30 per 1M
-  input/cached/output tokens). The two GPT runs came to ~$9.65 (low) and ~$12.08 (medium).
+  input/cached/output tokens). The low and medium GPT runs came to ~$9.65 and ~$12.08, respectively.
 </Callout>
 
 ## Does thinking harder help?
@@ -359,10 +370,11 @@ it into v2:
 - **One run per cell.** Enough to read the structure, not enough for confidence intervals. The next
   run does **≥3 repeats** (5 for the flaky prompt lane) so the Wilson interval becomes reportable and
   pass^k consistency becomes meaningful.
-- **One run per cell, and GPT cost is estimated.** The six-model sweep is still 1 run/cell, and the
+- **One run per cell, and GPT cost is estimated.** The full ten-config sweep is still 1 run/cell, and the
   GPT-5.5 dollar figures are derived from token usage rather than metered (Codex reports no cost).
-  Reasoning-effort sweeps (`Opus 4.8 high/xhigh`) and the diminishing-returns curve of "thinking
-  harder" are the obvious next charts now that the harness drives two agents.
+  The diminishing-returns curve of "thinking harder" is now charted above; broader per-effort and
+  cross-agent coverage is the obvious next step now that the harness drives three agents (Claude Code,
+  Codex, and opencode/Kilo).
 - **`multi-dotnet-ops` needs a clean re-run** with a fresh MCP server per cell and a local .NET
   toolchain.
 - **Fix the template lint gaps** so Full pass reflects scaffolding quality, not a linter our own

--- a/apps/web/perf-baseline.json
+++ b/apps/web/perf-baseline.json
@@ -1,11 +1,11 @@
 {
-  "updatedAt": "2026-06-17T11:49:46.000Z",
+  "updatedAt": "2026-06-29T12:09:57.235Z",
   "metrics": {
-    "mainJsGzip": 259,
-    "mainCssGzip": 29292,
-    "stackBuilderJsGzip": 61709,
-    "largestJsGzip": 567475,
-    "totalJsGzip": 1813077
+    "mainJsGzip": 260,
+    "mainCssGzip": 30342,
+    "stackBuilderJsGzip": 52259,
+    "largestJsGzip": 612714,
+    "totalJsGzip": 1801672
   },
   "budgets": {
     "mainJsGzip": 4096,

--- a/scripts/build-scaffbench-data.ts
+++ b/scripts/build-scaffbench-data.ts
@@ -52,27 +52,36 @@ function prettyModel(model: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+// A step is green when it actually ran and exited 0. A "skip" (a gate check that
+// should have run but no tool was configured) is NOT green — it carries exitCode
+// null and disqualifies the run. (Matches validationPassed in the harness lib.)
+function stepGreen(s: any): boolean {
+  return s.status !== "skip" && s.exitCode === 0 && !s.timedOut && !s.spawnError;
+}
+
 function corePass(result: any): boolean {
   const v = result?.validation;
   if (!v || !v.projectExists) return false;
-  const core = Object.entries(v.steps || {}).filter(([k]) => !GATE.test(k));
+  // "na" steps are excluded (not applicable); core steps are the non-gate ones.
+  const core = Object.entries(v.steps || {})
+    .filter(([k]) => !GATE.test(k))
+    .filter(([, s]: any) => s.status !== "na");
   if (!core.length) return false;
-  return core.every(([, s]: any) => s.exitCode === 0 && !s.timedOut && !s.spawnError);
+  return core.every(([, s]: any) => stepGreen(s));
 }
 
-// Full pass = every validation step (core + quality gate) passed. We compute it
-// here instead of trusting the harness `passRate === 100` because passRate is
-// VACUOUSLY 100 when zero steps ran — e.g. a model emits a project with no
-// recognizable build entrypoint, the harness validates nothing, and 0/0 reads as
-// "100%". Those are model failures, not passes (they're exactly how a weak free
-// model would otherwise leapfrog Opus). Require projectExists + at least one real
-// step, mirroring corePass; this also guarantees fullPass ⊆ corePass.
+// Full pass = Core pass AND every applicable quality-gate step actually ran and
+// passed. We compute it here (not via the harness `passRate === 100`) so the
+// status semantics are honored: passRate was VACUOUSLY 100 when zero steps ran,
+// and skipped lint/test / a `biome check --write` format step exited 0 and passed
+// silently (the Finding-1 inflation). "na" steps (genuinely testless scaffolds)
+// are excluded; a "skip" disqualifies. This also keeps fullPass ⊆ corePass.
 function fullPass(result: any): boolean {
-  const v = result?.validation;
-  if (!v || !v.projectExists) return false;
-  const steps = Object.entries(v.steps || {});
-  if (!steps.length) return false;
-  return steps.every(([, s]: any) => s.exitCode === 0 && !s.timedOut && !s.spawnError);
+  if (!corePass(result)) return false;
+  const v = result.validation;
+  const applicable = Object.entries(v.steps || {}).filter(([, s]: any) => s.status !== "na");
+  if (!applicable.length) return false;
+  return applicable.every(([, s]: any) => stepGreen(s));
 }
 
 type Cell = {

--- a/scripts/scaffbench-v2-lib.test.ts
+++ b/scripts/scaffbench-v2-lib.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   aggregateResults,
+  agentLabelForModel,
   canonicalCommand,
   classifyOutcome,
   deriveFailureTags,
@@ -25,6 +26,7 @@ import {
   typecheckGate,
   validationPassed,
   type RunResult,
+  type StepResult,
 } from "./scaffbench-v2-lib";
 
 const aiSpec = SCAFFBENCH_2_SPECS.find((spec) => spec.id === "ai-search-workbench")!;
@@ -293,6 +295,63 @@ describe("ScaffBench 2 scoring", () => {
     const empty = makeRun({ validation: { projectExists: true, steps: {} } });
     expect(validationPassed(empty)).toBe(false);
     expect(classifyOutcome(empty)).toBe("model-failure");
+  });
+
+  const okStep = (command: string): StepResult => ({
+    command,
+    exitCode: 0,
+    timedOut: false,
+    durationMs: 1,
+    stdoutTail: "",
+    stderrTail: "",
+  });
+
+  it("treats a 'skip' gate step as a failure, not a vacuous pass (Finding 1)", () => {
+    // Core is green but the linter could not run (no tool configured) -> 'skip'
+    // (exitCode null). Pre-fix this carried exitCode 0 and passed silently.
+    const run = makeRun({
+      validation: {
+        projectExists: true,
+        steps: {
+          install: okStep("bun install"),
+          build: okStep("bun run build"),
+          lint: {
+            command: "lint (no linter configured)",
+            exitCode: null,
+            timedOut: false,
+            status: "skip",
+            durationMs: 0,
+            stdoutTail: "skipped (tool not configured)",
+            stderrTail: "",
+          },
+        },
+      },
+    });
+    expect(validationPassed(run)).toBe(false);
+  });
+
+  it("excludes an 'na' step (genuinely testless scaffold) from the pass decision", () => {
+    const run = makeRun({
+      validation: {
+        projectExists: true,
+        steps: {
+          install: okStep("bun install"),
+          build: okStep("bun run build"),
+          format: okStep("biome format --check ."),
+          test: {
+            command: "test (no test script)",
+            exitCode: null,
+            timedOut: false,
+            status: "na",
+            durationMs: 0,
+            stdoutTail: "n/a",
+            stderrTail: "",
+          },
+        },
+      },
+    });
+    // The 'na' test is excluded; every real step is green -> pass.
+    expect(validationPassed(run)).toBe(true);
   });
 
   it("aggregates repeats with pass counts and failure tag counts", () => {
@@ -949,6 +1008,13 @@ describe("opencode / Kilo Code agent adapter", () => {
     // Bare provider/model strings that aren't opencode/kilo fall through normally.
     expect(providerForModel("gpt-5.5")).toBe("codex");
     expect(providerForModel("claude-opus-4-8")).toBe("claude");
+  });
+
+  it("labels the driving agent from the model (no more hardcoded 'Claude Code')", () => {
+    expect(agentLabelForModel("claude-opus-4-8")).toBe("Claude Code");
+    expect(agentLabelForModel("gpt-5.5")).toBe("Codex");
+    expect(agentLabelForModel("opencode/north-mini-code-free")).toBe("opencode");
+    expect(agentLabelForModel("kilo/nvidia/nemotron-3-super-120b-a12b:free")).toBe("Kilo Code");
   });
 
   it("parses opencode JSONL session, summed tokens, and cost", () => {

--- a/scripts/scaffbench-v2-lib.ts
+++ b/scripts/scaffbench-v2-lib.ts
@@ -77,6 +77,17 @@ export type StepResult = {
    * environment problem, distinct from a child process that ran and exited
    * non-zero (e.g. a generated `bun run build` whose script is broken). */
   spawnError?: boolean;
+  /**
+   * How to read this step when scoring:
+   * - "ran" (or absent): a real command executed — judge it by exitCode.
+   * - "skip": a check that SHOULD have run but no tool was configured/detected.
+   *   It is NOT a pass — it disqualifies a Full pass. Carries exitCode null so it
+   *   can never be mistaken for a green (=== 0) run (the old `skippedStep` set
+   *   exitCode 0, which silently passed missing lint/test — the Finding-1 bug).
+   * - "na": the check is legitimately not applicable (e.g. a scaffold with
+   *   genuinely zero tests). Excluded from scoring — neither pass nor fail.
+   */
+  status?: "ran" | "skip" | "na";
   durationMs: number;
   stdoutTail: string;
   stderrTail: string;
@@ -1520,6 +1531,21 @@ export function providerForModel(model: string): AgentProvider {
   return "claude";
 }
 
+// Human label for the agent that drove a model — for summary.md headers. Derived
+// from the model so non-Claude runs aren't mislabeled "Claude Code".
+export function agentLabelForModel(model: string): string {
+  switch (providerForModel(model)) {
+    case "codex":
+      return "Codex";
+    case "opencode":
+      return "opencode";
+    case "kilo":
+      return "Kilo Code";
+    default:
+      return "Claude Code";
+  }
+}
+
 // Codex (GPT) adapter — the second agent that lets ScaffBench drive non-Claude
 // models, mirroring runClaude. Runs `codex exec --json` with an ISOLATED config
 // (only the Better-Fullstack MCP server when on the MCP path; --ignore-user-config
@@ -1958,26 +1984,40 @@ async function validateBunProject(projectDir: string, options: ScaffbenchOptions
       await runCommand(bun, ["run", gate], projectDir, VALIDATION_TIMEOUT_MS),
     );
   }
+  // Quality gate — every check is READ-ONLY (never mutates the scaffold) and runs
+  // the project-LOCAL, version-pinned tool (node_modules/.bin/*) after install, so
+  // the verdict is reproducible and a step can't launder a real problem into a
+  // pass by auto-fixing it. A missing tool is a `skipStep` (disqualifies Full),
+  // never a silent exit-0 pass — that exit-0 skip + the `biome check --write`
+  // fallback were the Finding-1 inflation that made Full == Core for TS cells.
   if (options.qualityGate || scripts.lint) {
+    const biomeBin = localBin(projectDir, "biome");
+    const eslintBin = localBin(projectDir, "eslint");
     steps.lint = scripts.lint
       ? toStep(await runCommand(bun, ["run", "lint"], projectDir, VALIDATION_TIMEOUT_MS))
-      : skippedStep("bun run lint");
+      : biomeBin
+        ? toStep(await runCommand(biomeBin, ["lint", "."], projectDir, VALIDATION_TIMEOUT_MS))
+        : eslintBin
+          ? toStep(await runCommand(eslintBin, ["."], projectDir, VALIDATION_TIMEOUT_MS))
+          : skipStep("lint (no linter configured)");
   }
   if (options.qualityGate) {
-    if (scripts.format) {
-      steps.format = toStep(
-        await runCommand(bun, ["run", "format"], projectDir, VALIDATION_TIMEOUT_MS),
-      );
-    } else if (scripts.check) {
-      steps.format = toStep(
-        await runCommand(bun, ["run", "check"], projectDir, VALIDATION_TIMEOUT_MS),
-      );
-    } else {
-      steps.format = skippedStep("format/check");
-    }
+    // Read-only format check — deliberately NOT the project's `format`/`check`
+    // scripts: generated BFS projects ship `check: biome check --write .`, which
+    // auto-fixes and always exits 0. `biome format --check` / `prettier --check`
+    // report formatting drift without writing.
+    const biomeBin = localBin(projectDir, "biome");
+    const prettierBin = localBin(projectDir, "prettier");
+    steps.format = biomeBin
+      ? toStep(await runCommand(biomeBin, ["format", "--check", "."], projectDir, VALIDATION_TIMEOUT_MS))
+      : prettierBin
+        ? toStep(await runCommand(prettierBin, ["--check", "."], projectDir, VALIDATION_TIMEOUT_MS))
+        : skipStep("format (no formatter configured)");
+    // A scaffold with no test script is genuinely testless -> n/a (excluded from
+    // Full), neither a free pass nor a failure.
     steps.test = scripts.test
       ? toStep(await runCommand(bun, ["run", "test"], projectDir, VALIDATION_TIMEOUT_MS))
-      : skippedStep("bun run test");
+      : naStep("test (no test script)");
   }
   if (options.doctorCheck) {
     const bunx = existsSync(`${process.env.HOME}/.bun/bin/bunx`)
@@ -1995,7 +2035,7 @@ async function validateBunProject(projectDir: string, options: ScaffbenchOptions
   if (options.routeCheck) {
     steps.route = scripts.dev
       ? await runProjectRouteCheck(projectDir, options.outDir)
-      : skippedStep("route-check (no dev script)");
+      : naStep("route-check (no dev script)");
   }
 
   return steps;
@@ -2003,7 +2043,7 @@ async function validateBunProject(projectDir: string, options: ScaffbenchOptions
 
 async function runProjectRouteCheck(projectDir: string, outDir: string): Promise<StepResult> {
   const config = await readRouteCheckConfig(projectDir);
-  if (!config) return skippedStep("route-check (missing Better-Fullstack route metadata)");
+  if (!config) return naStep("route-check (missing Better-Fullstack route metadata)");
 
   const start = Date.now();
   let handle: any = null;
@@ -2124,9 +2164,22 @@ async function validatePythonProject(projectDir: string, options: ScaffbenchOpti
     steps.lint = toStep(
       await runCommand("uv", ["run", "ruff", "check", "."], projectDir, VALIDATION_TIMEOUT_MS),
     );
-    steps.test = toStep(
+    // Read-only format check, for parity with the TS/Rust/Go gates (was missing).
+    steps.format = toStep(
+      await runCommand(
+        "uv",
+        ["run", "ruff", "format", "--check", "."],
+        projectDir,
+        VALIDATION_TIMEOUT_MS,
+      ),
+    );
+    // pytest exit 5 = "no tests collected": a genuinely testless scaffold -> n/a
+    // (excluded from Full), not a failure (the old bare pytest would fail it) and
+    // not a pass. Any other non-zero stays a real test failure.
+    const pytest = toStep(
       await runCommand("uv", ["run", "pytest"], projectDir, VALIDATION_TIMEOUT_MS),
     );
+    steps.test = pytest.exitCode === 5 ? naStep("pytest (no tests collected)") : pytest;
   }
   return steps;
 }
@@ -2145,6 +2198,23 @@ async function validateGoProject(projectDir: string, options: ScaffbenchOptions)
     steps.lint = toStep(
       await runCommand("go", ["vet", "./..."], projectDir, VALIDATION_TIMEOUT_MS),
     );
+    // Read-only format check, for parity with the other gates (was missing).
+    // `gofmt -l .` lists unformatted files but exits 0 regardless, so treat any
+    // listed file as a failure.
+    const gofmt = await runCommand("gofmt", ["-l", "."], projectDir, VALIDATION_TIMEOUT_MS);
+    const unformatted = gofmt.stdout.trim();
+    steps.format = toStep(
+      gofmt.exitCode === 0 && unformatted
+        ? {
+            ...gofmt,
+            exitCode: 1,
+            stderr: `gofmt: ${unformatted.split("\n").filter(Boolean).length} file(s) need formatting:\n${unformatted}`,
+          }
+        : gofmt,
+    );
+    // go test reports "no test files" and exits 0 for a testless scaffold, which
+    // is an acceptable trivially-green test step (cf. cargo test). (TS/Python map
+    // their testless idioms to n/a; the Full outcome is the same either way.)
     steps.test = toStep(
       await runCommand("go", ["test", "./..."], projectDir, VALIDATION_TIMEOUT_MS),
     );
@@ -2192,15 +2262,42 @@ function toStep(result: CommandResult): StepResult {
   return step;
 }
 
-function skippedStep(command: string): StepResult {
+// A quality-gate check that SHOULD have run but no tool was configured/detected.
+// NOT a pass — it disqualifies a Full pass. exitCode null (never 0) so the
+// steps.every(exitCode === 0) scoring can't read it as green (the Finding-1 bug).
+function skipStep(command: string): StepResult {
   return {
     command,
-    exitCode: 0,
+    exitCode: null,
     timedOut: false,
+    status: "skip",
     durationMs: 0,
-    stdoutTail: "skipped",
+    stdoutTail: "skipped (tool not configured)",
     stderrTail: "",
   };
+}
+
+// A check that is legitimately not applicable (e.g. a scaffold with genuinely no
+// tests, or a route-check with no dev server). Excluded from scoring — neither
+// pass nor fail. exitCode null so it can never read as a green run either.
+function naStep(command: string): StepResult {
+  return {
+    command,
+    exitCode: null,
+    timedOut: false,
+    status: "na",
+    durationMs: 0,
+    stdoutTail: "n/a",
+    stderrTail: "",
+  };
+}
+
+// Resolve a project-local CLI binary (node_modules/.bin/<name>) so the gate runs
+// the version the project pins, not a bunx-latest download (which drifts the
+// verdict run-to-run). Returns null if the tool is not installed in the project.
+function localBin(projectDir: string, name: string): string | null {
+  const p = path.join(projectDir, "node_modules", ".bin", name);
+  return existsSync(p) ? p : null;
 }
 
 async function readPackageScripts(packageJsonPath: string) {
@@ -2673,16 +2770,23 @@ export async function scoreToolCompliance(
 
 export function validationPassed(result: RunResult) {
   if (!result.validation.projectExists) return false;
-  const steps = Object.values(result.validation.steps).filter((step): step is StepResult =>
+  const all = Object.values(result.validation.steps).filter((step): step is StepResult =>
     Boolean(step),
   );
-  // A run with zero executed validation steps must NOT pass vacuously:
-  // `[].every(...)` is `true`. This happens when the agent leaves a directory but
-  // no recognizable manifest (package.json / Cargo.toml / pyproject.toml / go.mod),
-  // so no validator fires — an unbuildable project, not a success. Require at
-  // least one real step before a non-skip-validation run can pass.
-  if (steps.length === 0) return false;
-  return steps.every((step) => step.exitCode === 0 && !step.timedOut);
+  // "na" steps (e.g. a genuinely testless scaffold) are excluded — neither pass
+  // nor fail. Everything else must be a real green run.
+  const applicable = all.filter((step) => step.status !== "na");
+  // A run with zero applicable steps must NOT pass vacuously (`[].every(...)` is
+  // true): the agent left a directory but no recognizable manifest, so no
+  // validator fired — an unbuildable project, not a success.
+  if (applicable.length === 0) return false;
+  // A "skip" (a check that should have run but no tool was configured) is NOT a
+  // pass — it disqualifies the run. (Pre-fix, skips carried exitCode 0 and passed
+  // silently: the Finding-1 inflation.)
+  return applicable.every(
+    (step) =>
+      step.status !== "skip" && step.exitCode === 0 && !step.timedOut && !step.spawnError,
+  );
 }
 
 function isBudgetExhausted(terminalReason: string | undefined) {
@@ -3020,7 +3124,7 @@ export function renderMarkdown(summary: ScaffbenchSummary) {
   return `# ScaffBench 2 Run
 
 Harness: ${summary.harnessVersion}
-Agent: Claude Code (single agent; single model family per row)
+Agent: ${agentLabelForModel(summary.options.model)} (single agent; single model family per row)
 Specs: ${summary.specs.map((spec) => spec.id).join(", ")}
 Repeats: ${summary.options.repeats}
 Prompt style: ${summary.options.promptStyle}
@@ -3028,7 +3132,7 @@ Prompt style: ${summary.options.promptStyle}
 ## Path × effort summary
 
 This is an ablation across creation paths and reasoning effort for one agent
-(Claude Code), not a cross-vendor leaderboard. Pass rate is over *scored* runs:
+(${agentLabelForModel(summary.options.model)}), not a cross-vendor leaderboard. Pass rate is over *scored* runs:
 infra-inconclusive runs (missing toolchain, validation timeout, exhausted token
 budget, or a crash with no output) are excluded from the denominator. "Wired
 libs" is scored from the generated artifact (deps + imports + files);


### PR DESCRIPTION
Addresses the ScaffBench-2 self-audit. **No benchmark re-run** (deferred); this makes the harness honest and corrects the published surfaces.

## Finding 1 — Full-pass was inflated (the important one)
For TypeScript cells the quality gate verified nothing past Core:
- `format` ran `bun run check` = `biome check --write` (auto-fixes → always exits 0)
- a missing `lint`/`test` script became `skippedStep(exitCode: 0)` → a silent pass
- so `steps.every(exitCode === 0)` passed whenever Core did → **Full == Core**.

Fix: `StepResult.status` (`ran`/`skip`/`na`, skip/na carry `exitCode: null`); read-only gate on the **project-local pinned** tools (`biome lint` + `biome format --check`, never `--write`); missing tool = `skip` (disqualifies Full), testless = `na` (excluded). Parity: Python `ruff format --check` + pytest exit-5→na; Go `gofmt -l`. `validationPassed` + generator `corePass`/`fullPass` are status-aware; `fullPass ⊆ corePass`.

**Verified end-to-end:** a pristine 2.1.1 TS scaffold now Core-passes but **Full-fails** (format/lint exit 1, test n/a). The shipped TS template isn't `biome`-clean — so honest TS Full ≈ 0% for *all* models (template hygiene, not model skill). This is why the homepage already shows **Core only** and the blog adds a caveat.

⚠️ **Changes future runs only.** Published numbers won't move without a re-run (deferred). The re-run is spec'd + ~$0 (deterministic re-scaffold from each cell's `bts.jsonc`, no agent calls).

## Finding 3 — blog scope/prose
title "six models"→"ten configs", intro names the free models + both new adapters, GPT cost note de-counted, limitations updated; **+ a Full-pass caveat callout** (under-enforced gate, being re-measured, live leaderboard shows Core).

## Finding 4 — `renderMarkdown` no longer hardcodes "Claude Code" (derives the agent label from the model).

## Finding 5 — removed the two legacy old-schema v2 run dirs (gitignored, local-only).

## Not here (needs the deferred re-run)
Finding 2 (raw `summary.*` artifacts still hold pre-fix numbers) — gitignored, regenerated by the re-run.

Tests: +5 (skip/na semantics, agent label) → 50 pass. Harness + web typecheck/lint clean; gate verified on a real scaffold.