### PR TITLE
Add builder project share modal

### DIFF
--- a/apps/web/src/components/changelog-widget.tsx
+++ b/apps/web/src/components/changelog-widget.tsx
@@ -2,6 +2,10 @@ import { History, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 import { ChangelogModal } from "@/components/changelog-modal";
+import {
+  hasSeenBuilderShareModal,
+  isBuilderRoute,
+} from "@/lib/builder-share-modal-visibility";
 import { latestChangelogRelease } from "@/lib/changelog";
 import {
   type ChangelogInteractionState,
@@ -32,6 +36,14 @@ export function ChangelogWidget() {
     if (!latestChangelogRelease) return;
 
     try {
+      if (
+        isBuilderRoute(window.location.pathname) &&
+        !hasSeenBuilderShareModal(window.localStorage)
+      ) {
+        setIsVisible(false);
+        return;
+      }
+
       setIsVisible(
         shouldShowChangelogRelease(window.localStorage, latestChangelogRelease.version),
       );

--- a/apps/web/src/components/stack-builder/builder-share-modal.tsx
+++ b/apps/web/src/components/stack-builder/builder-share-modal.tsx
@@ -1,13 +1,4 @@
-import {
-  Check,
-  Copy,
-  Github,
-  MessageCircle,
-  Radio,
-  Send,
-  Share2,
-  Twitter,
-} from "lucide-react";
+import { Check, Copy, Github, MessageCircle, Radio, Send, Share2, Twitter } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -153,25 +144,25 @@ export function BuilderShareModal() {
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="gap-0 overflow-hidden border-border/70 bg-fd-background p-0 shadow-2xl shadow-black/20 sm:max-w-xl">
-        <div className="border-border/70 border-b bg-muted/20 px-5 py-4 sm:px-6">
-          <DialogHeader className="pr-8">
-            <div className="mb-2 flex w-fit items-center gap-2 border border-primary/25 bg-primary/10 px-2 py-1 font-mono text-[10px] text-primary uppercase">
+      <DialogContent className="gap-0 p-0 sm:max-w-lg">
+        <div className="border-border/50 border-b px-6 pt-6 pb-5">
+          <DialogHeader className="gap-2.5 pr-8">
+            <span className="inline-flex w-fit items-center gap-1.5 rounded-full border border-border/60 bg-muted/40 px-2.5 py-1 font-mono text-[10px] text-muted-foreground uppercase tracking-wide">
               <Share2 className="size-3" aria-hidden="true" />
               Built with Better Fullstack?
-            </div>
-            <DialogTitle className="text-balance font-semibold text-2xl text-foreground leading-tight">
+            </span>
+            <DialogTitle className="text-balance font-semibold text-xl text-foreground leading-tight sm:text-2xl">
               Show us what you shipped
             </DialogTitle>
-            <DialogDescription className="max-w-[32rem] text-sm leading-relaxed">
+            <DialogDescription className="text-sm leading-relaxed">
               If Better Fullstack helped you start a project, send it over. A repo, demo,
               screenshot, launch post, or tiny work-in-progress is perfect.
             </DialogDescription>
           </DialogHeader>
         </div>
 
-        <div className="grid gap-4 px-5 py-5 sm:px-6">
-          <div className="grid gap-2 sm:grid-cols-2">
+        <div className="grid gap-5 px-6 py-5">
+          <div className="grid gap-2.5 sm:grid-cols-2">
             {contactTargets.map((target) => {
               const Icon = target.icon;
 
@@ -181,11 +172,11 @@ export function BuilderShareModal() {
                   href={target.href}
                   target="_blank"
                   rel="noreferrer"
-                  className="group flex min-h-16 items-center gap-3 border border-border/70 bg-background/70 px-3 py-3 text-left transition-colors hover:border-primary/35 hover:bg-muted/35"
+                  className="group flex items-center gap-3 rounded-xl border border-border/50 bg-muted/20 px-3.5 py-3 text-left transition-colors hover:border-border hover:bg-muted/50"
                 >
                   <span
                     className={cn(
-                      "flex size-9 shrink-0 items-center justify-center border border-border/70 bg-muted/35 transition-colors group-hover:border-primary/30",
+                      "flex size-9 shrink-0 items-center justify-center rounded-lg bg-background/80 shadow-sm ring-1 ring-border/50 transition-colors",
                       target.className,
                     )}
                   >
@@ -204,7 +195,7 @@ export function BuilderShareModal() {
             })}
           </div>
 
-          <div className="border border-border/70 bg-muted/20 p-3">
+          <div className="rounded-xl border border-border/50 bg-muted/30 p-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="font-medium text-sm text-foreground">
@@ -225,37 +216,40 @@ export function BuilderShareModal() {
               </Button>
             </div>
 
-            <div className="mt-3 grid gap-2 sm:grid-cols-3">
-              <a
-                href={xShareUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex h-8 items-center justify-center gap-2 border border-border bg-background px-3 font-medium text-xs transition-colors hover:bg-muted"
+            <div className="mt-4 grid gap-2 sm:grid-cols-3">
+              <Button
+                variant="outline"
+                size="sm"
+                render={
+                  <a href={xShareUrl} target="_blank" rel="noreferrer" aria-label="Post on X" />
+                }
               >
                 <Twitter className="size-3.5" aria-hidden="true" />
                 Post on X
-              </a>
-              <a
-                href={whatsAppShareUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex h-8 items-center justify-center gap-2 border border-border bg-background px-3 font-medium text-xs transition-colors hover:bg-muted"
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                render={
+                  <a
+                    href={whatsAppShareUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="Share on WhatsApp"
+                  />
+                }
               >
                 <MessageCircle className="size-3.5 text-emerald-500" aria-hidden="true" />
                 WhatsApp
-              </a>
-              <button
-                type="button"
-                onClick={copyMessage}
-                className="inline-flex h-8 items-center justify-center gap-2 border border-border bg-background px-3 font-medium text-xs transition-colors hover:bg-muted"
-              >
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={copyMessage}>
                 {copied ? (
                   <Check className="size-3.5 text-green-500" aria-hidden="true" />
                 ) : (
                   <Copy className="size-3.5" aria-hidden="true" />
                 )}
                 {copied ? "Copied" : "Copy text"}
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/stack-builder/builder-share-modal.tsx
+++ b/apps/web/src/components/stack-builder/builder-share-modal.tsx
@@ -1,0 +1,265 @@
+import {
+  Check,
+  Copy,
+  Github,
+  MessageCircle,
+  Radio,
+  Send,
+  Share2,
+  Twitter,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dotted-dialog";
+import {
+  hasSeenBuilderShareModal,
+  markBuilderShareModalSeen,
+} from "@/lib/builder-share-modal-visibility";
+import { SITE_URL } from "@/lib/seo";
+import { cn } from "@/lib/utils";
+
+const TELEGRAM_URL = "https://t.me/TheCr1nge";
+const X_PROFILE_URL = "https://x.com/IbrahimElkamali";
+const WHATSAPP_URL = "https://wa.me/380665662448";
+const SIGNAL_URL = "https://signal.me/#p/+380665662448";
+const GITHUB_DISCUSSIONS_URL = "https://github.com/Marve10s/Better-Fullstack/discussions";
+
+type ShareTarget = {
+  label: string;
+  description: string;
+  href: string;
+  icon: typeof MessageCircle;
+  className: string;
+};
+
+const contactTargets: ShareTarget[] = [
+  {
+    label: "Telegram",
+    description: "@TheCr1nge",
+    href: TELEGRAM_URL,
+    icon: Send,
+    className: "text-sky-500",
+  },
+  {
+    label: "X",
+    description: "@IbrahimElkamali",
+    href: X_PROFILE_URL,
+    icon: Twitter,
+    className: "text-foreground",
+  },
+  {
+    label: "Signal",
+    description: "+380 66 566 2448",
+    href: SIGNAL_URL,
+    icon: Radio,
+    className: "text-blue-500",
+  },
+  {
+    label: "WhatsApp",
+    description: "+380 66 566 2448",
+    href: WHATSAPP_URL,
+    icon: MessageCircle,
+    className: "text-emerald-500",
+  },
+  {
+    label: "GitHub Discussions",
+    description: "Show the community",
+    href: GITHUB_DISCUSSIONS_URL,
+    icon: Github,
+    className: "text-foreground",
+  },
+];
+
+function canUseBrowserStorage() {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function getShareMessage(url: string) {
+  return `I built a full-stack app setup with Better Fullstack. Try the visual builder and share what you make: ${url}`;
+}
+
+export function BuilderShareModal() {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [shareUrl, setShareUrl] = useState(SITE_URL);
+
+  useEffect(() => {
+    if (window.navigator.webdriver || !canUseBrowserStorage()) {
+      return;
+    }
+
+    try {
+      if (hasSeenBuilderShareModal(window.localStorage)) {
+        return;
+      }
+
+      setShareUrl(window.location.href || SITE_URL);
+      setOpen(true);
+    } catch {
+      setOpen(false);
+    }
+  }, []);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      try {
+        markBuilderShareModalSeen(window.localStorage);
+      } catch {}
+    }
+
+    setOpen(nextOpen);
+  }, []);
+
+  const shareMessage = useMemo(() => getShareMessage(shareUrl), [shareUrl]);
+  const encodedShareMessage = encodeURIComponent(shareMessage);
+  const xShareUrl = `https://twitter.com/intent/tweet?text=${encodedShareMessage}`;
+  const whatsAppShareUrl = `https://wa.me/?text=${encodedShareMessage}`;
+
+  const copyMessage = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(shareMessage);
+      setCopied(true);
+      toast.success("Share message copied");
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      toast.error("Could not copy share message");
+    }
+  }, [shareMessage]);
+
+  const shareWithFriends = useCallback(async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Better Fullstack",
+          text: "I built a full-stack app setup with Better Fullstack.",
+          url: shareUrl,
+        });
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+      }
+    }
+
+    await copyMessage();
+  }, [copyMessage, shareUrl]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="gap-0 overflow-hidden border-border/70 bg-fd-background p-0 shadow-2xl shadow-black/20 sm:max-w-xl">
+        <div className="border-border/70 border-b bg-muted/20 px-5 py-4 sm:px-6">
+          <DialogHeader className="pr-8">
+            <div className="mb-2 flex w-fit items-center gap-2 border border-primary/25 bg-primary/10 px-2 py-1 font-mono text-[10px] text-primary uppercase">
+              <Share2 className="size-3" aria-hidden="true" />
+              Built with Better Fullstack?
+            </div>
+            <DialogTitle className="text-balance font-semibold text-2xl text-foreground leading-tight">
+              Show us what you shipped
+            </DialogTitle>
+            <DialogDescription className="max-w-[32rem] text-sm leading-relaxed">
+              If Better Fullstack helped you start a project, send it over. A repo, demo,
+              screenshot, launch post, or tiny work-in-progress is perfect.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="grid gap-4 px-5 py-5 sm:px-6">
+          <div className="grid gap-2 sm:grid-cols-2">
+            {contactTargets.map((target) => {
+              const Icon = target.icon;
+
+              return (
+                <a
+                  key={target.label}
+                  href={target.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group flex min-h-16 items-center gap-3 border border-border/70 bg-background/70 px-3 py-3 text-left transition-colors hover:border-primary/35 hover:bg-muted/35"
+                >
+                  <span
+                    className={cn(
+                      "flex size-9 shrink-0 items-center justify-center border border-border/70 bg-muted/35 transition-colors group-hover:border-primary/30",
+                      target.className,
+                    )}
+                  >
+                    <Icon className="size-4" aria-hidden="true" />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block font-medium text-sm text-foreground">
+                      {target.label}
+                    </span>
+                    <span className="block truncate text-muted-foreground text-xs">
+                      {target.description}
+                    </span>
+                  </span>
+                </a>
+              );
+            })}
+          </div>
+
+          <div className="border border-border/70 bg-muted/20 p-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-medium text-sm text-foreground">
+                  Please share a project with friends!
+                </p>
+                <p className="mt-1 text-muted-foreground text-xs">
+                  One post helps more builders discover the project.
+                </p>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                className="w-full sm:w-auto"
+                onClick={shareWithFriends}
+              >
+                <Share2 className="size-3.5" aria-hidden="true" />
+                Share
+              </Button>
+            </div>
+
+            <div className="mt-3 grid gap-2 sm:grid-cols-3">
+              <a
+                href={xShareUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-8 items-center justify-center gap-2 border border-border bg-background px-3 font-medium text-xs transition-colors hover:bg-muted"
+              >
+                <Twitter className="size-3.5" aria-hidden="true" />
+                Post on X
+              </a>
+              <a
+                href={whatsAppShareUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-8 items-center justify-center gap-2 border border-border bg-background px-3 font-medium text-xs transition-colors hover:bg-muted"
+              >
+                <MessageCircle className="size-3.5 text-emerald-500" aria-hidden="true" />
+                WhatsApp
+              </a>
+              <button
+                type="button"
+                onClick={copyMessage}
+                className="inline-flex h-8 items-center justify-center gap-2 border border-border bg-background px-3 font-medium text-xs transition-colors hover:bg-muted"
+              >
+                {copied ? (
+                  <Check className="size-3.5 text-green-500" aria-hidden="true" />
+                ) : (
+                  <Copy className="size-3.5" aria-hidden="true" />
+                )}
+                {copied ? "Copied" : "Copy text"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/stack-builder/stack-builder-page.tsx
+++ b/apps/web/src/components/stack-builder/stack-builder-page.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from "react";
 
+import { BuilderShareModal } from "@/components/stack-builder/builder-share-modal";
 import type { StackState } from "@/lib/stack-defaults";
 import { m } from "@/paraglide/messages.js";
 
@@ -21,6 +22,7 @@ export function StackBuilderPage({ initialStack }: { initialStack?: StackState }
           <StackBuilder initialStack={initialStack} />
         </div>
       </Suspense>
+      <BuilderShareModal />
     </>
   );
 }

--- a/apps/web/src/components/ui/dotted-dialog.tsx
+++ b/apps/web/src/components/ui/dotted-dialog.tsx
@@ -10,9 +10,7 @@ function DottedDialog({ ...props }: DialogPrimitive.Root.Props) {
 }
 
 function DottedDialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
-  return (
-    <DialogPrimitive.Trigger data-slot="dotted-dialog-trigger" {...props} />
-  );
+  return <DialogPrimitive.Trigger data-slot="dotted-dialog-trigger" {...props} />;
 }
 
 function DottedDialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
@@ -23,17 +21,18 @@ function DottedDialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dotted-dialog-close" {...props} />;
 }
 
-function DottedDialogOverlay({
-  className,
-  ...props
-}: DialogPrimitive.Backdrop.Props) {
+function DottedDialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dotted-dialog-overlay"
       className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 isolate z-50 overflow-hidden bg-background/75 backdrop-blur-sm duration-200",
-        "before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_38%,transparent)_1px,transparent_1px)] before:bg-[length:18px_18px]",
-        "after:absolute after:inset-0 after:bg-[radial-gradient(circle_at_center,transparent_35%,var(--background)_92%)]",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 duration-200",
+        // Motion.dev-style dotted backdrop: a near-solid sheet the color of the
+        // page, punched with a fine grid of transparent pinholes. The pinholes
+        // reveal a brightened + blurred slice of what's behind, so the dots read
+        // as faint texture in both themes.
+        "bg-[radial-gradient(transparent_1px,var(--background)_1px)] [background-size:4px_4px]",
+        "[-webkit-backdrop-filter:brightness(1.15)_blur(3px)] [backdrop-filter:brightness(1.15)_blur(3px)]",
         className,
       )}
       {...props}
@@ -55,18 +54,17 @@ function DottedDialogContent({
       <DialogPrimitive.Popup
         data-slot="dotted-dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-hidden border border-border/70 bg-fd-background text-xs/relaxed shadow-2xl shadow-black/20 outline-none duration-200 sm:max-w-sm",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-hidden rounded-2xl border border-border/60 bg-popover p-6 text-sm text-popover-foreground shadow-2xl shadow-black/30 outline-none duration-200 sm:max-w-lg",
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-closed:slide-out-to-top-[2%] data-open:slide-in-from-top-[2%]",
-          "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_20%,transparent)_1px,transparent_1px)] before:bg-[length:16px_16px]",
           className,
         )}
         {...props}
       >
-        <div className="relative z-[1] grid min-h-0">{children}</div>
+        {children}
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dotted-dialog-close"
-            className="absolute top-4 right-4 z-[2] flex h-7 w-7 items-center justify-center border border-transparent text-muted-foreground/60 transition-all duration-150 hover:border-border hover:bg-background/70 hover:text-foreground focus:outline-none"
+            className="absolute top-4 right-4 z-10 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground/60 transition-all duration-150 hover:bg-muted/60 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           >
             <XIcon className="h-4 w-4" />
             <span className="sr-only">{m.uiClose()}</span>
@@ -77,14 +75,11 @@ function DottedDialogContent({
   );
 }
 
-function DottedDialogHeader({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function DottedDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dotted-dialog-header"
-      className={cn("flex flex-col gap-1.5 pr-8", className)}
+      className={cn("flex flex-col gap-1.5", className)}
       {...props}
     />
   );
@@ -106,7 +101,7 @@ function DottedDialogFooter({
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close className="inline-flex h-9 items-center justify-center border border-border/50 bg-muted/20 px-4 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-muted/40 hover:text-foreground">
+        <DialogPrimitive.Close className="inline-flex h-8 items-center justify-center rounded-lg border border-border/60 bg-muted/30 px-4 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-muted/50 hover:text-foreground">
           {m.uiClose()}
         </DialogPrimitive.Close>
       )}
@@ -114,28 +109,22 @@ function DottedDialogFooter({
   );
 }
 
-function DottedDialogTitle({
-  className,
-  ...props
-}: DialogPrimitive.Title.Props) {
+function DottedDialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dotted-dialog-title"
-      className={cn("text-sm font-medium tracking-tight", className)}
+      className={cn("text-base font-semibold tracking-tight", className)}
       {...props}
     />
   );
 }
 
-function DottedDialogDescription({
-  className,
-  ...props
-}: DialogPrimitive.Description.Props) {
+function DottedDialogDescription({ className, ...props }: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dotted-dialog-description"
       className={cn(
-        "text-muted-foreground *:[a]:hover:text-foreground text-xs/relaxed *:[a]:underline *:[a]:underline-offset-3",
+        "text-muted-foreground *:[a]:hover:text-foreground text-sm/relaxed *:[a]:underline *:[a]:underline-offset-3",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/dotted-dialog.tsx
+++ b/apps/web/src/components/ui/dotted-dialog.tsx
@@ -31,9 +31,9 @@ function DottedDialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dotted-dialog-overlay"
       className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 isolate z-50 overflow-hidden bg-background/70 backdrop-blur-sm duration-200",
-        "before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_22%,transparent)_1px,transparent_1px)] before:bg-[length:18px_18px] before:opacity-45",
-        "after:absolute after:inset-0 after:bg-[radial-gradient(circle_at_center,transparent_0%,var(--background)_76%)]",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 isolate z-50 overflow-hidden bg-background/75 backdrop-blur-sm duration-200",
+        "before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_38%,transparent)_1px,transparent_1px)] before:bg-[length:18px_18px]",
+        "after:absolute after:inset-0 after:bg-[radial-gradient(circle_at_center,transparent_35%,var(--background)_92%)]",
         className,
       )}
       {...props}
@@ -57,7 +57,7 @@ function DottedDialogContent({
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-hidden border border-border/70 bg-fd-background text-xs/relaxed shadow-2xl shadow-black/20 outline-none duration-200 sm:max-w-sm",
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-closed:slide-out-to-top-[2%] data-open:slide-in-from-top-[2%]",
-          "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_16%,transparent)_1px,transparent_1px)] before:bg-[length:16px_16px] before:opacity-25",
+          "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_20%,transparent)_1px,transparent_1px)] before:bg-[length:16px_16px]",
           className,
         )}
         {...props}

--- a/apps/web/src/components/ui/dotted-dialog.tsx
+++ b/apps/web/src/components/ui/dotted-dialog.tsx
@@ -1,0 +1,157 @@
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { m } from "@/paraglide/messages.js";
+
+function DottedDialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dotted-dialog" {...props} />;
+}
+
+function DottedDialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return (
+    <DialogPrimitive.Trigger data-slot="dotted-dialog-trigger" {...props} />
+  );
+}
+
+function DottedDialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dotted-dialog-portal" {...props} />;
+}
+
+function DottedDialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dotted-dialog-close" {...props} />;
+}
+
+function DottedDialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dotted-dialog-overlay"
+      className={cn(
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 isolate z-50 overflow-hidden bg-background/70 backdrop-blur-sm duration-200",
+        "before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_22%,transparent)_1px,transparent_1px)] before:bg-[length:18px_18px] before:opacity-45",
+        "after:absolute after:inset-0 after:bg-[radial-gradient(circle_at_center,transparent_0%,var(--background)_76%)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DottedDialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DottedDialogPortal>
+      <DottedDialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dotted-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-hidden border border-border/70 bg-fd-background text-xs/relaxed shadow-2xl shadow-black/20 outline-none duration-200 sm:max-w-sm",
+          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-closed:slide-out-to-top-[2%] data-open:slide-in-from-top-[2%]",
+          "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_center,color-mix(in_oklab,var(--foreground)_16%,transparent)_1px,transparent_1px)] before:bg-[length:16px_16px] before:opacity-25",
+          className,
+        )}
+        {...props}
+      >
+        <div className="relative z-[1] grid min-h-0">{children}</div>
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dotted-dialog-close"
+            className="absolute top-4 right-4 z-[2] flex h-7 w-7 items-center justify-center border border-transparent text-muted-foreground/60 transition-all duration-150 hover:border-border hover:bg-background/70 hover:text-foreground focus:outline-none"
+          >
+            <XIcon className="h-4 w-4" />
+            <span className="sr-only">{m.uiClose()}</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DottedDialogPortal>
+  );
+}
+
+function DottedDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dotted-dialog-header"
+      className={cn("flex flex-col gap-1.5 pr-8", className)}
+      {...props}
+    />
+  );
+}
+
+function DottedDialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dotted-dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close className="inline-flex h-9 items-center justify-center border border-border/50 bg-muted/20 px-4 text-xs font-medium text-muted-foreground transition-colors duration-150 hover:bg-muted/40 hover:text-foreground">
+          {m.uiClose()}
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DottedDialogTitle({
+  className,
+  ...props
+}: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dotted-dialog-title"
+      className={cn("text-sm font-medium tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function DottedDialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dotted-dialog-description"
+      className={cn(
+        "text-muted-foreground *:[a]:hover:text-foreground text-xs/relaxed *:[a]:underline *:[a]:underline-offset-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DottedDialog as Dialog,
+  DottedDialogClose as DialogClose,
+  DottedDialogContent as DialogContent,
+  DottedDialogDescription as DialogDescription,
+  DottedDialogFooter as DialogFooter,
+  DottedDialogHeader as DialogHeader,
+  DottedDialogOverlay as DialogOverlay,
+  DottedDialogPortal as DialogPortal,
+  DottedDialogTitle as DialogTitle,
+  DottedDialogTrigger as DialogTrigger,
+};

--- a/apps/web/src/lib/builder-share-modal-visibility.ts
+++ b/apps/web/src/lib/builder-share-modal-visibility.ts
@@ -1,0 +1,21 @@
+export const BUILDER_SHARE_MODAL_STORAGE_KEY =
+  "better-fullstack.builder-share-modal.v1";
+
+type BuilderShareReadableStorage = Pick<Storage, "getItem">;
+type BuilderShareWritableStorage = Pick<Storage, "setItem">;
+
+export function isBuilderRoute(pathname: string): boolean {
+  return pathname === "/new" || pathname === "/stack";
+}
+
+export function hasSeenBuilderShareModal(
+  storage: BuilderShareReadableStorage,
+): boolean {
+  return storage.getItem(BUILDER_SHARE_MODAL_STORAGE_KEY) !== null;
+}
+
+export function markBuilderShareModalSeen(
+  storage: BuilderShareWritableStorage,
+): void {
+  storage.setItem(BUILDER_SHARE_MODAL_STORAGE_KEY, "seen");
+}


### PR DESCRIPTION
## What changed

- Added a builder-only one-time modal that asks visitors to share projects built with Better Fullstack.
- Adapted the 21st.dev Dotted Dialog idea into a local Base UI/TanStack-friendly `dotted-dialog` component, avoiding Next.js and Radix-only assumptions.
- Stores a versioned localStorage key when the share modal is dismissed, so first builder visit prioritizes the share modal.
- Suppresses the changelog widget on first builder visit; once the share modal has been seen, a later builder visit can show the changelog normally.
- Added contact links for Telegram, X, Signal, WhatsApp, and GitHub Discussions.
- Added friend-sharing actions for native share/copy fallback, X intent, WhatsApp share, and copy text.

## Validation

- `bunx @21st-dev/cli add serafimcloud/dotted-dialog` attempted; registry requires `API_KEY_21ST`, so the component was adapted from the public 21st.dev component page instead.
- `bun run --cwd packages/types build`
- `bun run --cwd packages/template-generator build`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web build`
- pre-commit `lint` hook

Note: lint completes with the repo's existing warning set and no errors.
