### PR TITLE
fix(templates): migrate AI examples to the ai@6 streaming API

### DIFF
--- a/apps/cli/test/examples.test.ts
+++ b/apps/cli/test/examples.test.ts
@@ -3,16 +3,17 @@ import { join } from "node:path";
 
 import { EXAMPLES, expectError, expectSuccess, runTRPCTest, type TestConfig } from "./test-utils";
 
-const LEGACY_AI_RESPONSE_HELPERS = [
-  "result.toUIMessageStreamResponse(",
-  "result.pipeUIMessageStreamToResponse(",
+const REMOVED_AI_HELPERS = [
+  "toUIMessageStream(",
+  "createUIMessageStreamResponse(",
+  "result.stream",
 ];
 
 function expectModernAIChatOutput(files: string[]) {
   const output = files.join("\n");
 
-  expect(output).toContain("toUIMessageStream({ stream: result.stream })");
-  for (const helper of LEGACY_AI_RESPONSE_HELPERS) {
+  expect(output).toContain("result.toUIMessageStreamResponse(");
+  for (const helper of REMOVED_AI_HELPERS) {
     expect(output).not.toContain(helper);
   }
 }
@@ -68,7 +69,7 @@ describe("Example Configurations", () => {
       expect(aiPage).toContain("function MessageBubble");
       expect(aiPage).toContain("max-w-[min(42rem,85%)]");
       expect(aiPage).toContain("Loader2");
-      expect(aiRoute).toContain("createUIMessageStreamResponse");
+      expect(aiRoute).toContain("result.toUIMessageStreamResponse(");
       expectModernAIChatOutput([aiPage, aiRoute]);
     });
 
@@ -172,7 +173,7 @@ describe("Example Configurations", () => {
       expect(webPackageJson.dependencies?.["@ai-sdk/react"]).toBeDefined();
 
       const server = await Bun.file(join(projectDir, "apps/server/src/index.ts")).text();
-      expect(server).toContain("createUIMessageStreamResponse");
+      expect(server).toContain("result.toUIMessageStreamResponse(");
       expectModernAIChatOutput([aiRoute, server]);
     });
 

--- a/packages/template-generator/templates/backend/server/adonisjs/start/routes.ts.hbs
+++ b/packages/template-generator/templates/backend/server/adonisjs/start/routes.ts.hbs
@@ -16,9 +16,8 @@ import { createContext } from "@{{projectName}}/api/context";
 {{/if}}
 {{/if}}
 {{#if (includes examples "ai")}}
-import { pipeUIMessageStreamToResponse, streamText, toUIMessageStream, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, type UIMessage, convertToModelMessages } from "ai";
 import { google } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 {{#if (isBetterAuth auth)}}
 import { auth } from "@{{projectName}}/auth";
@@ -134,17 +133,11 @@ router.post("/ai", async ({ request, response }) => {
 	setCorsHeaders(response);
 	const body = request.body() as { messages?: UIMessage[] };
 	const messages = body.messages || [];
-	const model = wrapLanguageModel({
-		model: google("gemini-2.5-flash"),
-		middleware: devToolsMiddleware(),
-	});
+	const model = google("gemini-2.5-flash");
 	const result = streamText({
 		model,
 		messages: await convertToModelMessages(messages),
 	});
-	pipeUIMessageStreamToResponse({
-		response: response.response as any,
-		stream: toUIMessageStream({ stream: result.stream }),
-	});
+	result.pipeUIMessageStreamToResponse(response.response as any);
 });
 {{/if}}

--- a/packages/template-generator/templates/backend/server/elysia/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/elysia/src/index.ts.hbs
@@ -9,8 +9,7 @@ import { openapi } from "@elysiajs/openapi";
 {{/if}}
 {{#if (includes examples "ai")}}
 import { google } from "@ai-sdk/google";
-import { convertToModelMessages, createUIMessageStreamResponse, streamText, toUIMessageStream, type UIMessage, wrapLanguageModel } from "ai";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { convertToModelMessages, streamText, type UIMessage } from "ai";
 {{/if}}
 {{#if (eq api "trpc")}}
 import { createContext } from "@{{projectName}}/api/context";
@@ -215,18 +214,13 @@ new Elysia()
 	.post("/ai", async (context) => {
 		const body = (await context.request.json()) as { messages?: UIMessage[] };
 		const uiMessages = body.messages ?? [];
-		const model = wrapLanguageModel({
-			model: google("gemini-2.5-flash"),
-			middleware: devToolsMiddleware(),
-		});
+		const model = google("gemini-2.5-flash");
 		const result = streamText({
 			model,
 			messages: await convertToModelMessages(uiMessages)
 		});
 
-		return createUIMessageStreamResponse({
-			stream: toUIMessageStream({ stream: result.stream }),
-		});
+		return result.toUIMessageStreamResponse();
 	})
 {{/if}}
 	.get("/", () => "OK")

--- a/packages/template-generator/templates/backend/server/encore/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/encore/src/index.ts.hbs
@@ -3,9 +3,8 @@ import { api } from "encore.dev/api";
 import { auth } from "@{{projectName}}/auth";
 {{/if}}
 {{#if (and (includes examples "ai") (or (eq runtime "bun") (eq runtime "node")))}}
-import { streamText, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, convertToModelMessages } from "ai";
 import { google } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 
 interface Response {
@@ -53,10 +52,7 @@ interface AIRequest {
 export const chat = api(
 	{ expose: true, method: "POST", path: "/ai" },
 	async (req: AIRequest): Promise<Response> => {
-		const model = wrapLanguageModel({
-			model: google("gemini-2.5-flash"),
-			middleware: devToolsMiddleware(),
-		});
+		const model = google("gemini-2.5-flash");
 
 		const result = await streamText({
 			model,

--- a/packages/template-generator/templates/backend/server/express/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/express/src/index.ts.hbs
@@ -23,9 +23,8 @@ import { executeApolloRequest } from "@{{projectName}}/api";
 import cors from "cors";
 import express{{#if (or (eq api "apollo-server") (and (eq api "openapi") (isBetterAuth auth)))}}, { type Request }{{/if}} from "express";
 {{#if (includes examples "ai")}}
-import { pipeUIMessageStreamToResponse, streamText, toUIMessageStream, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, type UIMessage, convertToModelMessages } from "ai";
 import { google } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 {{#if (isBetterAuth auth)}}
 import { auth } from "@{{projectName}}/auth";
@@ -184,18 +183,12 @@ app.use("/docs", apiReference({ spec: { url: "/openapi.json" } }));
 {{#if (includes examples "ai")}}
 app.post("/ai", async (req, res) => {
 	const { messages = [] } = (req.body || {}) as { messages: UIMessage[] };
-	const model = wrapLanguageModel({
-		model: google("gemini-2.5-flash"),
-		middleware: devToolsMiddleware(),
-	});
+	const model = google("gemini-2.5-flash");
 	const result = streamText({
 		model,
 		messages: await convertToModelMessages(messages),
 	});
-	pipeUIMessageStreamToResponse({
-		response: res,
-		stream: toUIMessageStream({ stream: result.stream }),
-	});
+	result.pipeUIMessageStreamToResponse(res);
 });
 {{/if}}
 

--- a/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/fastify/src/index.ts.hbs
@@ -32,9 +32,8 @@ import { executeApolloRequest } from "@{{projectName}}/api";
 {{/if}}
 
 {{#if (includes examples "ai")}}
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, type UIMessage, convertToModelMessages } from "ai";
 import { google } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 
 {{#if (isBetterAuth auth)}}
@@ -287,18 +286,13 @@ interface AiRequestBody {
 
 fastify.post('/ai', async function (request) {
 	const { messages } = request.body as AiRequestBody;
-	const model = wrapLanguageModel({
-		model: google('gemini-2.5-flash'),
-		middleware: devToolsMiddleware(),
-	});
+	const model = google('gemini-2.5-flash');
 	const result = streamText({
 		model,
 		messages: await convertToModelMessages(messages),
 	});
 
-	return createUIMessageStreamResponse({
-		stream: toUIMessageStream({ stream: result.stream }),
-	});
+	return result.toUIMessageStreamResponse();
 });
 {{/if}}
 

--- a/packages/template-generator/templates/backend/server/fets/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/fets/src/index.ts.hbs
@@ -20,14 +20,12 @@ import { auth } from "@{{projectName}}/auth";
 {{/if}}
 import { createRouter, Response, type Router } from "fets";
 {{#if (and (includes examples "ai") (or (eq runtime "bun") (eq runtime "node")))}}
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, convertToModelMessages } from "ai";
 import { google } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 {{#if (and (includes examples "ai") (eq runtime "workers"))}}
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, convertToModelMessages } from "ai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 
 {{#if (or (isBetterAuth auth) (or (eq api "trpc") (eq api "orpc")))}}
@@ -198,17 +196,12 @@ const router: Router<any, any, any> = createRouter({
 		handler: async (request) => {
 			const body = await request.json();
 			const uiMessages = body.messages || [];
-			const model = wrapLanguageModel({
-				model: google("gemini-2.5-flash"),
-				middleware: devToolsMiddleware(),
-			});
+			const model = google("gemini-2.5-flash");
 			const result = streamText({
 				model,
 				messages: await convertToModelMessages(uiMessages),
 			});
-			return createUIMessageStreamResponse({
-				stream: toUIMessageStream({ stream: result.stream }),
-			}) as any;
+			return result.toUIMessageStreamResponse() as any;
 		},
 	})
 {{/if}}
@@ -222,17 +215,12 @@ const router: Router<any, any, any> = createRouter({
 			const google = createGoogleGenerativeAI({
 				apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
 			});
-			const model = wrapLanguageModel({
-				model: google("gemini-2.5-flash"),
-				middleware: devToolsMiddleware(),
-			});
+			const model = google("gemini-2.5-flash");
 			const result = streamText({
 				model,
 				messages: await convertToModelMessages(uiMessages),
 			});
-			return createUIMessageStreamResponse({
-				stream: toUIMessageStream({ stream: result.stream }),
-			}) as any;
+			return result.toUIMessageStreamResponse() as any;
 		},
 	})
 {{/if}};

--- a/packages/template-generator/templates/backend/server/hono/src/index.ts.hbs
+++ b/packages/template-generator/templates/backend/server/hono/src/index.ts.hbs
@@ -38,14 +38,12 @@ import { logger } from "hono/logger";
 import { bot as chatSdkBot } from "./bot";
 {{/if}}
 {{#if (and (includes examples "ai") (or (eq runtime "bun") (eq runtime "node")))}}
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, convertToModelMessages } from "ai";
 import { google } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 {{#if (and (includes examples "ai") (eq runtime "workers"))}}
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, convertToModelMessages } from "ai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 {{/if}}
 
 const app = new Hono();
@@ -210,18 +208,13 @@ app.route("/", openApiApp);
 app.post("/ai", async (c) => {
 	const body = await c.req.json();
 	const uiMessages = body.messages || [];
-	const model = wrapLanguageModel({
-		model: google("gemini-2.5-flash"),
-		middleware: devToolsMiddleware(),
-	});
+	const model = google("gemini-2.5-flash");
 	const result = streamText({
 		model,
 		messages: await convertToModelMessages(uiMessages),
 	});
 
-	return createUIMessageStreamResponse({
-		stream: toUIMessageStream({ stream: result.stream }),
-	});
+	return result.toUIMessageStreamResponse();
 });
 {{/if}}
 
@@ -232,18 +225,13 @@ app.post("/ai", async (c) => {
 	const google = createGoogleGenerativeAI({
 		apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
 	});
-	const model = wrapLanguageModel({
-		model: google("gemini-2.5-flash"),
-		middleware: devToolsMiddleware(),
-	});
+	const model = google("gemini-2.5-flash");
 	const result = streamText({
 		model,
 		messages: await convertToModelMessages(uiMessages),
 	});
 
-	return createUIMessageStreamResponse({
-		stream: toUIMessageStream({ stream: result.stream }),
-	});
+	return result.toUIMessageStreamResponse();
 });
 {{/if}}
 

--- a/packages/template-generator/templates/backend/server/nestjs/src/ai/ai.service.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nestjs/src/ai/ai.service.ts.hbs
@@ -1,26 +1,19 @@
 {{#if (includes examples "ai")}}
 import { Injectable } from "@nestjs/common";
-import { pipeUIMessageStreamToResponse, streamText, toUIMessageStream, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, type UIMessage, convertToModelMessages } from "ai";
 import { google } from "@ai-sdk/google";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 import type { Request, Response } from "express";
 
 @Injectable()
 export class AiService {
 	async streamChat(req: Request, res: Response) {
 		const { messages = [] } = (req.body || {}) as { messages: UIMessage[] };
-		const model = wrapLanguageModel({
-			model: google("gemini-2.5-flash"),
-			middleware: devToolsMiddleware(),
-		});
+		const model = google("gemini-2.5-flash");
 		const result = streamText({
 			model,
 			messages: await convertToModelMessages(messages),
 		});
-		pipeUIMessageStreamToResponse({
-			response: res,
-			stream: toUIMessageStream({ stream: result.stream }),
-		});
+		result.pipeUIMessageStreamToResponse(res);
 	}
 }
 {{/if}}

--- a/packages/template-generator/templates/backend/server/nitro/routes/ai.post.ts.hbs
+++ b/packages/template-generator/templates/backend/server/nitro/routes/ai.post.ts.hbs
@@ -109,14 +109,13 @@ export default defineEventHandler(async (event) => {
 	});
 });
 {{else}}
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
+import { streamText, type UIMessage, convertToModelMessages } from "ai";
 {{#if (or (eq runtime "bun") (eq runtime "node"))}}
 import { google } from "@ai-sdk/google";
 {{else}}
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { env } from "@{{projectName}}/env/server";
 {{/if}}
-import { devToolsMiddleware } from "@ai-sdk/devtools";
 
 export default defineEventHandler(async (event) => {
 	const body = await readBody<{ messages?: UIMessage[] }>(event);
@@ -127,19 +126,14 @@ export default defineEventHandler(async (event) => {
 		apiKey: env.GOOGLE_GENERATIVE_AI_API_KEY,
 	});
 {{/if}}
-	const model = wrapLanguageModel({
-		model: google("gemini-2.5-flash"),
-		middleware: devToolsMiddleware(),
-	});
+	const model = google("gemini-2.5-flash");
 
 	const result = streamText({
 		model,
 		messages: await convertToModelMessages(messages),
 	});
 
-	return createUIMessageStreamResponse({
-		stream: toUIMessageStream({ stream: result.stream }),
-	});
+	return result.toUIMessageStreamResponse();
 });
 {{/if}}
 {{else}}

--- a/packages/template-generator/templates/examples/ai/fullstack/next/src/app/api/ai/route.ts.hbs
+++ b/packages/template-generator/templates/examples/ai/fullstack/next/src/app/api/ai/route.ts.hbs
@@ -161,25 +161,19 @@ export async function POST(req: Request) {
 }
 {{else}}
 import { google } from "@ai-sdk/google";
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { streamText, type UIMessage, convertToModelMessages } from "ai";
 
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
 	const { messages }: { messages: UIMessage[] } = await req.json();
 
-	const model = wrapLanguageModel({
-		model: google("gemini-2.5-flash"),
-		middleware: devToolsMiddleware(),
-	});
+	const model = google("gemini-2.5-flash");
 	const result = streamText({
 		model,
 		messages: await convertToModelMessages(messages),
 	});
 
-	return createUIMessageStreamResponse({
-		stream: toUIMessageStream({ stream: result.stream }),
-	});
+	return result.toUIMessageStreamResponse();
 }
 {{/if}}

--- a/packages/template-generator/templates/examples/ai/fullstack/tanstack-start/src/routes/api/ai/$.ts.hbs
+++ b/packages/template-generator/templates/examples/ai/fullstack/tanstack-start/src/routes/api/ai/$.ts.hbs
@@ -210,8 +210,7 @@ export const Route = createFileRoute("/api/ai/$")({
 {{else}}
 import { createFileRoute } from "@tanstack/react-router";
 import { google } from "@ai-sdk/google";
-import { createUIMessageStreamResponse, streamText, toUIMessageStream, type UIMessage, convertToModelMessages, wrapLanguageModel } from "ai";
-import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { streamText, type UIMessage, convertToModelMessages } from "ai";
 
 export const Route = createFileRoute("/api/ai/$")({
   server: {
@@ -220,18 +219,13 @@ export const Route = createFileRoute("/api/ai/$")({
         try {
           const { messages }: { messages: UIMessage[] } = await request.json();
 
-          const model = wrapLanguageModel({
-            model: google("gemini-2.5-flash"),
-            middleware: devToolsMiddleware(),
-          });
+          const model = google("gemini-2.5-flash");
           const result = streamText({
             model,
             messages: await convertToModelMessages(messages),
           });
 
-          return createUIMessageStreamResponse({
-            stream: toUIMessageStream({ stream: result.stream }),
-          });
+          return result.toUIMessageStreamResponse();
         } catch (error) {
           console.error("AI API error:", error);
           return new Response(


### PR DESCRIPTION
## Problem
The Vercel AI SDK bumped to **`ai@6`** (the templates leave `ai` unpinned, so it drifts in via `@ai-sdk/*` peers). ai@6 **removed** the standalone `toUIMessageStream({ stream: result.stream })` and the `.stream` property on the `streamText` result, and `wrapLanguageModel(...) + devToolsMiddleware()` no longer type-checks (V3/V4 model-spec mismatch). The example routes were written for ai@5, so any `--examples ai` / `--ai <provider>` combo failed at typecheck **and** bundle (this is what was red-flagging the smoke CI on unrelated PRs).

## Fix — migrate to the ai@6 result methods (11 templates)
- **Response frameworks** (next, tanstack-start, hono, fastify, nitro, elysia, fets): `return result.toUIMessageStreamResponse();`
- **Pipe frameworks** (express, nestjs, adonisjs): `result.pipeUIMessageStreamToResponse(res);`
- **encore** (non-streaming): drop the `wrapLanguageModel`/devtools wrapper, use the model directly.
- Remove the incompatible `@ai-sdk/devtools` middleware everywhere.

## Test update
`apps/cli/test/examples.test.ts` previously *enforced* the now-removed ai@5 pattern (it labelled the result methods "legacy"). Inverted: the removed helpers (`toUIMessageStream(`, `createUIMessageStreamResponse(`, `result.stream`) are now forbidden; `result.toUIMessageStreamResponse(` is required.

## Verification (against real ai@6)
- Regenerated bundle: **0** residual removed-API symbols.
- `apps/cli` AI examples test: **27/27 pass**.
- Scaffold + `bun install` + `check-types` green for **next** (Response fullstack), **hono** (Response backend), **express** (pipe backend) — both response styles compile.

## Follow-up (not in this PR)
`ai` is still unpinned in the templates, so it can drift again on a future major. Worth pinning `ai` + `@ai-sdk/*` to a coherent set (same pattern as the graphql-16 / babel-7 pins). Flagging for a separate change.