### PR TITLE
chore(release): 2.1.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Scaffold production-ready fullstack apps in seconds. Pick your stack from 425 options — the CLI wires everything together.",
   "keywords": [
     "algolia",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -80,6 +80,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.1.2"
+    "create-better-fullstack": "^2.1.3"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -62,7 +62,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.1.2",
+    "@better-fullstack/types": "^2.1.3",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",


### PR DESCRIPTION
## Release v2.1.3

Patch release: a batch of generated-template bug fixes shipped since 2.1.2.

### Template fixes
- **Payments**: dodo/paddle/lemon-squeezy env-schema gaps (TS2339), paddle async webhook unmarshal, lemon-squeezy SDK 4.x type alignment, stripe apiVersion no longer pinned (staleness-proof)
- **Java**: testcontainers 2.x `junit-jupiter`→`testcontainers-junit-jupiter` rename (spring-boot 4 BOM) for maven + gradle
- **Elixir**: prom_ex.ex leading-comma syntax error → trailing commas
- **TypeScript (ts-rest)**: context.ts catch-all branch for fets/unlisted backends (was a dangling import)
- **Go**: `os` imported-unused on the frameworkless+loggingless+sentry path
- **Solid**: tanstack-solid-router routeTree.gen via tsr.config.json + `tsr generate` in check-types
- Earlier batch: Rust cargo fmt/clippy hygiene, Python ruff dedupe, Go gofmt, biome 2.5 preset/lineWidth

Bumps create-better-fullstack, create-bfs, @better-fullstack/types, @better-fullstack/template-generator to 2.1.3.

*Manual release bump (equivalent to `bun run bump patch`).*