### PR TITLE
feat(auth): support Supabase Auth with TanStack Start fullstack

### DIFF
--- a/apps/cli/src/helpers/core/post-installation.ts
+++ b/apps/cli/src/helpers/core/post-installation.ts
@@ -590,10 +590,11 @@ function getAuthSetupInstructions(
   }
 
   if (auth === "supabase-auth") {
+    const supabasePublicPrefix = frontend.includes("tanstack-start") ? "VITE_" : "NEXT_PUBLIC_";
     return (
       `${pc.bold("Supabase Auth Setup:")}\n` +
       `${pc.cyan("•")} Create a project at ${pc.underline("https://supabase.com/dashboard")}\n` +
-      `${pc.cyan("•")} Set ${pc.white("NEXT_PUBLIC_SUPABASE_URL")}, ${pc.white("NEXT_PUBLIC_SUPABASE_ANON_KEY")},\n` +
+      `${pc.cyan("•")} Set ${pc.white(`${supabasePublicPrefix}SUPABASE_URL`)}, ${pc.white(`${supabasePublicPrefix}SUPABASE_ANON_KEY`)},\n` +
       `   and ${pc.white("SUPABASE_SERVICE_ROLE_KEY")} in ${pc.white(envPath)}`
     );
   }

--- a/apps/cli/src/utils/compatibility-rules.ts
+++ b/apps/cli/src/utils/compatibility-rules.ts
@@ -352,16 +352,26 @@ function validateSupabaseAuthCompatibility(
   if (auth !== "supabase-auth") return;
 
   const hasNextJs = frontends.includes("next");
+  const hasTanStackStart = frontends.includes("tanstack-start");
+  const hasNativeFrontend = frontends.some((f) =>
+    ["native-bare", "native-uniwind", "native-unistyles"].includes(f),
+  );
 
   if (backend !== "self") {
     exitWithError(
-      "In Better-Fullstack, Supabase Auth is currently supported only with the 'self' backend (fullstack Next.js). Please use '--backend self' or choose a different auth provider.",
+      "In Better-Fullstack, Supabase Auth is currently supported only with the 'self' backend (fullstack Next.js or TanStack Start). Please use '--backend self' or choose a different auth provider.",
     );
   }
 
-  if (!hasNextJs) {
+  if (hasNativeFrontend) {
     exitWithError(
-      "In Better-Fullstack, Supabase Auth currently requires the Next.js frontend. Please use '--frontend next' or choose a different auth provider.",
+      "In Better-Fullstack, Supabase Auth with the 'self' backend is currently supported only for web-only Next.js or TanStack Start projects (no native companion app). Please remove the native frontend or choose a different auth provider.",
+    );
+  }
+
+  if (!hasNextJs && !hasTanStackStart) {
+    exitWithError(
+      "In Better-Fullstack, Supabase Auth currently requires the Next.js or TanStack Start frontend. Please use '--frontend next' or '--frontend tanstack-start', or choose a different auth provider.",
     );
   }
 }

--- a/apps/cli/test/auth.test.ts
+++ b/apps/cli/test/auth.test.ts
@@ -819,9 +819,9 @@ describe("Authentication Configurations", () => {
       expect(result.result?.projectConfig.auth).toBe("none");
     });
 
-    it("should normalize supabase-auth + non-next frontend to no auth", async () => {
+    it("should work with supabase-auth + self backend + tanstack-start", async () => {
       const result = await runTRPCTest({
-        projectName: "supabase-auth-non-next-fail",
+        projectName: "supabase-auth-self-tanstack-start",
         auth: "supabase-auth",
         backend: "self",
         runtime: "none",
@@ -834,10 +834,11 @@ describe("Authentication Configurations", () => {
         dbSetup: "none",
         webDeploy: "none",
         serverDeploy: "none",
+        install: false,
       });
 
       expectSuccess(result);
-      expect(result.result?.projectConfig.auth).toBe("none");
+      expect(result.result?.projectConfig.auth).toBe("supabase-auth");
     });
 
     it("should normalize supabase-auth + tanstack-router frontend to no auth", async () => {

--- a/packages/template-generator/src/processors/auth-deps.ts
+++ b/packages/template-generator/src/processors/auth-deps.ts
@@ -241,9 +241,10 @@ function processStandardAuthDeps(vfs: VirtualFileSystem, config: ProjectConfig):
     }
   } else if (auth === "supabase-auth") {
     const hasNextJs = frontend.includes("next");
+    const hasTanStackStart = frontend.includes("tanstack-start");
 
-    // Supabase Auth only works with Next.js (self backend)
-    if (hasNextJs && webExists) {
+    // Supabase Auth works with Next.js or TanStack Start (self backend)
+    if ((hasNextJs || hasTanStackStart) && webExists) {
       addPackageDependency({
         vfs,
         packagePath: webPath,

--- a/packages/template-generator/src/processors/env-vars.ts
+++ b/packages/template-generator/src/processors/env-vars.ts
@@ -796,6 +796,10 @@ function buildServerVars(
     }
   }
 
+  // Supabase Auth exposes the project URL + anon key to the browser, so the
+  // public prefix depends on the frontend bundler (Next.js vs Vite/TanStack Start).
+  const supabasePublicPrefix = frontend.includes("tanstack-start") ? "VITE_" : "NEXT_PUBLIC_";
+
   return [
     {
       key: "BETTER_AUTH_SECRET",
@@ -862,13 +866,13 @@ function buildServerVars(
       comment: "Stack Auth Secret Server Key - get it at https://app.stack-auth.com",
     },
     {
-      key: "NEXT_PUBLIC_SUPABASE_URL",
+      key: `${supabasePublicPrefix}SUPABASE_URL`,
       value: "",
       condition: auth === "supabase-auth",
       comment: "Supabase Project URL - get it at https://supabase.com/dashboard",
     },
     {
-      key: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      key: `${supabasePublicPrefix}SUPABASE_ANON_KEY`,
       value: "",
       condition: auth === "supabase-auth",
       comment: "Supabase Anon/Public Key - get it at https://supabase.com/dashboard",

--- a/packages/template-generator/src/template-handlers/auth.ts
+++ b/packages/template-generator/src/template-handlers/auth.ts
@@ -196,27 +196,27 @@ export async function processAuthTemplates(
     return;
   }
 
-  // Supabase Auth is specifically for Next.js fullstack (self backend)
+  // Supabase Auth is for Next.js or TanStack Start fullstack (self backend)
   if (
     authProvider === "supabase-auth" &&
     config.backend === "self" &&
-    config.frontend.includes("next")
+    (config.frontend.includes("next") || config.frontend.includes("tanstack-start"))
   ) {
-    const nextFramework = "next";
-    // Process fullstack templates (server client and middleware)
+    const supabaseFramework = config.frontend.includes("next") ? "next" : "tanstack-start";
+    // Process fullstack templates (supabase server/client and middleware)
     processTemplatesFromPrefix(
       vfs,
       templates,
-      `auth/supabase-auth/fullstack/${nextFramework}`,
+      `auth/supabase-auth/fullstack/${supabaseFramework}`,
       "apps/web",
       config,
     );
 
-    // Process web templates (components and client utilities)
+    // Process web templates (components, routes, and client utilities)
     processTemplatesFromPrefix(
       vfs,
       templates,
-      `auth/supabase-auth/web/react/${nextFramework}`,
+      `auth/supabase-auth/web/react/${supabaseFramework}`,
       "apps/web",
       config,
     );

--- a/packages/template-generator/templates/auth/supabase-auth/fullstack/tanstack-start/src/lib/supabase/client.ts.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/fullstack/tanstack-start/src/lib/supabase/client.ts.hbs
@@ -1,0 +1,6 @@
+import { createBrowserClient } from "@supabase/ssr";
+import { env } from "@{{projectName}}/env/web";
+
+export function createClient() {
+  return createBrowserClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_ANON_KEY);
+}

--- a/packages/template-generator/templates/auth/supabase-auth/fullstack/tanstack-start/src/lib/supabase/server.ts.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/fullstack/tanstack-start/src/lib/supabase/server.ts.hbs
@@ -1,6 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { env } from "@{{projectName}}/env/web";
-import { getCookies, setCookie } from "@tanstack/react-start/server";
+import { getCookies, setCookie, setResponseHeader } from "@tanstack/react-start/server";
 
 export function createClient() {
   return createServerClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_ANON_KEY, {
@@ -11,12 +11,15 @@ export function createClient() {
           value,
         }));
       },
-      setAll(cookiesToSet) {
+      setAll(cookiesToSet, headers) {
         // Supabase refreshes the session by writing new auth cookies. In a
-        // TanStack Start server context these are attached to the response
-        // headers of the current request via `setCookie`.
-        cookiesToSet.forEach(({ name, value }) => {
-          setCookie(name, value);
+        // TanStack Start server context these are attached to the current
+        // response together with Supabase's cache-control headers.
+        cookiesToSet.forEach(({ name, value, options }) => {
+          setCookie(name, value, options);
+        });
+        Object.entries(headers).forEach(([name, value]) => {
+          setResponseHeader(name, value);
         });
       },
     },

--- a/packages/template-generator/templates/auth/supabase-auth/fullstack/tanstack-start/src/lib/supabase/server.ts.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/fullstack/tanstack-start/src/lib/supabase/server.ts.hbs
@@ -1,0 +1,24 @@
+import { createServerClient } from "@supabase/ssr";
+import { env } from "@{{projectName}}/env/web";
+import { getCookies, setCookie } from "@tanstack/react-start/server";
+
+export function createClient() {
+  return createServerClient(env.VITE_SUPABASE_URL, env.VITE_SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return Object.entries(getCookies()).map(([name, value]) => ({
+          name,
+          value,
+        }));
+      },
+      setAll(cookiesToSet) {
+        // Supabase refreshes the session by writing new auth cookies. In a
+        // TanStack Start server context these are attached to the response
+        // headers of the current request via `setCookie`.
+        cookiesToSet.forEach(({ name, value }) => {
+          setCookie(name, value);
+        });
+      },
+    },
+  });
+}

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/components/sign-in-form.tsx.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/components/sign-in-form.tsx.hbs
@@ -1,0 +1,125 @@
+import { useAuthClient } from "@/lib/auth-client";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+export default function SignInForm({
+  onSwitchToSignUp,
+}: {
+  onSwitchToSignUp: () => void;
+}) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const { signInWithEmail, signInWithOAuth } = useAuthClient();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    const { error } = await signInWithEmail(email, password);
+
+    if (error) {
+      setError(error.message);
+      setIsLoading(false);
+    } else {
+      navigate({ to: "/dashboard" });
+    }
+  };
+
+  const handleOAuthSignIn = async (provider: "google" | "github") => {
+    setIsLoading(true);
+    setError(null);
+    const { error } = await signInWithOAuth(provider);
+    if (error) {
+      setError(error.message);
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto mt-10 w-full max-w-md p-6">
+      <h2 className="mb-6 text-center text-2xl font-bold">Sign In</h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
+          />
+        </div>
+
+        {error && <div className="text-sm text-red-600">{error}</div>}
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+        >
+          {isLoading ? "Signing in..." : "Sign In"}
+        </button>
+      </form>
+
+      <div className="mt-4">
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-gray-300" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="bg-white px-2 text-gray-500">Or continue with</span>
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={() => handleOAuthSignIn("github")}
+            disabled={isLoading}
+            className="w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-50"
+          >
+            GitHub
+          </button>
+          <button
+            type="button"
+            onClick={() => handleOAuthSignIn("google")}
+            disabled={isLoading}
+            className="w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-50"
+          >
+            Google
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onSwitchToSignUp}
+        className="mt-4 w-full text-sm text-indigo-600 hover:text-indigo-800"
+      >
+        Need an account? Sign Up
+      </button>
+    </div>
+  );
+}

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/components/sign-up-form.tsx.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/components/sign-up-form.tsx.hbs
@@ -1,0 +1,170 @@
+import { useAuthClient } from "@/lib/auth-client";
+import { useState } from "react";
+
+export default function SignUpForm({
+  onSwitchToSignIn,
+}: {
+  onSwitchToSignIn: () => void;
+}) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const { signUpWithEmail, signInWithOAuth } = useAuthClient();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      setIsLoading(false);
+      return;
+    }
+
+    const { error } = await signUpWithEmail(email, password);
+
+    if (error) {
+      setError(error.message);
+      setIsLoading(false);
+    } else {
+      setSuccess(true);
+      setIsLoading(false);
+    }
+  };
+
+  const handleOAuthSignIn = async (provider: "google" | "github") => {
+    setIsLoading(true);
+    setError(null);
+    const { error } = await signInWithOAuth(provider);
+    if (error) {
+      setError(error.message);
+      setIsLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="mx-auto mt-10 w-full max-w-md p-6 text-center">
+        <h2 className="mb-4 text-2xl font-bold">Check your email</h2>
+        <p className="mb-4 text-gray-600">
+          We&apos;ve sent you a confirmation link. Please check your email to complete
+          your registration.
+        </p>
+        <button
+          type="button"
+          onClick={onSwitchToSignIn}
+          className="text-indigo-600 hover:text-indigo-800"
+        >
+          Back to Sign In
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto mt-10 w-full max-w-md p-6">
+      <h2 className="mb-6 text-center text-2xl font-bold">Sign Up</h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={6}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="confirmPassword"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Confirm Password
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            minLength={6}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
+          />
+        </div>
+
+        {error && <div className="text-sm text-red-600">{error}</div>}
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="w-full rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+        >
+          {isLoading ? "Creating account..." : "Sign Up"}
+        </button>
+      </form>
+
+      <div className="mt-4">
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-gray-300" />
+          </div>
+          <div className="relative flex justify-center text-sm">
+            <span className="bg-white px-2 text-gray-500">Or continue with</span>
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={() => handleOAuthSignIn("github")}
+            disabled={isLoading}
+            className="w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-50"
+          >
+            GitHub
+          </button>
+          <button
+            type="button"
+            onClick={() => handleOAuthSignIn("google")}
+            disabled={isLoading}
+            className="w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-50"
+          >
+            Google
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onSwitchToSignIn}
+        className="mt-4 w-full text-sm text-indigo-600 hover:text-indigo-800"
+      >
+        Already have an account? Sign In
+      </button>
+    </div>
+  );
+}

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/components/user-menu.tsx.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/components/user-menu.tsx.hbs
@@ -1,0 +1,41 @@
+import { useAuthClient } from "@/lib/auth-client";
+import { useNavigate } from "@tanstack/react-router";
+
+export default function UserMenu() {
+  const { user, signOut, isLoading } = useAuthClient();
+  const navigate = useNavigate();
+
+  const handleSignOut = async () => {
+    await signOut();
+    navigate({ to: "/login" });
+  };
+
+  if (isLoading) {
+    return <div className="h-8 w-8 animate-pulse rounded-full bg-gray-200" />;
+  }
+
+  if (!user) {
+    return (
+      <button
+        type="button"
+        onClick={() => navigate({ to: "/login" })}
+        className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+      >
+        Sign In
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-4">
+      <span className="text-sm text-gray-700">{user.email}</span>
+      <button
+        type="button"
+        onClick={handleSignOut}
+        className="rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+      >
+        Sign Out
+      </button>
+    </div>
+  );
+}

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/functions/get-user.ts.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/functions/get-user.ts.hbs
@@ -1,0 +1,10 @@
+import { createClient } from "@/lib/supabase/server";
+import { createServerFn } from "@tanstack/react-start";
+
+export const getUser = createServerFn({ method: "GET" }).handler(async () => {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user;
+});

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/lib/auth-client.ts.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/lib/auth-client.ts.hbs
@@ -1,0 +1,60 @@
+import { createClient } from "@/lib/supabase/client";
+import type { User } from "@supabase/supabase-js";
+import { useEffect, useState } from "react";
+
+export function useUser() {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    // Get initial user
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setUser(user);
+      setIsLoading(false);
+    });
+
+    // Listen for auth changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return { user, isLoading };
+}
+
+export function useAuthClient() {
+  const { user, isLoading } = useUser();
+
+  return {
+    user,
+    isAuthenticated: !!user,
+    isLoading,
+    signOut: async () => {
+      const supabase = createClient();
+      await supabase.auth.signOut();
+    },
+    signInWithEmail: async (email: string, password: string) => {
+      const supabase = createClient();
+      return supabase.auth.signInWithPassword({ email, password });
+    },
+    signUpWithEmail: async (email: string, password: string) => {
+      const supabase = createClient();
+      return supabase.auth.signUp({ email, password });
+    },
+    signInWithOAuth: async (provider: "google" | "github") => {
+      const supabase = createClient();
+      return supabase.auth.signInWithOAuth({
+        provider,
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+    },
+  };
+}

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/routes/auth/callback.ts.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/routes/auth/callback.ts.hbs
@@ -1,0 +1,34 @@
+import { createClient } from "@/lib/supabase/server";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/auth/callback")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const { searchParams, origin } = new URL(request.url);
+        const code = searchParams.get("code");
+        // if "next" is in the query params, use it as the redirect URL
+        const next = searchParams.get("next") ?? "/dashboard";
+
+        if (code) {
+          const supabase = createClient();
+          const { error } = await supabase.auth.exchangeCodeForSession(code);
+          if (!error) {
+            // The auth cookies set by `exchangeCodeForSession` are merged onto
+            // this redirect response by the TanStack Start server runtime.
+            return new Response(null, {
+              status: 302,
+              headers: { Location: `${origin}${next}` },
+            });
+          }
+        }
+
+        // Return the user to the login page with an error flag.
+        return new Response(null, {
+          status: 302,
+          headers: { Location: `${origin}/login?error=auth-code-error` },
+        });
+      },
+    },
+  },
+});

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/routes/dashboard.tsx.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/routes/dashboard.tsx.hbs
@@ -1,0 +1,57 @@
+import { getUser } from "@/functions/get-user";
+import UserMenu from "@/components/user-menu";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/dashboard")({
+  component: RouteComponent,
+  beforeLoad: async () => {
+    const user = await getUser();
+    if (!user) {
+      throw redirect({ to: "/login" });
+    }
+    return { user };
+  },
+});
+
+function RouteComponent() {
+  const { user } = Route.useRouteContext();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+          <UserMenu />
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <div className="rounded-lg bg-white p-6 shadow">
+            <h2 className="mb-4 text-lg font-medium text-gray-900">
+              Welcome, {user.email}
+            </h2>
+            <p className="text-gray-600">
+              You are now signed in with Supabase Auth.
+            </p>
+            <div className="mt-4 rounded-md bg-gray-50 p-4">
+              <h3 className="mb-2 text-sm font-medium text-gray-700">User Info</h3>
+              <pre className="overflow-auto text-xs text-gray-600">
+                {JSON.stringify(
+                  {
+                    id: user.id,
+                    email: user.email,
+                    created_at: user.created_at,
+                    last_sign_in_at: user.last_sign_in_at,
+                  },
+                  null,
+                  2
+                )}
+              </pre>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/routes/login.tsx.hbs
+++ b/packages/template-generator/templates/auth/supabase-auth/web/react/tanstack-start/src/routes/login.tsx.hbs
@@ -1,0 +1,22 @@
+import SignInForm from "@/components/sign-in-form";
+import SignUpForm from "@/components/sign-up-form";
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+
+export const Route = createFileRoute("/login")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const [isSignUp, setIsSignUp] = useState(false);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      {isSignUp ? (
+        <SignUpForm onSwitchToSignIn={() => setIsSignUp(false)} />
+      ) : (
+        <SignInForm onSwitchToSignUp={() => setIsSignUp(true)} />
+      )}
+    </div>
+  );
+}

--- a/packages/template-generator/templates/frontend/react/web-base/src/components/header.tsx.hbs
+++ b/packages/template-generator/templates/frontend/react/web-base/src/components/header.tsx.hbs
@@ -12,6 +12,7 @@ import { ModeToggle } from "./mode-toggle";
 {{#if (or
   (and (not (includes frontend "vinext")) (ne auth "none") (ne auth "clerk") (ne backend "convex") (or (isBetterAuth auth) (includes frontend "next")))
   (and (eq auth "clerk") (eq backend "self") (or (includes frontend "next") (includes frontend "tanstack-start")))
+  (and (eq auth "supabase-auth") (eq backend "self") (includes frontend "tanstack-start"))
 )}}
 import UserMenu from "./user-menu";
 {{/if}}
@@ -70,6 +71,7 @@ export default function Header() {
           {{#if (or
             (and (not (includes frontend "vinext")) (ne auth "none") (ne auth "clerk") (ne backend "convex") (or (isBetterAuth auth) (includes frontend "next")))
             (and (eq auth "clerk") (eq backend "self") (or (includes frontend "next") (includes frontend "tanstack-start")))
+            (and (eq auth "supabase-auth") (eq backend "self") (includes frontend "tanstack-start"))
           )}}
           <UserMenu />
           {{/if}}

--- a/packages/template-generator/templates/packages/env/src/web.ts.hbs
+++ b/packages/template-generator/templates/packages/env/src/web.ts.hbs
@@ -5,7 +5,7 @@ import { createEnv } from "@t3-oss/env-nuxt";
 {{else}}
 import { createEnv } from "@t3-oss/env-core";
 {{/if}}
-{{#if (or (or (eq backend "convex") (and (eq backend "self") (or (eq auth "clerk") (eq auth "workos")))) (and (ne backend "self") (ne backend "none")))}}
+{{#if (or (or (eq backend "convex") (and (eq backend "self") (or (eq auth "clerk") (eq auth "workos") (and (eq auth "supabase-auth") (includes frontend "tanstack-start"))))) (and (ne backend "self") (ne backend "none")))}}
 import { z } from "zod";
 {{/if}}
 
@@ -88,6 +88,10 @@ export const env = createEnv({
 	client: {
 {{#if (and (eq auth "clerk") (includes frontend "tanstack-start"))}}
 		VITE_CLERK_PUBLISHABLE_KEY: z.string().min(1),
+{{/if}}
+{{#if (and (eq auth "supabase-auth") (includes frontend "tanstack-start"))}}
+		VITE_SUPABASE_URL: z.url(),
+		VITE_SUPABASE_ANON_KEY: z.string().min(1),
 {{/if}}
 	},
 	runtimeEnv: (import.meta as ImportMeta & { env: ImportMetaEnvRecord }).env,

--- a/packages/template-generator/test/processors/auth-deps.test.ts
+++ b/packages/template-generator/test/processors/auth-deps.test.ts
@@ -167,6 +167,24 @@ describe("processAuthDeps", () => {
     });
   }
 
+  it("adds Supabase Auth packages for TanStack Start", () => {
+    const vfs = createSeededVFS(["apps/web/package.json"]);
+
+    processAuthDeps(
+      vfs,
+      makeConfig({
+        auth: "supabase-auth",
+        backend: "self",
+        frontend: ["tanstack-start"],
+      }),
+    );
+
+    expectIncludesAll(getDeps(vfs, "apps/web/package.json").deps, [
+      "@supabase/supabase-js",
+      "@supabase/ssr",
+    ]);
+  });
+
   it("uses the Auth0 v4 SDK expected by the Next templates", () => {
     expect(dependencyVersionMap["@auth0/nextjs-auth0"]).toBe("^4.23.0");
   });

--- a/packages/types/src/capabilities.ts
+++ b/packages/types/src/capabilities.ts
@@ -283,6 +283,35 @@ function getAuthDisabledReason(context: CapabilityStackContext, optionId: Auth):
     return "In Better-Fullstack, Clerk is currently supported with Convex, Next.js fullstack, or TanStack Start fullstack";
   }
 
+  if (optionId === "supabase-auth") {
+    if (isSelfBackend(backend)) {
+      if ((hasNextJs || hasTanStackStart) && hasNativeFrontend) {
+        return "In Better-Fullstack, Supabase Auth with self backend is currently supported only for web-only Next.js or TanStack Start projects (no native companion app)";
+      }
+
+      if (hasNextJs || hasTanStackStart) {
+        return null;
+      }
+
+      if (backend === "self-astro" || webFrontend.includes("astro")) {
+        return "In Better-Fullstack, Supabase Auth is not yet supported for Astro fullstack projects";
+      }
+      if (backend === "self-nuxt" || webFrontend.includes("nuxt")) {
+        return "In Better-Fullstack, Supabase Auth is not yet supported for Nuxt fullstack projects";
+      }
+      if (backend === "self-svelte" || webFrontend.includes("svelte")) {
+        return "In Better-Fullstack, Supabase Auth is not yet supported for SvelteKit fullstack projects";
+      }
+      if (backend === "self-solid-start" || webFrontend.includes("solid-start")) {
+        return "In Better-Fullstack, Supabase Auth is not yet supported for SolidStart fullstack projects";
+      }
+
+      return "In Better-Fullstack, Supabase Auth is currently supported with Next.js fullstack or TanStack Start fullstack";
+    }
+
+    return "In Better-Fullstack, Supabase Auth is currently supported only with the 'self' backend (fullstack Next.js or TanStack Start)";
+  }
+
   const nextOnlyLabel = getNextOnlyAuthLabel(optionId);
   if (backend !== "self" && backend !== "self-next") {
     return `In Better-Fullstack, ${nextOnlyLabel} is currently supported only with the 'self' backend (fullstack Next.js)`;


### PR DESCRIPTION
Closes #271.

## What

Extends **Supabase Auth** (previously Next.js-only) to the `self` backend with a **TanStack Start** frontend. Follows the exact pattern the maintainer used to add Clerk `self` + TanStack Start support. Supabase-as-database already worked with any frontend; this closes the gap for Supabase **Auth**.

## Changes

**Gating / validation**
- `packages/types/src/capabilities.ts` — `getAuthDisabledReason` allows `supabase-auth` for `self`/`self-tanstack-start` + next|tanstack-start (no native companion app). Drives both the CLI normalizer and the web Stack Builder.
- `apps/cli/src/utils/compatibility-rules.ts` — `validateSupabaseAuthCompatibility` accepts tanstack-start.

**Generator**
- `template-handlers/auth.ts` — routes `supabase-auth` to next **or** tanstack-start template prefixes.
- `processors/auth-deps.ts` — adds `@supabase/ssr` + `@supabase/supabase-js` for tanstack-start.
- `processors/env-vars.ts` — frontend-aware prefix: `VITE_SUPABASE_*` (tanstack-start) vs `NEXT_PUBLIC_SUPABASE_*` (next).
- `templates/packages/env/src/web.ts.hbs` + `web-base/.../header.tsx.hbs` — env schema + `UserMenu` wiring.
- **10 new templates** under `auth/supabase-auth/{fullstack,web/react}/tanstack-start/`: browser + server Supabase clients (cookies via `getCookies`/`setCookie` from `@tanstack/react-start/server`), `getUser` server fn, login/dashboard routes, OAuth `auth/callback` server route, sign-in/up forms, user-menu.
- `apps/cli/.../post-installation.ts` — setup instructions show the correct env var names per frontend.

**Tests**
- New positive CLI test (`supabase-auth + self + tanstack-start`), converted the now-supported normalization test, added an auth-deps test for the new combo.

## Verification

- Source typechecks clean (`tsc --noEmit` = 0): types, template-generator, cli. oxlint clean on edited files.
- Suites green: auth `128`, types `97`, template-generator `128`, template-snapshots `95`, cli-builder-sync `603`, builder/command parity + reproducible-command.
- **Real scaffold** of `supabase-auth + self + tanstack-start` → `bun install` → `vite build` (client + SSR bundles compile all Supabase files) → **`tsc --noEmit` = 0**.
- **Regression**: Next.js supabase-auth still emits `NEXT_PUBLIC_*` and its next-specific middleware.

## Notes

- Native companion apps are intentionally not supported with `supabase-auth` + `self` (same restriction as Clerk).
- The generated template bundle (`templates.generated.ts`) and `dist/` are gitignored and rebuilt on CI from the `.hbs` sources.