### PR TITLE
fix(native): single-page web output for unistyles + expo-router

### DIFF
--- a/packages/template-generator/templates/frontend/native/unistyles/app.json.hbs
+++ b/packages/template-generator/templates/frontend/native/unistyles/app.json.hbs
@@ -24,7 +24,10 @@
     },
     "web": {
       {{#if (eq mobileNavigation "expo-router")}}
-      "output": "static",
+      {{! Unistyles styles resolve at runtime and can't be statically rendered
+          at build time (StyleSheet.configure runs after StyleSheet.create during
+          static SSR), so use single-page (client-rendered) web output. }}
+      "output": "single",
       {{/if}}
       "favicon": "./assets/images/favicon.png"
     },


### PR DESCRIPTION
## Problem
`react-native-unistyles` resolves styles at runtime, so it can't be statically rendered at build time. During Expo's **static web export** (`web.output: "static"`), `StyleSheet.create` runs before `StyleSheet.configure`, throwing:
```
Unistyles: One of your stylesheets is trying to get the theme, but no theme has been selected yet. Did you forget to call StyleSheet.configure?
```
The generated native app's `build` script is `expo export`, so **any native-unistyles + expo-router project failed `bun run build`** (the web target) — iOS/Android bundled fine. This is a real user-facing bug; it was surfaced by the RN build guard added in #295.

## Fix
Switch the **unistyles** variant's `web.output` from `"static"` → `"single"` (client-rendered SPA) — the correct web mode for a runtime-styling library. `bare`/`uniwind` keep `"static"` (they render fine). One-line template change.

## Verified
Scaffold native-unistyles + expo-router → `bun install` → `expo export`: **Web + iOS + Android all bundle, exit 0** (was failing on web before). Template snapshots unchanged; the babel-pin guard test stays green.