### PR TITLE
CLI onboarding: Web Builder handoff + Core/Full/Custom configuration scope

### DIFF
--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -14,6 +14,7 @@ export type { AvailableDependencies } from "@better-fullstack/template-generator
 const __filename = fileURLToPath(import.meta.url);
 const distPath = path.dirname(__filename);
 export const PKG_ROOT = path.join(distPath, "../");
+export const BUILDER_URL = "https://better-fullstack-web.vercel.app/new";
 
 export const DEFAULT_CONFIG_BASE = createCliDefaultProjectConfigBase(getUserPkgManager());
 

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -1,4 +1,4 @@
-import { intro, log, outro } from "@clack/prompts";
+import { intro, log, note, outro } from "@clack/prompts";
 import consola from "consola";
 import fs from "fs-extra";
 import path from "node:path";
@@ -6,15 +6,17 @@ import pc from "picocolors";
 
 import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 
-import { getDefaultConfig } from "../../constants";
+import { BUILDER_URL, getDefaultConfig } from "../../constants";
+import { CreateCommandOptionsSchema } from "../../create-command-input";
 import { gatherConfig } from "../../prompts/config-prompts";
+import { isCancel, isGoBack, navigableSelect } from "../../prompts/navigable";
 import { getProjectName } from "../../prompts/project-name";
 import { getVersionChannelChoice } from "../../prompts/version-channel";
 import { maybeShowTelemetryNotice, trackProjectCreation } from "../../utils/analytics";
 import { resolveCreateConfigBase } from "../../utils/config-source";
 import { isSilent, runWithContextAsync } from "../../utils/context";
 import { displayConfig } from "../../utils/display-config";
-import { CLIError, UserCancelledError } from "../../utils/errors";
+import { CLIError, UserCancelledError, exitCancelled } from "../../utils/errors";
 import { generateReproducibleCommand } from "../../utils/generate-reproducible-command";
 import { runGeneratedChecks } from "../../utils/generated-checks";
 import { displayPreflightWarnings } from "../../utils/preflight-display";
@@ -23,6 +25,7 @@ import { addToHistory } from "../../utils/project-history";
 import { canPromptInteractively } from "../../utils/prompt-environment";
 import { renderTitle } from "../../utils/render-title";
 import { getTemplateConfig, getTemplateDescription } from "../../utils/templates";
+import { openUrl } from "../../utils/open-url";
 import {
   getProvidedFlags,
   processAndValidateFlags,
@@ -33,6 +36,133 @@ import { createProject } from "./create-project";
 
 interface CreateHandlerOptions {
   silent?: boolean;
+}
+
+type BuilderPromptEnvironment = {
+  npmConfigUserAgent?: string;
+  forceBuilderPrompt?: string;
+  skipBuilderPrompt?: string;
+  silent?: boolean;
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
+  ci?: string;
+};
+
+type BuilderPromptGateInput = Pick<CreateInput, "yes" | "part" | "template"> &
+  Partial<ProjectConfig> & {
+    config?: string;
+    fromHistory?: number;
+    yolo?: boolean;
+    manualDb?: boolean;
+  };
+
+// Keys that don't express a stack choice; booleans with zod defaults
+// (yes/yolo/manualDb/...) are always present in parsed input, so their truthy
+// forms are handled explicitly in the gate instead.
+const NON_STACK_CREATE_OPTION_KEYS = new Set([
+  "template",
+  "fromHistory",
+  "config",
+  "yes",
+  "yolo",
+  "manualDb",
+  "part",
+  "verbose",
+  "dryRun",
+  "verify",
+  "versionChannel",
+  "directoryConflict",
+  "renderTitle",
+  "disableAnalytics",
+]);
+
+const CREATE_STACK_FLAG_KEYS = new Set(
+  Object.keys(CreateCommandOptionsSchema.shape).filter(
+    (key) => !NON_STACK_CREATE_OPTION_KEYS.has(key),
+  ),
+);
+
+function hasCreateStackFlags(input: BuilderPromptGateInput): boolean {
+  return Object.entries(input).some(([key, value]) => {
+    if (value === undefined) return false;
+    if (key === "template" && value === "none") return false;
+    return CREATE_STACK_FLAG_KEYS.has(key);
+  });
+}
+
+export function shouldShowBuilderRecommendationPrompt({
+  input,
+  hasConfigBase,
+  environment = {},
+}: {
+  input: BuilderPromptGateInput;
+  hasConfigBase: boolean;
+  environment?: BuilderPromptEnvironment;
+}): boolean {
+  if (environment.skipBuilderPrompt === "1") return false;
+  if (
+    !canPromptInteractively({
+      silent: environment.silent,
+      stdinIsTTY: environment.stdinIsTTY,
+      stdoutIsTTY: environment.stdoutIsTTY,
+      ci: environment.ci,
+    })
+  ) {
+    return false;
+  }
+  if (
+    input.yes ||
+    input.yolo ||
+    input.manualDb ||
+    input.part?.length ||
+    hasConfigBase ||
+    input.config ||
+    input.fromHistory ||
+    (input.template && input.template !== "none")
+  ) {
+    return false;
+  }
+  if (hasCreateStackFlags(input)) return false;
+  if (environment.forceBuilderPrompt === "1") return true;
+  return Boolean(environment.npmConfigUserAgent);
+}
+
+async function showBuilderRecommendationPrompt() {
+  note(
+    `The Web Builder walks the full stack visually — every option, live compatibility checks — and hands you back a single command to run.\n\n${BUILDER_URL}`,
+    "Prefer a visual builder?",
+  );
+
+  const response = await navigableSelect<"open" | "continue">({
+    message: "How would you like to continue?",
+    options: [
+      {
+        value: "open",
+        label: "Open the Web Builder",
+        hint: "recommended — opens in your browser",
+      },
+      {
+        value: "continue",
+        label: "Continue in the CLI",
+      },
+    ],
+    initialValue: "open",
+  });
+
+  if (isCancel(response) || isGoBack(response)) return exitCancelled("Operation cancelled");
+
+  if (response === "open") {
+    try {
+      await openUrl(BUILDER_URL);
+      log.success(pc.blue("Opened Web Builder in your browser."));
+    } catch {
+      log.message(`Please visit ${BUILDER_URL}`);
+    }
+    outro(pc.magenta("Web Builder is ready when you are."));
+    return "opened" as const;
+  }
+
+  return "continue" as const;
 }
 
 function getYesBaseConfig(flagConfig: Partial<ProjectConfig>): ProjectConfig {
@@ -130,6 +260,21 @@ export async function createProjectHandler(
 
       const configBase = await resolveCreateConfigBase(input);
       const hasConfigBase = configBase !== undefined;
+      if (
+        shouldShowBuilderRecommendationPrompt({
+          input,
+          hasConfigBase,
+          environment: {
+            npmConfigUserAgent: process.env.npm_config_user_agent,
+            forceBuilderPrompt: process.env.BFS_FORCE_BUILDER_PROMPT,
+            skipBuilderPrompt: process.env.BFS_SKIP_BUILDER_PROMPT,
+          },
+        })
+      ) {
+        const builderChoice = await showBuilderRecommendationPrompt();
+        if (builderChoice === "opened") return;
+      }
+
       if (hasConfigBase && !isSilent()) {
         log.info(
           pc.cyan(

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -54,6 +54,7 @@ type BuilderPromptGateInput = Pick<CreateInput, "yes" | "part" | "template"> &
     fromHistory?: number;
     yolo?: boolean;
     manualDb?: boolean;
+    dryRun?: boolean;
   };
 
 // Keys that don't express a stack choice; booleans with zod defaults
@@ -114,6 +115,7 @@ export function shouldShowBuilderRecommendationPrompt({
     input.yes ||
     input.yolo ||
     input.manualDb ||
+    input.dryRun ||
     input.part?.length ||
     hasConfigBase ||
     input.config ||

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -434,6 +434,16 @@ const CONFIG_SCOPE_META_KEYS = new Set<PromptGroupKey>([
   "configSections",
 ]);
 
+const SHADCN_FLAG_KEYS = new Set([
+  "shadcnBase",
+  "shadcnStyle",
+  "shadcnIconLibrary",
+  "shadcnColorTheme",
+  "shadcnBaseColor",
+  "shadcnFont",
+  "shadcnRadius",
+]);
+
 // Record form so the compiler enforces completeness: adding a prompt to
 // PromptGroupResults without listing it here is a type error, which in turn
 // forces classifying it in CONFIG_SCOPE_REGISTRY via the coverage test.
@@ -574,15 +584,34 @@ export const CONFIG_PROMPT_ENTRY_KEYS = Object.keys(
   CONFIG_PROMPT_ENTRY_KEY_MAP,
 ) as PromptGroupKey[];
 
-function hasStackPromptFlags(flags: Partial<ProjectConfig>) {
+export function hasStackPromptFlags(flags: Partial<ProjectConfig>) {
   return Object.keys(flags).some((key) => {
     if (key === "projectName" || key === "projectDir" || key === "relativePath") return false;
+    if (SHADCN_FLAG_KEYS.has(key)) return true;
     return CONFIG_PROMPT_ENTRY_KEYS.includes(key as PromptGroupKey);
   });
 }
 
+export async function getScopedDefaultPromptValue<K extends PromptGroupKey>(
+  key: K,
+  results: Partial<PromptGroupResults>,
+  flags: Partial<ProjectConfig>,
+): Promise<PromptGroupResults[K]> {
+  if (key === "serverDeploy" && results.ecosystem === "typescript") {
+    return getServerDeploymentChoice(
+      flags.serverDeploy,
+      results.runtime,
+      results.backend,
+      results.webDeploy,
+    ) as Promise<PromptGroupResults[K]>;
+  }
+
+  return getDefaultPromptValue(key as ConfigPromptKey) as PromptGroupResults[K];
+}
+
 function scopedPrompt<K extends PromptGroupKey>(
   key: K,
+  flags: Partial<ProjectConfig>,
   prompt: (opts: {
     results: Partial<PromptGroupResults>;
   }) => Promise<PromptGroupResults[K] | symbol | undefined> | undefined,
@@ -597,7 +626,7 @@ function scopedPrompt<K extends PromptGroupKey>(
         opts.results.configSections,
       )
     ) {
-      return Promise.resolve(getDefaultPromptValue(key as ConfigPromptKey) as PromptGroupResults[K]);
+      return getScopedDefaultPromptValue(key, opts.results, flags);
     }
 
     return prompt(opts);
@@ -1343,7 +1372,7 @@ export async function gatherConfig(
   const scopedPromptEntries = Object.fromEntries(
     Object.entries(promptEntries).map(([key, prompt]) => [
       key,
-      scopedPrompt(key as PromptGroupKey, prompt as never),
+      scopedPrompt(key as PromptGroupKey, flags, prompt as never),
     ]),
   ) as NavigablePromptGroup<PromptGroupResults>;
 

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -140,6 +140,14 @@ import { getAuthChoice } from "./auth";
 import { getBackendFrameworkChoice } from "./backend";
 import { getCachingChoice } from "./caching";
 import { getCMSChoice } from "./cms";
+import {
+  type ConfigPromptKey,
+  type ConfigScope,
+  getConfigScopeChoice,
+  getConfigSectionsChoice,
+  getDefaultPromptValue,
+  shouldAskConfigPromptKey,
+} from "./config-scope";
 import { getCSSFrameworkChoice } from "./css-framework";
 import { getDatabaseChoice } from "./database";
 import { getDBSetupChoice } from "./database-setup";
@@ -225,7 +233,7 @@ import {
   gatherMultiEcosystemConfig,
   getCompositionModeChoice,
 } from "./multi-ecosystem-composer";
-import { navigableGroup } from "./navigable-group";
+import { navigableGroup, type NavigablePromptGroup } from "./navigable-group";
 import { getObservabilityChoice } from "./observability";
 import { getORMChoice } from "./orm";
 import { getPackageManagerChoice } from "./package-manager";
@@ -279,6 +287,8 @@ import { getDeploymentChoice } from "./web-deploy";
 type PromptGroupResults = {
   // Ecosystem choice first
   ecosystem: Ecosystem;
+  configScope: ConfigScope;
+  configSections: string[];
   // TypeScript ecosystem
   frontend: Frontend[];
   astroIntegration: AstroIntegration | undefined;
@@ -416,6 +426,184 @@ type PromptGroupResults = {
   install: boolean;
 };
 
+type PromptGroupKey = keyof PromptGroupResults;
+
+const CONFIG_SCOPE_META_KEYS = new Set<PromptGroupKey>([
+  "ecosystem",
+  "configScope",
+  "configSections",
+]);
+
+// Record form so the compiler enforces completeness: adding a prompt to
+// PromptGroupResults without listing it here is a type error, which in turn
+// forces classifying it in CONFIG_SCOPE_REGISTRY via the coverage test.
+const CONFIG_PROMPT_ENTRY_KEY_MAP = {
+  ecosystem: true,
+  configScope: true,
+  configSections: true,
+  frontend: true,
+  astroIntegration: true,
+  uiLibrary: true,
+  shadcnOptions: true,
+  cssFramework: true,
+  backend: true,
+  runtime: true,
+  database: true,
+  orm: true,
+  api: true,
+  auth: true,
+  payments: true,
+  email: true,
+  effect: true,
+  addons: true,
+  examples: true,
+  dbSetup: true,
+  webDeploy: true,
+  serverDeploy: true,
+  ai: true,
+  validation: true,
+  forms: true,
+  stateManagement: true,
+  animation: true,
+  testing: true,
+  realtime: true,
+  jobQueue: true,
+  fileUpload: true,
+  logging: true,
+  observability: true,
+  featureFlags: true,
+  analytics: true,
+  cms: true,
+  caching: true,
+  rateLimit: true,
+  i18n: true,
+  search: true,
+  vectorDb: true,
+  fileStorage: true,
+  mobileNavigation: true,
+  mobileUI: true,
+  mobileStorage: true,
+  mobileTesting: true,
+  mobilePush: true,
+  mobileOTA: true,
+  mobileDeepLinking: true,
+  rustWebFramework: true,
+  rustFrontend: true,
+  rustOrm: true,
+  rustApi: true,
+  rustCli: true,
+  rustLibraries: true,
+  rustLogging: true,
+  rustErrorHandling: true,
+  rustCaching: true,
+  rustAuth: true,
+  rustRealtime: true,
+  rustMessageQueue: true,
+  rustObservability: true,
+  rustTemplating: true,
+  pythonWebFramework: true,
+  pythonOrm: true,
+  pythonValidation: true,
+  pythonAi: true,
+  pythonAuth: true,
+  pythonApi: true,
+  pythonTaskQueue: true,
+  pythonGraphql: true,
+  pythonQuality: true,
+  pythonTesting: true,
+  pythonCaching: true,
+  pythonRealtime: true,
+  pythonObservability: true,
+  pythonCli: true,
+  goWebFramework: true,
+  goOrm: true,
+  goApi: true,
+  goCli: true,
+  goLogging: true,
+  goAuth: true,
+  goTesting: true,
+  goRealtime: true,
+  goMessageQueue: true,
+  goCaching: true,
+  goConfig: true,
+  goObservability: true,
+  javaWebFramework: true,
+  javaLanguage: true,
+  javaBuildTool: true,
+  javaOrm: true,
+  javaAuth: true,
+  javaApi: true,
+  javaLogging: true,
+  javaLibraries: true,
+  javaTestingLibraries: true,
+  dotnetWebFramework: true,
+  dotnetOrm: true,
+  dotnetAuth: true,
+  dotnetApi: true,
+  dotnetTesting: true,
+  dotnetJobQueue: true,
+  dotnetRealtime: true,
+  dotnetObservability: true,
+  dotnetValidation: true,
+  dotnetCaching: true,
+  dotnetDeploy: true,
+  elixirWebFramework: true,
+  elixirOrm: true,
+  elixirAuth: true,
+  elixirApi: true,
+  elixirRealtime: true,
+  elixirJobs: true,
+  elixirValidation: true,
+  elixirHttp: true,
+  elixirJson: true,
+  elixirEmail: true,
+  elixirCaching: true,
+  elixirObservability: true,
+  elixirTesting: true,
+  elixirQuality: true,
+  elixirDeploy: true,
+  elixirLibraries: true,
+  aiDocs: true,
+  git: true,
+  workspaceShape: true,
+  packageManager: true,
+  install: true,
+} as const satisfies Record<PromptGroupKey, true>;
+
+export const CONFIG_PROMPT_ENTRY_KEYS = Object.keys(
+  CONFIG_PROMPT_ENTRY_KEY_MAP,
+) as PromptGroupKey[];
+
+function hasStackPromptFlags(flags: Partial<ProjectConfig>) {
+  return Object.keys(flags).some((key) => {
+    if (key === "projectName" || key === "projectDir" || key === "relativePath") return false;
+    return CONFIG_PROMPT_ENTRY_KEYS.includes(key as PromptGroupKey);
+  });
+}
+
+function scopedPrompt<K extends PromptGroupKey>(
+  key: K,
+  prompt: (opts: {
+    results: Partial<PromptGroupResults>;
+  }) => Promise<PromptGroupResults[K] | symbol | undefined> | undefined,
+) {
+  return (opts: { results: Partial<PromptGroupResults> }) => {
+    if (
+      !CONFIG_SCOPE_META_KEYS.has(key) &&
+      !shouldAskConfigPromptKey(
+        opts.results.ecosystem,
+        key as ConfigPromptKey,
+        opts.results.configScope,
+        opts.results.configSections,
+      )
+    ) {
+      return Promise.resolve(getDefaultPromptValue(key as ConfigPromptKey) as PromptGroupResults[K]);
+    }
+
+    return prompt(opts);
+  };
+}
+
 export async function gatherConfig(
   flags: Partial<ProjectConfig>,
   projectName: string,
@@ -429,10 +617,17 @@ export async function gatherConfig(
     }
   }
 
-  const result = await navigableGroup<PromptGroupResults>(
-    {
+  const shouldPromptForScope = !hasStackPromptFlags(flags);
+  const promptEntries = {
       // Ecosystem choice first
       ecosystem: () => getEcosystemChoice(flags.ecosystem),
+      configScope: () => (shouldPromptForScope ? getConfigScopeChoice() : Promise.resolve("full")),
+      configSections: ({ results }) => {
+        if (!shouldPromptForScope || results.configScope !== "custom") {
+          return Promise.resolve([] as string[]);
+        }
+        return getConfigSectionsChoice(results.ecosystem ?? "typescript");
+      },
       // TypeScript ecosystem prompts (skip if Rust or Python)
       frontend: ({ results }) => {
         if (results.ecosystem === "react-native") {
@@ -1143,7 +1338,17 @@ export async function gatherConfig(
       },
       install: ({ results }) =>
         getinstallChoice(flags.install, results.ecosystem, results.javaBuildTool),
-    },
+    } satisfies NavigablePromptGroup<PromptGroupResults>;
+
+  const scopedPromptEntries = Object.fromEntries(
+    Object.entries(promptEntries).map(([key, prompt]) => [
+      key,
+      scopedPrompt(key as PromptGroupKey, prompt as never),
+    ]),
+  ) as NavigablePromptGroup<PromptGroupResults>;
+
+  const result = await navigableGroup<PromptGroupResults>(
+    scopedPromptEntries,
     {
       onCancel: () => exitCancelled("Operation cancelled"),
     },

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -240,6 +240,7 @@ import { getPackageManagerChoice } from "./package-manager";
 import { getWorkspaceShapeChoice } from "./workspace-shape";
 import { getPaymentsChoice } from "./payments";
 import { getRateLimitChoice } from "./rate-limit";
+import { PROMPT_RESOLVER_REGISTRY } from "./prompt-resolver-registry";
 import {
   getPythonAiChoice,
   getPythonApiChoice,
@@ -592,19 +593,96 @@ export function hasStackPromptFlags(flags: Partial<ProjectConfig>) {
   });
 }
 
+function getPromptResolutionValue(key: ConfigPromptKey, results: Partial<PromptGroupResults>, flags: Partial<ProjectConfig>) {
+  const resolver = PROMPT_RESOLVER_REGISTRY[key];
+  if (!resolver) return undefined;
+
+  const frontends = results.frontend ?? flags.frontend;
+  const contextByKey: Record<string, Record<string, unknown>> = {
+    frontend: { frontend: flags.frontend, backend: flags.backend, auth: flags.auth },
+    backend: { backendFramework: flags.backend, frontends },
+    runtime: { runtime: flags.runtime, backend: results.backend },
+    database: { database: flags.database, backend: results.backend, runtime: results.runtime },
+    orm: {
+      orm: flags.orm,
+      hasDatabase: results.database !== undefined && results.database !== "none",
+      database: results.database,
+      backend: results.backend,
+      runtime: results.runtime,
+    },
+    api: {
+      api: flags.api,
+      frontend: frontends,
+      backend: results.backend,
+      astroIntegration: results.astroIntegration,
+    },
+    auth: {
+      auth: flags.auth,
+      backend: results.backend,
+      frontend: frontends,
+      ecosystem: results.ecosystem,
+    },
+    payments: {
+      payments: flags.payments,
+      auth: results.auth,
+      backend: results.backend,
+      frontends,
+    },
+    email: { email: flags.email, backend: results.backend, ecosystem: results.ecosystem },
+    uiLibrary: {
+      uiLibrary: flags.uiLibrary,
+      frontends,
+      astroIntegration: results.astroIntegration,
+    },
+    cssFramework: { cssFramework: flags.cssFramework, uiLibrary: results.uiLibrary },
+    forms: { forms: flags.forms, frontends },
+    stateManagement: { stateManagement: flags.stateManagement, frontends },
+    animation: { animation: flags.animation, frontends },
+    caching: { caching: flags.caching, backend: results.backend, ecosystem: results.ecosystem },
+    search: { search: flags.search, backend: results.backend, ecosystem: results.ecosystem },
+    observability: {
+      observability: flags.observability,
+      backend: results.backend,
+      ecosystem: results.ecosystem,
+    },
+    realtime: { realtime: flags.realtime, backend: results.backend },
+    jobQueue: { jobQueue: flags.jobQueue, backend: results.backend },
+    fileUpload: { fileUpload: flags.fileUpload, backend: results.backend },
+    logging: { logging: flags.logging, backend: results.backend },
+    rateLimit: { rateLimit: flags.rateLimit, backend: results.backend },
+    cms: { cms: flags.cms, backend: results.backend },
+    vectorDb: { vectorDb: flags.vectorDb, backend: results.backend, ecosystem: results.ecosystem },
+    fileStorage: { fileStorage: flags.fileStorage, backend: results.backend },
+  };
+  const selectedValue = flags[key as keyof ProjectConfig];
+  const context = contextByKey[key] ?? { value: selectedValue };
+  const resolution = resolver.resolve(context);
+
+  return resolution.autoValue ?? resolution.initialValue;
+}
+
 export async function getScopedDefaultPromptValue<K extends PromptGroupKey>(
   key: K,
   results: Partial<PromptGroupResults>,
   flags: Partial<ProjectConfig>,
 ): Promise<PromptGroupResults[K]> {
   if (key === "serverDeploy" && results.ecosystem === "typescript") {
-    return getServerDeploymentChoice(
-      flags.serverDeploy,
-      results.runtime,
-      results.backend,
-      results.webDeploy,
-    ) as Promise<PromptGroupResults[K]>;
+    if (flags.serverDeploy !== undefined) return flags.serverDeploy as PromptGroupResults[K];
+    if (results.backend !== "hono") return "none" as PromptGroupResults[K];
+    if (results.runtime === "workers") return "cloudflare" as PromptGroupResults[K];
+    return "none" as PromptGroupResults[K];
   }
+
+  if (key === "effect" && results.ecosystem === "typescript") {
+    return (flags.effect ?? (results.backend === "effect" ? "effect-full" : "none")) as PromptGroupResults[K];
+  }
+
+  if (key === "validation" && results.ecosystem === "typescript" && results.backend === "effect") {
+    return (flags.validation ?? "effect-schema") as PromptGroupResults[K];
+  }
+
+  const resolvedValue = getPromptResolutionValue(key as ConfigPromptKey, results, flags);
+  if (resolvedValue !== undefined) return resolvedValue as PromptGroupResults[K];
 
   return getDefaultPromptValue(key as ConfigPromptKey) as PromptGroupResults[K];
 }

--- a/apps/cli/src/prompts/config-scope.ts
+++ b/apps/cli/src/prompts/config-scope.ts
@@ -44,6 +44,12 @@ export const CONFIG_SCOPE_ALWAYS_KEYS = [
   "install",
 ] as const satisfies ConfigPromptKey[];
 
+const sharedServiceSection = {
+  id: "shared-services",
+  label: "Shared Services",
+  promptKeys: ["email", "caching", "search", "observability"],
+} as const satisfies ConfigSection;
+
 const typescriptSections = [
   {
     id: "ui-styling",
@@ -145,6 +151,7 @@ export const CONFIG_SCOPE_REGISTRY = {
   rust: {
     core: ["rustWebFramework", "rustFrontend", "database", "dbSetup", "rustOrm", "rustApi", "rustAuth"],
     sections: [
+      sharedServiceSection,
       {
         id: "cli-libraries",
         label: "CLI & Libraries",
@@ -170,6 +177,7 @@ export const CONFIG_SCOPE_REGISTRY = {
   python: {
     core: ["pythonWebFramework", "database", "dbSetup", "pythonOrm", "pythonAuth", "pythonApi"],
     sections: [
+      sharedServiceSection,
       {
         id: "type-safety-ai",
         label: "Validation & AI",
@@ -195,6 +203,7 @@ export const CONFIG_SCOPE_REGISTRY = {
   go: {
     core: ["goWebFramework", "database", "dbSetup", "goOrm", "goApi", "goAuth"],
     sections: [
+      sharedServiceSection,
       {
         id: "cli-config",
         label: "CLI, Config & Logging",
@@ -215,6 +224,7 @@ export const CONFIG_SCOPE_REGISTRY = {
   java: {
     core: ["javaWebFramework", "javaLanguage", "javaBuildTool", "database", "dbSetup", "javaOrm", "javaAuth", "javaApi"],
     sections: [
+      sharedServiceSection,
       {
         id: "libraries",
         label: "Libraries",
@@ -230,6 +240,7 @@ export const CONFIG_SCOPE_REGISTRY = {
   dotnet: {
     core: ["dotnetWebFramework", "database", "dbSetup", "dotnetOrm", "dotnetAuth", "dotnetApi"],
     sections: [
+      sharedServiceSection,
       {
         id: "quality",
         label: "Testing & Observability",

--- a/apps/cli/src/prompts/config-scope.ts
+++ b/apps/cli/src/prompts/config-scope.ts
@@ -1,0 +1,405 @@
+import pc from "picocolors";
+
+import type { Ecosystem, ProjectConfig } from "../types";
+
+import { getDefaultConfig } from "../constants";
+import { exitCancelled } from "../utils/errors";
+import { isCancel, isGoBack, navigableMultiselect, navigableSelect } from "./navigable";
+
+export type ConfigScope = "core" | "full" | "custom";
+
+export type ConfigPromptKey = Exclude<
+  keyof ProjectConfig,
+  | "projectName"
+  | "projectDir"
+  | "relativePath"
+  | "versionChannel"
+  | "stackParts"
+  | "template"
+  | "shadcnBase"
+  | "shadcnStyle"
+  | "shadcnIconLibrary"
+  | "shadcnColorTheme"
+  | "shadcnBaseColor"
+  | "shadcnFont"
+  | "shadcnRadius"
+> | "astroIntegration" | "shadcnOptions";
+
+export type ConfigSection = {
+  id: string;
+  label: string;
+  promptKeys: ConfigPromptKey[];
+};
+
+export type EcosystemScopeRegistry = {
+  core: ConfigPromptKey[];
+  sections: ConfigSection[];
+};
+
+export const CONFIG_SCOPE_ALWAYS_KEYS = [
+  "aiDocs",
+  "git",
+  "workspaceShape",
+  "packageManager",
+  "install",
+] as const satisfies ConfigPromptKey[];
+
+const typescriptSections = [
+  {
+    id: "ui-styling",
+    label: "UI & Styling",
+    promptKeys: ["uiLibrary", "shadcnOptions", "cssFramework"],
+  },
+  {
+    id: "state-forms",
+    label: "State, Forms & Animation",
+    promptKeys: ["stateManagement", "forms", "animation"],
+  },
+  {
+    id: "type-safety",
+    label: "Validation & Effect",
+    promptKeys: ["validation", "effect"],
+  },
+  {
+    id: "payments-email",
+    label: "Payments & Email",
+    promptKeys: ["payments", "email"],
+  },
+  {
+    id: "ai",
+    label: "AI & Vector DB",
+    promptKeys: ["ai", "vectorDb"],
+  },
+  {
+    id: "data-storage",
+    label: "Data & Storage",
+    promptKeys: ["caching", "search", "fileStorage", "fileUpload"],
+  },
+  {
+    id: "backend-extras",
+    label: "Jobs, Realtime & Rate Limiting",
+    promptKeys: ["jobQueue", "realtime", "rateLimit"],
+  },
+  {
+    id: "quality",
+    label: "Testing & Observability",
+    promptKeys: ["testing", "logging", "observability"],
+  },
+  {
+    id: "content",
+    label: "Content, Analytics & i18n",
+    promptKeys: ["cms", "analytics", "i18n", "featureFlags"],
+  },
+  {
+    id: "deploy",
+    label: "Deployment",
+    promptKeys: ["webDeploy", "serverDeploy"],
+  },
+  {
+    id: "addons-examples",
+    label: "Addons & Examples",
+    promptKeys: ["addons", "examples"],
+  },
+] as const satisfies ConfigSection[];
+
+export const CONFIG_SCOPE_REGISTRY = {
+  typescript: {
+    core: [
+      "frontend",
+      "astroIntegration",
+      "backend",
+      "runtime",
+      "database",
+      "orm",
+      "api",
+      "auth",
+      "dbSetup",
+    ],
+    sections: typescriptSections,
+  },
+  "react-native": {
+    core: ["frontend", "mobileNavigation", "backend", "runtime", "database", "orm", "api", "auth", "dbSetup"],
+    sections: [
+      {
+        id: "mobile-experience",
+        label: "Mobile Experience",
+        promptKeys: ["mobileUI", "mobileStorage", "mobileDeepLinking"],
+      },
+      {
+        id: "mobile-delivery",
+        label: "Mobile Delivery",
+        promptKeys: ["mobilePush", "mobileOTA", "mobileTesting"],
+      },
+      {
+        id: "commerce",
+        label: "Payments",
+        promptKeys: ["payments"],
+      },
+      {
+        id: "extras",
+        label: "Data & Discovery",
+        promptKeys: ["caching", "search", "observability"],
+      },
+    ],
+  },
+  rust: {
+    core: ["rustWebFramework", "rustFrontend", "database", "dbSetup", "rustOrm", "rustApi", "rustAuth"],
+    sections: [
+      {
+        id: "cli-libraries",
+        label: "CLI & Libraries",
+        promptKeys: ["rustCli", "rustLibraries", "rustTemplating"],
+      },
+      {
+        id: "quality",
+        label: "Logging & Error Handling",
+        promptKeys: ["rustLogging", "rustErrorHandling"],
+      },
+      {
+        id: "backend-extras",
+        label: "Caching, Realtime & Queues",
+        promptKeys: ["rustCaching", "rustRealtime", "rustMessageQueue"],
+      },
+      {
+        id: "observability",
+        label: "Observability",
+        promptKeys: ["rustObservability"],
+      },
+    ],
+  },
+  python: {
+    core: ["pythonWebFramework", "database", "dbSetup", "pythonOrm", "pythonAuth", "pythonApi"],
+    sections: [
+      {
+        id: "type-safety-ai",
+        label: "Validation & AI",
+        promptKeys: ["pythonValidation", "pythonAi"],
+      },
+      {
+        id: "api-jobs",
+        label: "GraphQL, Tasks & CLI",
+        promptKeys: ["pythonGraphql", "pythonTaskQueue", "pythonCli"],
+      },
+      {
+        id: "data-realtime",
+        label: "Caching & Realtime",
+        promptKeys: ["pythonCaching", "pythonRealtime"],
+      },
+      {
+        id: "quality",
+        label: "Quality, Testing & Observability",
+        promptKeys: ["pythonQuality", "pythonTesting", "pythonObservability"],
+      },
+    ],
+  },
+  go: {
+    core: ["goWebFramework", "database", "dbSetup", "goOrm", "goApi", "goAuth"],
+    sections: [
+      {
+        id: "cli-config",
+        label: "CLI, Config & Logging",
+        promptKeys: ["goCli", "goConfig", "goLogging"],
+      },
+      {
+        id: "backend-extras",
+        label: "Realtime, Queues & Caching",
+        promptKeys: ["goRealtime", "goMessageQueue", "goCaching"],
+      },
+      {
+        id: "quality",
+        label: "Testing & Observability",
+        promptKeys: ["goTesting", "goObservability"],
+      },
+    ],
+  },
+  java: {
+    core: ["javaWebFramework", "javaLanguage", "javaBuildTool", "database", "dbSetup", "javaOrm", "javaAuth", "javaApi"],
+    sections: [
+      {
+        id: "libraries",
+        label: "Libraries",
+        promptKeys: ["javaLibraries"],
+      },
+      {
+        id: "quality",
+        label: "Logging & Testing",
+        promptKeys: ["javaLogging", "javaTestingLibraries"],
+      },
+    ],
+  },
+  dotnet: {
+    core: ["dotnetWebFramework", "database", "dbSetup", "dotnetOrm", "dotnetAuth", "dotnetApi"],
+    sections: [
+      {
+        id: "quality",
+        label: "Testing & Observability",
+        promptKeys: ["dotnetTesting", "dotnetObservability"],
+      },
+      {
+        id: "backend-extras",
+        label: "Jobs, Realtime & Caching",
+        promptKeys: ["dotnetJobQueue", "dotnetRealtime", "dotnetCaching"],
+      },
+      {
+        id: "validation-deploy",
+        label: "Validation & Deployment",
+        promptKeys: ["dotnetValidation", "dotnetDeploy"],
+      },
+    ],
+  },
+  elixir: {
+    core: ["elixirWebFramework", "database", "dbSetup", "elixirOrm", "elixirAuth", "elixirApi"],
+    sections: [
+      {
+        id: "backend-extras",
+        label: "Realtime & Jobs",
+        promptKeys: ["elixirRealtime", "elixirJobs"],
+      },
+      {
+        id: "type-safety-http",
+        label: "Validation, HTTP & JSON",
+        promptKeys: ["elixirValidation", "elixirHttp", "elixirJson"],
+      },
+      {
+        id: "data-email",
+        label: "Email & Caching",
+        promptKeys: ["elixirEmail", "elixirCaching"],
+      },
+      {
+        id: "quality",
+        label: "Testing, Quality & Observability",
+        promptKeys: ["elixirTesting", "elixirQuality", "elixirObservability"],
+      },
+      {
+        id: "deploy-libraries",
+        label: "Deployment & Libraries",
+        promptKeys: ["elixirDeploy", "elixirLibraries"],
+      },
+    ],
+  },
+} as const satisfies Record<Ecosystem, EcosystemScopeRegistry>;
+
+export const SCOPED_CONFIG_PROMPT_KEYS = [
+  ...new Set(
+    Object.values(CONFIG_SCOPE_REGISTRY).flatMap((registry) => [
+      ...registry.core,
+      ...registry.sections.flatMap((section) => section.promptKeys),
+      ...CONFIG_SCOPE_ALWAYS_KEYS,
+    ]),
+  ),
+].sort();
+
+export function getConfigScopePromptKeys(
+  ecosystem: Ecosystem,
+  scope: ConfigScope,
+  selectedSectionIds: string[] = [],
+): Set<ConfigPromptKey> {
+  const registry = CONFIG_SCOPE_REGISTRY[ecosystem];
+  const keys = new Set<ConfigPromptKey>([...registry.core, ...CONFIG_SCOPE_ALWAYS_KEYS]);
+
+  if (scope === "full") {
+    for (const section of registry.sections) {
+      for (const key of section.promptKeys) keys.add(key);
+    }
+  }
+
+  if (scope === "custom") {
+    const selected = new Set(selectedSectionIds);
+    for (const section of registry.sections) {
+      if (!selected.has(section.id)) continue;
+      for (const key of section.promptKeys) keys.add(key);
+    }
+  }
+
+  return keys;
+}
+
+export function shouldAskConfigPromptKey(
+  ecosystem: Ecosystem | undefined,
+  key: ConfigPromptKey,
+  scope: ConfigScope | undefined,
+  selectedSectionIds: string[] | undefined,
+): boolean {
+  if (!ecosystem || !scope || scope === "full") return true;
+  const registry = CONFIG_SCOPE_REGISTRY[ecosystem];
+  const known = new Set<ConfigPromptKey>([
+    ...registry.core,
+    ...registry.sections.flatMap((section) => section.promptKeys),
+    ...CONFIG_SCOPE_ALWAYS_KEYS,
+  ]);
+  // Keys outside this ecosystem's registry (e.g. rust* prompts while
+  // configuring typescript) must run their own ecosystem guard, which resolves
+  // them to the correct "not applicable" value without showing UI. Substituting
+  // getDefaultConfig() values here would leak cross-ecosystem defaults.
+  if (!known.has(key)) return true;
+  return getConfigScopePromptKeys(ecosystem, scope, selectedSectionIds).has(key);
+}
+
+export function getDefaultPromptValue(key: ConfigPromptKey): unknown {
+  if (key === "astroIntegration") return undefined;
+  const defaults = getDefaultConfig();
+  if (key === "shadcnOptions") {
+    // uiLibrary defaults to shadcn-ui, so a skipped shadcn prompt must carry
+    // the default options instead of leaving the config fields undefined.
+    return {
+      shadcnBase: defaults.shadcnBase,
+      shadcnStyle: defaults.shadcnStyle,
+      shadcnIconLibrary: defaults.shadcnIconLibrary,
+      shadcnColorTheme: defaults.shadcnColorTheme,
+      shadcnBaseColor: defaults.shadcnBaseColor,
+      shadcnFont: defaults.shadcnFont,
+      shadcnRadius: defaults.shadcnRadius,
+    };
+  }
+  return defaults[key as keyof ProjectConfig];
+}
+
+export async function getConfigScopeChoice(): Promise<ConfigScope | symbol> {
+  const response = await navigableSelect<ConfigScope>({
+    message: "How much do you want to configure?",
+    options: [
+      {
+        value: "core",
+        label: "Core",
+        hint: "essentials only — framework, database, auth, API; sensible defaults for everything else",
+      },
+      {
+        value: "full",
+        label: "Full",
+        hint: "walk through every option",
+      },
+      {
+        value: "custom",
+        label: "Custom",
+        hint: "pick which sections to configure",
+      },
+    ],
+    initialValue: "core",
+  });
+
+  if (isCancel(response)) return exitCancelled("Operation cancelled");
+  return response;
+}
+
+export async function getConfigSectionsChoice(
+  ecosystem: Ecosystem,
+  initialValues: string[] = [],
+  availableSectionIds?: string[],
+): Promise<string[] | symbol> {
+  const sections = CONFIG_SCOPE_REGISTRY[ecosystem].sections.filter(
+    (section) => !availableSectionIds || availableSectionIds.includes(section.id),
+  );
+  const response = await navigableMultiselect<string>({
+    message: `Which sections do you want to configure? ${pc.dim("(essentials are always included)")}`,
+    options: sections.map((section) => ({
+      value: section.id,
+      label: section.label,
+    })),
+    initialValues,
+    required: false,
+  });
+
+  if (isCancel(response)) return exitCancelled("Operation cancelled");
+  if (isGoBack(response)) return response;
+  return response;
+}

--- a/apps/cli/src/prompts/multi-ecosystem-composer.ts
+++ b/apps/cli/src/prompts/multi-ecosystem-composer.ts
@@ -16,6 +16,14 @@ import { exitCancelled } from "../utils/errors";
 import { getAddonsChoice } from "./addons";
 import { getAiDocsChoice } from "./ai-docs";
 import { getAstroIntegrationChoice } from "./astro-integration";
+import {
+  type ConfigPromptKey,
+  type ConfigScope,
+  getConfigScopeChoice,
+  getConfigSectionsChoice,
+  getDefaultPromptValue,
+  shouldAskConfigPromptKey,
+} from "./config-scope";
 import { getCSSFrameworkChoice } from "./css-framework";
 import { getDatabaseChoice } from "./database";
 import { getDBSetupChoice } from "./database-setup";
@@ -110,7 +118,7 @@ import {
   getRustOrmChoice,
   getRustWebFrameworkChoice,
 } from "./rust-ecosystem";
-import { getShadcnOptions } from "./shadcn-options";
+import { getShadcnOptions, type ShadcnOptions } from "./shadcn-options";
 import { getUILibraryChoice } from "./ui-library";
 import { getDeploymentChoice } from "./web-deploy";
 
@@ -181,6 +189,26 @@ function promptValue<T>(value: T | symbol): T {
   return value;
 }
 
+function hasMultiStackPromptFlags(flags: Partial<ProjectConfig>) {
+  return Object.keys(flags).some(
+    (key) => key !== "projectName" && key !== "projectDir" && key !== "relativePath",
+  );
+}
+
+async function scopedPromptValue<T>(
+  ecosystem: Ecosystem,
+  key: ConfigPromptKey,
+  scope: ConfigScope,
+  selectedSectionIds: string[],
+  prompt: () => Promise<T | symbol>,
+): Promise<T> {
+  if (!shouldAskConfigPromptKey(ecosystem, key, scope, selectedSectionIds)) {
+    return getDefaultPromptValue(key) as T;
+  }
+
+  return promptValue(await prompt());
+}
+
 async function selectDatabaseConfig(flags: Partial<ProjectConfig>) {
   const database = promptValue(await getDatabaseChoice(flags.database, "hono", "bun"));
   const dbSetup = promptValue(
@@ -197,6 +225,16 @@ export async function gatherMultiEcosystemConfig(
   relativePath: string,
 ): Promise<ProjectConfig> {
   const baseConfig = getDefaultConfig();
+  const shouldPromptForScope = !hasMultiStackPromptFlags(flags);
+  const configScope = shouldPromptForScope
+    ? promptValue(await getConfigScopeChoice())
+    : "full";
+  // The multi-ecosystem TS part is frontend-only, so offer only the sections
+  // whose prompts this composer actually asks.
+  const typeScriptSections =
+    configScope === "custom"
+      ? promptValue(await getConfigSectionsChoice("typescript", [], ["ui-styling"]))
+      : [];
 
   const frontend = promptValue(
     await navigableSelect<Frontend>({
@@ -211,27 +249,37 @@ export async function gatherMultiEcosystemConfig(
       ? promptValue(await getAstroIntegrationChoice(flags.astroIntegration))
       : undefined;
   const uiLibrary = hasWebStyling(frontendList)
-    ? promptValue(await getUILibraryChoice(flags.uiLibrary, frontendList, astroIntegration))
+    ? await scopedPromptValue("typescript", "uiLibrary", configScope, typeScriptSections, () =>
+        getUILibraryChoice(flags.uiLibrary, frontendList, astroIntegration),
+      )
     : "none";
   const shadcnOptions =
     uiLibrary === "shadcn-ui"
-      ? promptValue(
-          await getShadcnOptions({
-            shadcnBase: flags.shadcnBase,
-            shadcnStyle: flags.shadcnStyle,
-            shadcnIconLibrary: flags.shadcnIconLibrary,
-            shadcnColorTheme: flags.shadcnColorTheme,
-            shadcnBaseColor: flags.shadcnBaseColor,
-            shadcnFont: flags.shadcnFont,
-            shadcnRadius: flags.shadcnRadius,
-          }),
-        )
+      ? shouldAskConfigPromptKey("typescript", "shadcnOptions", configScope, typeScriptSections)
+        ? promptValue(
+            await getShadcnOptions({
+              shadcnBase: flags.shadcnBase,
+              shadcnStyle: flags.shadcnStyle,
+              shadcnIconLibrary: flags.shadcnIconLibrary,
+              shadcnColorTheme: flags.shadcnColorTheme,
+              shadcnBaseColor: flags.shadcnBaseColor,
+              shadcnFont: flags.shadcnFont,
+              shadcnRadius: flags.shadcnRadius,
+            }),
+          )
+        : (getDefaultPromptValue("shadcnOptions") as ShadcnOptions)
       : undefined;
   const cssFramework = hasWebStyling(frontendList)
-    ? promptValue(await getCSSFrameworkChoice(flags.cssFramework, uiLibrary))
+    ? await scopedPromptValue("typescript", "cssFramework", configScope, typeScriptSections, () =>
+        getCSSFrameworkChoice(flags.cssFramework, uiLibrary),
+      )
     : "none";
 
   const backendEcosystem = await selectBackendEcosystem();
+  const backendSections =
+    configScope === "custom"
+      ? promptValue(await getConfigSectionsChoice(backendEcosystem))
+      : [];
   const stackPartSpecs = [`frontend:typescript:${frontend}`];
   const backendChoices: Partial<ProjectConfig> = {};
   let database: Database = "none";
@@ -253,27 +301,53 @@ export async function gatherMultiEcosystemConfig(
     const goAuth =
       goWebFramework === "none" ? "none" : promptValue(await getGoAuthChoice(flags.goAuth));
     const goCli =
-      goWebFramework === "none" ? "none" : promptValue(await getGoCliChoice(flags.goCli));
+      goWebFramework === "none"
+        ? "none"
+        : await scopedPromptValue("go", "goCli", configScope, backendSections, () =>
+            getGoCliChoice(flags.goCli),
+          );
     const goLogging =
-      goWebFramework === "none" ? "none" : promptValue(await getGoLoggingChoice(flags.goLogging));
+      goWebFramework === "none"
+        ? "none"
+        : await scopedPromptValue("go", "goLogging", configScope, backendSections, () =>
+            getGoLoggingChoice(flags.goLogging),
+          );
     const goTesting =
-      goWebFramework === "none" ? [] : promptValue(await getGoTestingChoice(flags.goTesting));
+      goWebFramework === "none"
+        ? []
+        : await scopedPromptValue("go", "goTesting", configScope, backendSections, () =>
+            getGoTestingChoice(flags.goTesting),
+          );
     const goRealtime =
       goWebFramework === "none"
         ? "none"
-        : promptValue(await getGoRealtimeChoice(flags.goRealtime));
+        : await scopedPromptValue("go", "goRealtime", configScope, backendSections, () =>
+            getGoRealtimeChoice(flags.goRealtime),
+          );
     const goMessageQueue =
       goWebFramework === "none"
         ? "none"
-        : promptValue(await getGoMessageQueueChoice(flags.goMessageQueue));
+        : await scopedPromptValue("go", "goMessageQueue", configScope, backendSections, () =>
+            getGoMessageQueueChoice(flags.goMessageQueue),
+          );
     const goCaching =
-      goWebFramework === "none" ? "none" : promptValue(await getGoCachingChoice(flags.goCaching));
+      goWebFramework === "none"
+        ? "none"
+        : await scopedPromptValue("go", "goCaching", configScope, backendSections, () =>
+            getGoCachingChoice(flags.goCaching),
+          );
     const goConfig =
-      goWebFramework === "none" ? "none" : promptValue(await getGoConfigChoice(flags.goConfig));
+      goWebFramework === "none"
+        ? "none"
+        : await scopedPromptValue("go", "goConfig", configScope, backendSections, () =>
+            getGoConfigChoice(flags.goConfig),
+          );
     const goObservability =
       goWebFramework === "none"
         ? "none"
-        : promptValue(await getGoObservabilityChoice(flags.goObservability));
+        : await scopedPromptValue("go", "goObservability", configScope, backendSections, () =>
+            getGoObservabilityChoice(flags.goObservability),
+          );
     Object.assign(backendChoices, {
       goWebFramework,
       goOrm,
@@ -323,36 +397,60 @@ export async function gatherMultiEcosystemConfig(
       rustWebFramework === "none" ? "none" : promptValue(await getRustAuthChoice(flags.rustAuth));
     const rustFrontend = "none";
     const rustCli =
-      rustWebFramework === "none" ? "none" : promptValue(await getRustCliChoice(flags.rustCli));
+      rustWebFramework === "none"
+        ? "none"
+        : await scopedPromptValue("rust", "rustCli", configScope, backendSections, () =>
+            getRustCliChoice(flags.rustCli),
+          );
     const rustLibraries =
-      rustWebFramework === "none" ? [] : promptValue(await getRustLibrariesChoice(flags.rustLibraries));
+      rustWebFramework === "none"
+        ? []
+        : await scopedPromptValue("rust", "rustLibraries", configScope, backendSections, () =>
+            getRustLibrariesChoice(flags.rustLibraries),
+          );
     const rustLogging =
       rustWebFramework === "none"
         ? "none"
-        : promptValue(await getRustLoggingChoice(flags.rustLogging));
-    const rustErrorHandling = promptValue(
-      await getRustErrorHandlingChoice(flags.rustErrorHandling),
+        : await scopedPromptValue("rust", "rustLogging", configScope, backendSections, () =>
+            getRustLoggingChoice(flags.rustLogging),
+          );
+    const rustErrorHandling = await scopedPromptValue(
+      "rust",
+      "rustErrorHandling",
+      configScope,
+      backendSections,
+      () => getRustErrorHandlingChoice(flags.rustErrorHandling),
     );
     const rustCaching =
       rustWebFramework === "none"
         ? "none"
-        : promptValue(await getRustCachingChoice(flags.rustCaching));
+        : await scopedPromptValue("rust", "rustCaching", configScope, backendSections, () =>
+            getRustCachingChoice(flags.rustCaching),
+          );
     const rustRealtime =
       rustWebFramework === "none"
         ? "none"
-        : promptValue(await getRustRealtimeChoice(flags.rustRealtime));
+        : await scopedPromptValue("rust", "rustRealtime", configScope, backendSections, () =>
+            getRustRealtimeChoice(flags.rustRealtime),
+          );
     const rustMessageQueue =
       rustWebFramework === "none"
         ? "none"
-        : promptValue(await getRustMessageQueueChoice(flags.rustMessageQueue));
+        : await scopedPromptValue("rust", "rustMessageQueue", configScope, backendSections, () =>
+            getRustMessageQueueChoice(flags.rustMessageQueue),
+          );
     const rustObservability =
       rustWebFramework === "none"
         ? "none"
-        : promptValue(await getRustObservabilityChoice(flags.rustObservability));
+        : await scopedPromptValue("rust", "rustObservability", configScope, backendSections, () =>
+            getRustObservabilityChoice(flags.rustObservability),
+          );
     const rustTemplating =
       rustWebFramework === "none"
         ? "none"
-        : promptValue(await getRustTemplatingChoice(flags.rustTemplating));
+        : await scopedPromptValue("rust", "rustTemplating", configScope, backendSections, () =>
+            getRustTemplatingChoice(flags.rustTemplating),
+          );
     Object.assign(backendChoices, {
       rustWebFramework,
       rustOrm,
@@ -401,9 +499,15 @@ export async function gatherMultiEcosystemConfig(
     const pythonValidation =
       pythonWebFramework === "none"
         ? "none"
-        : promptValue(await getPythonValidationChoice(flags.pythonValidation));
+        : await scopedPromptValue("python", "pythonValidation", configScope, backendSections, () =>
+            getPythonValidationChoice(flags.pythonValidation),
+          );
     const pythonAi =
-      pythonWebFramework === "none" ? [] : promptValue(await getPythonAiChoice(flags.pythonAi));
+      pythonWebFramework === "none"
+        ? []
+        : await scopedPromptValue("python", "pythonAi", configScope, backendSections, () =>
+            getPythonAiChoice(flags.pythonAi),
+          );
     const pythonAuth =
       pythonWebFramework === "none"
         ? "none"
@@ -411,33 +515,51 @@ export async function gatherMultiEcosystemConfig(
     const pythonTaskQueue =
       pythonWebFramework === "none"
         ? "none"
-        : promptValue(await getPythonTaskQueueChoice(flags.pythonTaskQueue));
+        : await scopedPromptValue("python", "pythonTaskQueue", configScope, backendSections, () =>
+            getPythonTaskQueueChoice(flags.pythonTaskQueue),
+          );
     const pythonGraphql =
       pythonWebFramework === "none"
         ? "none"
-        : promptValue(await getPythonGraphqlChoice(flags.pythonGraphql));
+        : await scopedPromptValue("python", "pythonGraphql", configScope, backendSections, () =>
+            getPythonGraphqlChoice(flags.pythonGraphql),
+          );
     const pythonQuality =
       pythonWebFramework === "none"
         ? "none"
-        : promptValue(await getPythonQualityChoice(flags.pythonQuality));
+        : await scopedPromptValue("python", "pythonQuality", configScope, backendSections, () =>
+            getPythonQualityChoice(flags.pythonQuality),
+          );
     const pythonTesting =
       pythonWebFramework === "none"
         ? []
-        : promptValue(await getPythonTestingChoice(flags.pythonTesting));
+        : await scopedPromptValue("python", "pythonTesting", configScope, backendSections, () =>
+            getPythonTestingChoice(flags.pythonTesting),
+          );
     const pythonCaching =
       pythonWebFramework === "none"
         ? "none"
-        : promptValue(await getPythonCachingChoice(flags.pythonCaching));
+        : await scopedPromptValue("python", "pythonCaching", configScope, backendSections, () =>
+            getPythonCachingChoice(flags.pythonCaching),
+          );
     const pythonRealtime =
       pythonWebFramework === "none"
         ? "none"
-        : promptValue(await getPythonRealtimeChoice(flags.pythonRealtime));
+        : await scopedPromptValue("python", "pythonRealtime", configScope, backendSections, () =>
+            getPythonRealtimeChoice(flags.pythonRealtime),
+          );
     const pythonObservability =
       pythonWebFramework === "none"
         ? "none"
-        : promptValue(await getPythonObservabilityChoice(flags.pythonObservability));
+        : await scopedPromptValue("python", "pythonObservability", configScope, backendSections, () =>
+            getPythonObservabilityChoice(flags.pythonObservability),
+          );
     const pythonCli =
-      pythonWebFramework === "none" ? [] : promptValue(await getPythonCliChoice(flags.pythonCli));
+      pythonWebFramework === "none"
+        ? []
+        : await scopedPromptValue("python", "pythonCli", configScope, backendSections, () =>
+            getPythonCliChoice(flags.pythonCli),
+          );
     Object.assign(backendChoices, {
       pythonWebFramework,
       pythonOrm,
@@ -492,9 +614,15 @@ export async function gatherMultiEcosystemConfig(
     const javaLibraries =
       javaWebFramework !== "spring-boot" || javaBuildTool === "none"
         ? []
-        : promptValue(await getJavaLibrariesChoice(flags.javaLibraries));
-    const javaTestingLibraries = promptValue(
-      await getJavaTestingLibrariesChoice(flags.javaTestingLibraries),
+        : await scopedPromptValue("java", "javaLibraries", configScope, backendSections, () =>
+            getJavaLibrariesChoice(flags.javaLibraries),
+          );
+    const javaTestingLibraries = await scopedPromptValue(
+      "java",
+      "javaTestingLibraries",
+      configScope,
+      backendSections,
+      () => getJavaTestingLibrariesChoice(flags.javaTestingLibraries),
     );
     const javaApi =
       javaWebFramework !== "spring-boot" || javaBuildTool === "none"
@@ -503,7 +631,9 @@ export async function gatherMultiEcosystemConfig(
     const javaLogging =
       javaWebFramework !== "spring-boot" || javaBuildTool === "none"
         ? "none"
-        : promptValue(await getJavaLoggingChoice(flags.javaLogging));
+        : await scopedPromptValue("java", "javaLogging", configScope, backendSections, () =>
+            getJavaLoggingChoice(flags.javaLogging),
+          );
     Object.assign(backendChoices, {
       javaWebFramework,
       javaBuildTool,
@@ -545,31 +675,45 @@ export async function gatherMultiEcosystemConfig(
     const dotnetTesting =
       dotnetWebFramework === "none"
         ? []
-        : promptValue(await getDotnetTestingChoice(flags.dotnetTesting));
+        : await scopedPromptValue("dotnet", "dotnetTesting", configScope, backendSections, () =>
+            getDotnetTestingChoice(flags.dotnetTesting),
+          );
     const dotnetJobQueue =
       dotnetWebFramework === "none"
         ? "none"
-        : promptValue(await getDotnetJobQueueChoice(flags.dotnetJobQueue));
+        : await scopedPromptValue("dotnet", "dotnetJobQueue", configScope, backendSections, () =>
+            getDotnetJobQueueChoice(flags.dotnetJobQueue),
+          );
     const dotnetRealtime =
       dotnetWebFramework === "none"
         ? "none"
-        : promptValue(await getDotnetRealtimeChoice(flags.dotnetRealtime));
+        : await scopedPromptValue("dotnet", "dotnetRealtime", configScope, backendSections, () =>
+            getDotnetRealtimeChoice(flags.dotnetRealtime),
+          );
     const dotnetObservability =
       dotnetWebFramework === "none"
         ? []
-        : promptValue(await getDotnetObservabilityChoice(flags.dotnetObservability));
+        : await scopedPromptValue("dotnet", "dotnetObservability", configScope, backendSections, () =>
+            getDotnetObservabilityChoice(flags.dotnetObservability),
+          );
     const dotnetValidation =
       dotnetWebFramework === "none"
         ? "none"
-        : promptValue(await getDotnetValidationChoice(flags.dotnetValidation));
+        : await scopedPromptValue("dotnet", "dotnetValidation", configScope, backendSections, () =>
+            getDotnetValidationChoice(flags.dotnetValidation),
+          );
     const dotnetCaching =
       dotnetWebFramework === "none"
         ? "none"
-        : promptValue(await getDotnetCachingChoice(flags.dotnetCaching));
+        : await scopedPromptValue("dotnet", "dotnetCaching", configScope, backendSections, () =>
+            getDotnetCachingChoice(flags.dotnetCaching),
+          );
     const dotnetDeploy =
       dotnetWebFramework === "none"
         ? "none"
-        : promptValue(await getDotnetDeployChoice(flags.dotnetDeploy));
+        : await scopedPromptValue("dotnet", "dotnetDeploy", configScope, backendSections, () =>
+            getDotnetDeployChoice(flags.dotnetDeploy),
+          );
     Object.assign(backendChoices, {
       dotnetWebFramework,
       dotnetOrm,
@@ -636,51 +780,75 @@ export async function gatherMultiEcosystemConfig(
     const elixirRealtime =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirRealtimeChoice(flags.elixirRealtime));
+        : await scopedPromptValue("elixir", "elixirRealtime", configScope, backendSections, () =>
+            getElixirRealtimeChoice(flags.elixirRealtime),
+          );
     const elixirJobs =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirJobsChoice(flags.elixirJobs));
+        : await scopedPromptValue("elixir", "elixirJobs", configScope, backendSections, () =>
+            getElixirJobsChoice(flags.elixirJobs),
+          );
     const elixirValidation =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirValidationChoice(flags.elixirValidation));
+        : await scopedPromptValue("elixir", "elixirValidation", configScope, backendSections, () =>
+            getElixirValidationChoice(flags.elixirValidation),
+          );
     const elixirHttp =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirHttpChoice(flags.elixirHttp));
+        : await scopedPromptValue("elixir", "elixirHttp", configScope, backendSections, () =>
+            getElixirHttpChoice(flags.elixirHttp),
+          );
     const elixirJson =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirJsonChoice(flags.elixirJson));
+        : await scopedPromptValue("elixir", "elixirJson", configScope, backendSections, () =>
+            getElixirJsonChoice(flags.elixirJson),
+          );
     const elixirEmail =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirEmailChoice(flags.elixirEmail));
+        : await scopedPromptValue("elixir", "elixirEmail", configScope, backendSections, () =>
+            getElixirEmailChoice(flags.elixirEmail),
+          );
     const elixirCaching =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirCachingChoice(flags.elixirCaching));
+        : await scopedPromptValue("elixir", "elixirCaching", configScope, backendSections, () =>
+            getElixirCachingChoice(flags.elixirCaching),
+          );
     const elixirObservability =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirObservabilityChoice(flags.elixirObservability));
+        : await scopedPromptValue("elixir", "elixirObservability", configScope, backendSections, () =>
+            getElixirObservabilityChoice(flags.elixirObservability),
+          );
     const elixirTesting =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirTestingChoice(flags.elixirTesting));
+        : await scopedPromptValue("elixir", "elixirTesting", configScope, backendSections, () =>
+            getElixirTestingChoice(flags.elixirTesting),
+          );
     const elixirQuality =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirQualityChoice(flags.elixirQuality));
+        : await scopedPromptValue("elixir", "elixirQuality", configScope, backendSections, () =>
+            getElixirQualityChoice(flags.elixirQuality),
+          );
     const elixirDeploy =
       elixirWebFramework === "none"
         ? "none"
-        : promptValue(await getElixirDeployChoice(flags.elixirDeploy));
+        : await scopedPromptValue("elixir", "elixirDeploy", configScope, backendSections, () =>
+            getElixirDeployChoice(flags.elixirDeploy),
+          );
     const elixirLibraries =
       elixirWebFramework === "none"
         ? []
-        : promptValue(await getElixirLibrariesChoice(flags.elixirLibraries));
+        : await scopedPromptValue("elixir", "elixirLibraries", configScope, backendSections, () =>
+            getElixirLibrariesChoice(flags.elixirLibraries),
+          );
     Object.assign(backendChoices, {
       elixirWebFramework,
       elixirOrm,
@@ -725,13 +893,28 @@ export async function gatherMultiEcosystemConfig(
 
   const stackParts = parseStackPartSpecs(stackPartSpecs, "selected");
   const graphPartial = stackPartsToLegacyProjectConfigPartial(stackParts);
-  const addons = promptValue(
-    await getAddonsChoice(flags.addons, frontendList, "none", "none", "bun"),
+  const addons = await scopedPromptValue(
+    "typescript",
+    "addons",
+    configScope,
+    typeScriptSections,
+    () => getAddonsChoice(flags.addons, frontendList, "none", "none", "bun"),
   );
-  const webDeploy = promptValue(
-    await getDeploymentChoice(flags.webDeploy, "bun", "none", frontendList),
+  const webDeploy = await scopedPromptValue(
+    "typescript",
+    "webDeploy",
+    configScope,
+    typeScriptSections,
+    () => getDeploymentChoice(flags.webDeploy, "bun", "none", frontendList),
   );
-  const serverDeploy = await selectServerDeployment(flags.serverDeploy);
+  const serverDeploy = shouldAskConfigPromptKey(
+    "typescript",
+    "serverDeploy",
+    configScope,
+    typeScriptSections,
+  )
+    ? await selectServerDeployment(flags.serverDeploy)
+    : (getDefaultPromptValue("serverDeploy") as ServerDeploy);
   const aiDocs = promptValue(await getAiDocsChoice(flags.aiDocs));
   const git = promptValue(await getGitChoice(flags.git));
   const packageManager = promptValue(await getPackageManagerChoice(flags.packageManager));

--- a/apps/cli/src/prompts/multi-ecosystem-composer.ts
+++ b/apps/cli/src/prompts/multi-ecosystem-composer.ts
@@ -229,11 +229,16 @@ export async function gatherMultiEcosystemConfig(
   const configScope = shouldPromptForScope
     ? promptValue(await getConfigScopeChoice())
     : "full";
-  // The multi-ecosystem TS part is frontend-only, so offer only the sections
-  // whose prompts this composer actually asks.
+  // Offer only the TypeScript sections whose prompts this composer actually asks.
   const typeScriptSections =
     configScope === "custom"
-      ? promptValue(await getConfigSectionsChoice("typescript", [], ["ui-styling"]))
+      ? promptValue(
+          await getConfigSectionsChoice("typescript", [], [
+            "ui-styling",
+            "deploy",
+            "addons-examples",
+          ]),
+        )
       : [];
 
   const frontend = promptValue(

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -59,16 +59,7 @@ export async function getServerDeploymentChoice(
     return "cloudflare";
   }
 
-  const options: DeploymentOption[] = [
-    { value: "none", label: "None", hint: "Skip server deployment setup" },
-    { value: "railway", label: "Railway", hint: "Deploy with Railway cloud development platform" },
-    { value: "fly", label: "Fly.io", hint: "Deploy globally with Fly.io edge platform" },
-    { value: "render", label: "Render", hint: "Deploy with Render's Blueprint and Docker builds" },
-    { value: "netlify", label: "Netlify", hint: "Deploy Hono APIs with Netlify Functions" },
-    { value: "docker", label: "Docker", hint: "Container-based deployment with Dockerfile" },
-    { value: "sst", label: "SST", hint: "Deploy to AWS with SST (Serverless Stack)" },
-    { value: "vercel", label: "Vercel", hint: "Deploy to Vercel's edge network with zero config" },
-  ];
+  const options = getServerDeploymentOptions(runtime);
 
   const response = await navigableSelect<ServerDeploy>({
     message: "Select server deployment",
@@ -79,6 +70,27 @@ export async function getServerDeploymentChoice(
   if (isCancel(response)) return exitCancelled("Operation cancelled");
 
   return response;
+}
+
+export function getServerDeploymentOptions(runtime?: Runtime): DeploymentOption[] {
+  return [
+    { value: "none", label: "None", hint: "Skip server deployment setup" },
+    { value: "railway", label: "Railway", hint: "Deploy with Railway cloud development platform" },
+    { value: "fly", label: "Fly.io", hint: "Deploy globally with Fly.io edge platform" },
+    { value: "render", label: "Render", hint: "Deploy with Render's Blueprint and Docker builds" },
+    ...(runtime === "node"
+      ? [
+          {
+            value: "netlify" as const,
+            label: "Netlify",
+            hint: "Deploy Hono APIs with Netlify Functions",
+          },
+        ]
+      : []),
+    { value: "docker", label: "Docker", hint: "Container-based deployment with Dockerfile" },
+    { value: "sst", label: "SST", hint: "Deploy to AWS with SST (Serverless Stack)" },
+    { value: "vercel", label: "Vercel", hint: "Deploy to Vercel's edge network with zero config" },
+  ];
 }
 
 export async function getServerDeploymentToAdd(

--- a/apps/cli/src/prompts/server-deploy.ts
+++ b/apps/cli/src/prompts/server-deploy.ts
@@ -59,7 +59,26 @@ export async function getServerDeploymentChoice(
     return "cloudflare";
   }
 
-  return "none";
+  const options: DeploymentOption[] = [
+    { value: "none", label: "None", hint: "Skip server deployment setup" },
+    { value: "railway", label: "Railway", hint: "Deploy with Railway cloud development platform" },
+    { value: "fly", label: "Fly.io", hint: "Deploy globally with Fly.io edge platform" },
+    { value: "render", label: "Render", hint: "Deploy with Render's Blueprint and Docker builds" },
+    { value: "netlify", label: "Netlify", hint: "Deploy Hono APIs with Netlify Functions" },
+    { value: "docker", label: "Docker", hint: "Container-based deployment with Dockerfile" },
+    { value: "sst", label: "SST", hint: "Deploy to AWS with SST (Serverless Stack)" },
+    { value: "vercel", label: "Vercel", hint: "Deploy to Vercel's edge network with zero config" },
+  ];
+
+  const response = await navigableSelect<ServerDeploy>({
+    message: "Select server deployment",
+    options,
+    initialValue: DEFAULT_CONFIG.serverDeploy,
+  });
+
+  if (isCancel(response)) return exitCancelled("Operation cancelled");
+
+  return response;
 }
 
 export async function getServerDeploymentToAdd(

--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -10,6 +10,7 @@ import { historyHandler } from "./commands/history";
 import { telemetryHandler } from "./commands/telemetry";
 import { CreateCommandInputSchema, CreateCommandOptionsSchema } from "./create-command-input";
 import { createProjectHandler } from "./helpers/core/command-handlers";
+import { BUILDER_URL } from "./constants";
 import {
   type AddInput,
   type Addons,
@@ -261,7 +262,6 @@ export const router = os.router({
   builder: os
     .meta({ description: "Open the interactive web-based stack builder at better-fullstack.dev" })
     .handler(async () => {
-      const BUILDER_URL = "https://better-fullstack-web.vercel.app/new";
       try {
         await openUrl(BUILDER_URL);
         log.success(pc.blue("Opened builder in your default browser."));

--- a/apps/cli/src/utils/open-url.ts
+++ b/apps/cli/src/utils/open-url.ts
@@ -1,20 +1,15 @@
-import { log } from "@clack/prompts";
 import { $ } from "execa";
 
 export async function openUrl(url: string) {
   const platform = process.platform;
 
-  try {
-    if (platform === "darwin") {
-      await $({ stdio: "ignore" })`open ${url}`;
-    } else if (platform === "win32") {
-      // Windows needs special handling for ampersands
-      const escapedUrl = url.replace(/&/g, "^&");
-      await $({ stdio: "ignore" })`cmd /c start "" ${escapedUrl}`;
-    } else {
-      await $({ stdio: "ignore" })`xdg-open ${url}`;
-    }
-  } catch {
-    log.message(`Please open ${url} in your browser.`);
+  if (platform === "darwin") {
+    await $({ stdio: "ignore" })`open ${url}`;
+  } else if (platform === "win32") {
+    // Windows needs special handling for ampersands
+    const escapedUrl = url.replace(/&/g, "^&");
+    await $({ stdio: "ignore" })`cmd /c start "" ${escapedUrl}`;
+  } else {
+    await $({ stdio: "ignore" })`xdg-open ${url}`;
   }
 }

--- a/apps/cli/test/builder-recommendation.test.ts
+++ b/apps/cli/test/builder-recommendation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+
+import { shouldShowBuilderRecommendationPrompt } from "../src/helpers/core/command-handlers";
+
+function shouldShow({
+  input = {},
+  hasConfigBase = false,
+  environment = {},
+}: Parameters<typeof shouldShowBuilderRecommendationPrompt>[0]) {
+  return shouldShowBuilderRecommendationPrompt({
+    input,
+    hasConfigBase,
+    environment: {
+      npmConfigUserAgent: "bun/1.2.0 npm/? node/v22",
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      ...environment,
+    },
+  });
+}
+
+describe("builder recommendation prompt gate", () => {
+  it("shows for a package-manager create invocation in an interactive bare run", () => {
+    expect(shouldShow({ input: {} })).toBe(true);
+  });
+
+  it("requires a package-manager user agent unless forced", () => {
+    expect(
+      shouldShow({
+        input: {},
+        environment: { npmConfigUserAgent: undefined },
+      }),
+    ).toBe(false);
+    expect(
+      shouldShow({
+        input: {},
+        environment: {
+          npmConfigUserAgent: undefined,
+          forceBuilderPrompt: "1",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not bypass interactivity for the force override", () => {
+    expect(
+      shouldShow({
+        input: {},
+        environment: {
+          npmConfigUserAgent: undefined,
+          forceBuilderPrompt: "1",
+          stdinIsTTY: false,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("can be skipped with BFS_SKIP_BUILDER_PROMPT", () => {
+    expect(
+      shouldShow({
+        input: {},
+        environment: { skipBuilderPrompt: "1" },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not show outside interactive terminals or inside CI", () => {
+    expect(shouldShow({ input: {}, environment: { stdinIsTTY: false } })).toBe(false);
+    expect(shouldShow({ input: {}, environment: { stdoutIsTTY: false } })).toBe(false);
+    expect(shouldShow({ input: {}, environment: { ci: "1" } })).toBe(false);
+  });
+
+  it("does not show when stack/config shortcuts are present", () => {
+    expect(shouldShow({ input: { frontend: ["next"] } })).toBe(false);
+    expect(shouldShow({ input: { yes: true } })).toBe(false);
+    expect(shouldShow({ input: { part: ["frontend:typescript:next"] } })).toBe(false);
+    expect(shouldShow({ input: { config: "bts.jsonc" } })).toBe(false);
+    expect(shouldShow({ input: {}, hasConfigBase: true })).toBe(false);
+  });
+});

--- a/apps/cli/test/builder-recommendation.test.ts
+++ b/apps/cli/test/builder-recommendation.test.ts
@@ -73,6 +73,7 @@ describe("builder recommendation prompt gate", () => {
   it("does not show when stack/config shortcuts are present", () => {
     expect(shouldShow({ input: { frontend: ["next"] } })).toBe(false);
     expect(shouldShow({ input: { yes: true } })).toBe(false);
+    expect(shouldShow({ input: { dryRun: true } })).toBe(false);
     expect(shouldShow({ input: { part: ["frontend:typescript:next"] } })).toBe(false);
     expect(shouldShow({ input: { config: "bts.jsonc" } })).toBe(false);
     expect(shouldShow({ input: {}, hasConfigBase: true })).toBe(false);

--- a/apps/cli/test/cms.test.ts
+++ b/apps/cli/test/cms.test.ts
@@ -901,6 +901,11 @@ describe("CMS Options", () => {
         }),
       );
       expectSuccess(result);
+
+      const webPkg = await Bun.file(`${result.projectDir}/apps/web/package.json`).json();
+      expect(webPkg.dependencies["@strapi/client"]).toBeDefined();
+      expect(webPkg.dependencies.qs).toBeDefined();
+      expect(webPkg.devDependencies["@types/qs"]).toBeDefined();
     });
 
     test("strapi with Vinext and PostgreSQL", async () => {

--- a/apps/cli/test/config-scope.test.ts
+++ b/apps/cli/test/config-scope.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  CONFIG_PROMPT_ENTRY_KEYS,
+} from "../src/prompts/config-prompts";
+import {
+  CONFIG_SCOPE_ALWAYS_KEYS,
+  CONFIG_SCOPE_REGISTRY,
+  SCOPED_CONFIG_PROMPT_KEYS,
+  shouldAskConfigPromptKey,
+} from "../src/prompts/config-scope";
+
+const META_KEYS = new Set(["ecosystem", "configScope", "configSections"]);
+
+describe("configuration scope registry", () => {
+  it("classifies every gatherConfig prompt key and only gatherConfig prompt keys", () => {
+    const scopedPromptEntries = CONFIG_PROMPT_ENTRY_KEYS.filter((key) => !META_KEYS.has(key));
+
+    expect([...SCOPED_CONFIG_PROMPT_KEYS].sort()).toEqual([...scopedPromptEntries].sort());
+  });
+
+  it("does not duplicate prompt keys within an ecosystem registry", () => {
+    for (const [ecosystem, registry] of Object.entries(CONFIG_SCOPE_REGISTRY)) {
+      const keys = [
+        ...registry.core,
+        ...registry.sections.flatMap((section) => section.promptKeys),
+        ...CONFIG_SCOPE_ALWAYS_KEYS,
+      ];
+      const duplicates = keys.filter((key, index) => keys.indexOf(key) !== index);
+
+      expect(duplicates, `${ecosystem} has duplicate scoped prompt keys`).toEqual([]);
+    }
+  });
+
+  it("keeps TypeScript sections aligned with the CLI onboarding spec", () => {
+    expect(CONFIG_SCOPE_REGISTRY.typescript.core).toEqual([
+      "frontend",
+      "astroIntegration",
+      "backend",
+      "runtime",
+      "database",
+      "orm",
+      "api",
+      "auth",
+      "dbSetup",
+    ]);
+    expect(CONFIG_SCOPE_REGISTRY.typescript.sections.map((section) => section.id)).toEqual([
+      "ui-styling",
+      "state-forms",
+      "type-safety",
+      "payments-email",
+      "ai",
+      "data-storage",
+      "backend-extras",
+      "quality",
+      "content",
+      "deploy",
+      "addons-examples",
+    ]);
+  });
+});
+
+describe("shouldAskConfigPromptKey", () => {
+  it("delegates keys from other ecosystems to the prompt's own guard", () => {
+    expect(shouldAskConfigPromptKey("rust", "frontend", "core", [])).toBe(true);
+    expect(shouldAskConfigPromptKey("rust", "uiLibrary", "core", [])).toBe(true);
+    expect(shouldAskConfigPromptKey("typescript", "rustWebFramework", "core", [])).toBe(true);
+  });
+
+  it("skips unselected extras for the active ecosystem", () => {
+    expect(shouldAskConfigPromptKey("rust", "rustCaching", "core", [])).toBe(false);
+    expect(shouldAskConfigPromptKey("typescript", "payments", "core", [])).toBe(false);
+    expect(shouldAskConfigPromptKey("typescript", "payments", "custom", ["payments-email"])).toBe(
+      true,
+    );
+    expect(shouldAskConfigPromptKey("typescript", "payments", "full", [])).toBe(true);
+  });
+});

--- a/apps/cli/test/config-scope.test.ts
+++ b/apps/cli/test/config-scope.test.ts
@@ -77,6 +77,16 @@ describe("shouldAskConfigPromptKey", () => {
     );
     expect(shouldAskConfigPromptKey("typescript", "payments", "full", [])).toBe(true);
   });
+
+  it("scopes shared service prompts for non-TypeScript ecosystems", () => {
+    expect(shouldAskConfigPromptKey("go", "email", "core", [])).toBe(false);
+    expect(shouldAskConfigPromptKey("python", "search", "core", [])).toBe(false);
+    expect(shouldAskConfigPromptKey("rust", "observability", "custom", [])).toBe(false);
+    expect(shouldAskConfigPromptKey("dotnet", "caching", "custom", ["shared-services"])).toBe(
+      true,
+    );
+    expect(shouldAskConfigPromptKey("java", "email", "full", [])).toBe(true);
+  });
 });
 
 describe("scoped prompt defaults", () => {
@@ -93,6 +103,58 @@ describe("scoped prompt defaults", () => {
         {},
       ),
     ).resolves.toBe("cloudflare");
+  });
+
+  it("keeps skipped server deployment non-interactive when Hono can run without deployment", async () => {
+    await expect(
+      getScopedDefaultPromptValue(
+        "serverDeploy",
+        {
+          ecosystem: "typescript",
+          backend: "hono",
+          runtime: "bun",
+          webDeploy: "none",
+        },
+        {},
+      ),
+    ).resolves.toBe("none");
+  });
+
+  it("uses contextual UI defaults when UI styling is skipped", async () => {
+    await expect(
+      getScopedDefaultPromptValue(
+        "uiLibrary",
+        {
+          ecosystem: "typescript",
+          frontend: ["svelte"],
+        },
+        {},
+      ),
+    ).resolves.toBe("daisyui");
+  });
+
+  it("uses Effect backend defaults when type-safety prompts are skipped", async () => {
+    await expect(
+      getScopedDefaultPromptValue(
+        "effect",
+        {
+          ecosystem: "typescript",
+          backend: "effect",
+        },
+        {},
+      ),
+    ).resolves.toBe("effect-full");
+
+    await expect(
+      getScopedDefaultPromptValue(
+        "validation",
+        {
+          ecosystem: "typescript",
+          backend: "effect",
+        },
+        {},
+      ),
+    ).resolves.toBe("effect-schema");
   });
 
   it("treats individual shadcn option flags as stack prompt intent", () => {

--- a/apps/cli/test/config-scope.test.ts
+++ b/apps/cli/test/config-scope.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 
 import {
   CONFIG_PROMPT_ENTRY_KEYS,
+  getScopedDefaultPromptValue,
+  hasStackPromptFlags,
 } from "../src/prompts/config-prompts";
 import {
   CONFIG_SCOPE_ALWAYS_KEYS,
@@ -74,5 +76,26 @@ describe("shouldAskConfigPromptKey", () => {
       true,
     );
     expect(shouldAskConfigPromptKey("typescript", "payments", "full", [])).toBe(true);
+  });
+});
+
+describe("scoped prompt defaults", () => {
+  it("preserves contextual server deployment defaults when deployment prompts are skipped", async () => {
+    await expect(
+      getScopedDefaultPromptValue(
+        "serverDeploy",
+        {
+          ecosystem: "typescript",
+          backend: "hono",
+          runtime: "workers",
+          webDeploy: "none",
+        },
+        {},
+      ),
+    ).resolves.toBe("cloudflare");
+  });
+
+  it("treats individual shadcn option flags as stack prompt intent", () => {
+    expect(hasStackPromptFlags({ shadcnStyle: "vega" })).toBe(true);
   });
 });

--- a/apps/cli/test/server-deploy-prompt.test.ts
+++ b/apps/cli/test/server-deploy-prompt.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+
+import { getServerDeploymentOptions } from "../src/prompts/server-deploy";
+
+describe("server deployment prompt", () => {
+  it("does not offer Netlify unless the runtime is Node", async () => {
+    expect(getServerDeploymentOptions("bun").map((option) => option.value)).not.toContain(
+      "netlify",
+    );
+
+    expect(getServerDeploymentOptions("node").map((option) => option.value)).toContain("netlify");
+  });
+});

--- a/packages/template-generator/src/processors/cms-deps.ts
+++ b/packages/template-generator/src/processors/cms-deps.ts
@@ -4,6 +4,15 @@ import type { VirtualFileSystem } from "../core/virtual-fs";
 
 import { addPackageDependency, type AvailableDependencies } from "../utils/add-deps";
 
+const REACT_CMS_FRONTENDS = new Set([
+  "tanstack-router",
+  "react-router",
+  "react-vite",
+  "tanstack-start",
+  "next",
+  "vinext",
+]);
+
 export function processCMSDeps(vfs: VirtualFileSystem, config: ProjectConfig): void {
   const { cms, frontend, database } = config;
   if (!cms || cms === "none") return;
@@ -14,9 +23,7 @@ export function processCMSDeps(vfs: VirtualFileSystem, config: ProjectConfig): v
     frontend.includes("astro") ||
     frontend.includes("nuxt") ||
     frontend.includes("svelte") ||
-    frontend.some((f) =>
-      ["tanstack-router", "react-router", "react-vite", "tanstack-start"].includes(f),
-    );
+    frontend.some((f) => REACT_CMS_FRONTENDS.has(f));
 
   if (cms === "payload") {
     if (!hasNext) return;

--- a/testing/cli-scope-e2e-2026-07-07/run.sh
+++ b/testing/cli-scope-e2e-2026-07-07/run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASE="$ROOT/testing/cli-scope-e2e-2026-07-07"
+RUNS="$BASE/runs"
+EXPECT_SCRIPT="$BASE/scenario.exp"
+
+rm -rf "$RUNS"
+mkdir -p "$RUNS"
+
+pass_count=0
+fail_count=0
+
+contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq "$(echo "$needle" | tr -d '[:space:]')" "$file"
+}
+
+not_contains() {
+  local file="$1"
+  local needle="$2"
+  ! grep -Fq "$(echo "$needle" | tr -d '[:space:]')" "$file"
+}
+
+normalize_transcript() {
+  local source="$1"
+  local dest="$2"
+  perl -0pe 's/\e\[[0-9;?]*[ -\/]*[@-~]//g' "$source" | tr -d '[:space:]' > "$dest"
+}
+
+run_scenario() {
+  local id="$1"
+  local label="$2"
+  local use_user_agent="$3"
+  local workdir="$RUNS/$id"
+  local project="cli-scope-$id"
+  local transcript="$RUNS/$id.transcript"
+  mkdir -p "$workdir"
+
+  if /usr/bin/expect "$EXPECT_SCRIPT" "$id" "$ROOT" "$workdir" "$project" "$transcript" "$use_user_agent" >/dev/null 2>&1; then
+    local normalized="$RUNS/$id.normalized"
+    normalize_transcript "$transcript" "$normalized"
+    if validate_scenario "$id" "$normalized" "$workdir/$project"; then
+      echo "PASS $id - $label"
+      pass_count=$((pass_count + 1))
+      return
+    fi
+  fi
+
+  echo "FAIL $id - $label"
+  echo "  transcript: $transcript"
+  fail_count=$((fail_count + 1))
+}
+
+validate_scenario() {
+  local id="$1"
+  local transcript="$2"
+  local project_dir="$3"
+
+  case "$id" in
+    s1)
+      contains "$transcript" "Prefer a visual builder?" &&
+        contains "$transcript" "How much do you want to configure?" &&
+        contains "$transcript" "Project created" &&
+        not_contains "$transcript" "Select payments provider" &&
+        not_contains "$transcript" "Select caching solution" &&
+        test -f "$project_dir/bts.jsonc"
+      ;;
+    s2)
+      contains "$transcript" "Prefer a visual builder?" &&
+        contains "$transcript" "Payments & Email" &&
+        contains "$transcript" "Deployment" &&
+        contains "$transcript" "Select payments provider" &&
+        contains "$transcript" "Select web deployment" &&
+        contains "$transcript" "Select server deployment" &&
+        not_contains "$transcript" "Select caching solution" &&
+        not_contains "$transcript" "Select testing framework" &&
+        contains "$transcript" "Project created" &&
+        test -f "$project_dir/bts.jsonc"
+      ;;
+    s3)
+      contains "$transcript" "Prefer a visual builder?" &&
+        contains "$transcript" "Full" &&
+        contains "$transcript" "Project created" &&
+        test -f "$project_dir/bts.jsonc"
+      ;;
+    s4)
+      contains "$transcript" "Prefer a visual builder?" &&
+        { contains "$transcript" "Opened Web Builder in your browser." || contains "$transcript" "Please visit https://better-fullstack-web.vercel.app/new"; } &&
+        not_contains "$transcript" "Select ecosystem"
+      ;;
+    s5)
+      not_contains "$transcript" "Prefer a visual builder?" &&
+        contains "$transcript" "How much do you want to configure?" &&
+        contains "$transcript" "Project created" &&
+        test -f "$project_dir/bts.jsonc"
+      ;;
+    s6)
+      contains "$transcript" "Prefer a visual builder?" &&
+        contains "$transcript" "Select project composition" &&
+        contains "$transcript" "Select backend ecosystem" &&
+        contains "$transcript" "How much do you want to configure?" &&
+        contains "$transcript" "Project created" &&
+        test -f "$project_dir/bts.jsonc"
+      ;;
+    s7)
+      contains "$transcript" "How much do you want to configure?" &&
+        contains "$transcript" "Select Rust web framework" &&
+        contains "$transcript" "Project created" &&
+        not_contains "$transcript" "Select Rust caching library" &&
+        not_contains "$transcript" "Select Rust message queue" &&
+        test -f "$project_dir/bts.jsonc" &&
+        ! grep -q "tanstack-router" "$project_dir/bts.jsonc"
+      ;;
+  esac
+}
+
+run_scenario s1 "builder panel, Continue in CLI, Core scope skips extras" 1
+run_scenario s2 "builder panel, Custom scope asks payments/email and deployment only" 1
+run_scenario s3 "builder panel, Full scope completes" 1
+run_scenario s4 "builder panel opens Web Builder and exits" 1
+run_scenario s5 "no package-manager user agent skips builder but still asks scope" 0
+run_scenario s6 "multi-ecosystem Core scope completes" 1
+run_scenario s7 "rust ecosystem Core scope skips extras without TS leakage" 1
+
+echo "Summary: $pass_count PASS, $fail_count FAIL"
+test "$fail_count" -eq 0

--- a/testing/cli-scope-e2e-2026-07-07/scenario.exp
+++ b/testing/cli-scope-e2e-2026-07-07/scenario.exp
@@ -1,0 +1,251 @@
+#!/usr/bin/expect -f
+
+set scenario [lindex $argv 0]
+set repo [lindex $argv 1]
+set workdir [lindex $argv 2]
+set project [lindex $argv 3]
+set transcript [lindex $argv 4]
+set use_user_agent [lindex $argv 5]
+
+set timeout 240
+log_file -noappend $transcript
+
+set env(BTS_TELEMETRY_DISABLED) 1
+if {$use_user_agent == "1"} {
+  set env(npm_config_user_agent) "bun/1.2.0 npm/? node/v22"
+} else {
+  catch {unset env(npm_config_user_agent)}
+}
+
+proc down {count} {
+  for {set i 0} {$i < $count} {incr i} {
+    send "\033\[B"
+    sleep 0.2
+  }
+}
+
+proc choose_no {} {
+  send "\033\[C"
+  sleep 0.2
+  send "\r"
+}
+
+proc choose_none_ai_docs {} {
+  down 3
+  send " "
+  sleep 0.05
+  send "\r"
+}
+
+proc choose_scope {scenario} {
+  sleep 0.3
+  if {$scenario == "s2"} {
+    down 2
+    sleep 0.2
+    send "\r"
+    return
+  }
+  if {$scenario == "s3"} {
+    down 1
+    sleep 0.2
+    send "\r"
+    return
+  }
+  send "\r"
+}
+
+proc choose_sections {scenario} {
+  sleep 1.0
+  if {$scenario == "s2"} {
+    down 3
+    sleep 0.5
+    send " "
+    sleep 0.5
+    down 6
+    sleep 0.5
+    send " "
+    sleep 0.5
+    send "\r"
+    return
+  }
+  send "\r"
+}
+
+proc letters_re {text} {
+  set out ""
+  foreach char [split $text ""] {
+    append out [string map {
+      "\\" "\\\\"
+      "." "\\."
+      "*" "\\*"
+      "+" "\\+"
+      "?" "\\?"
+      "^" "\\^"
+      "$" "\\$"
+      "(" "\\("
+      ")" "\\)"
+      "[" "\\["
+      "]" "\\]"
+      "{" "\\{"
+      "}" "\\}"
+      "|" "\\|"
+    } $char]
+    append out "\\s*"
+  }
+  return $out
+}
+
+set re_continue [letters_re "Howwouldyouliketocontinue"]
+set re_composition [letters_re "Selectprojectcomposition"]
+set re_version [letters_re "Choosedependencyversionchannel"]
+set re_scope [letters_re "Custom"]
+set re_sections [letters_re "Addons"]
+set re_ai_docs [letters_re "GenerateAIdocumentationfiles"]
+set re_git [letters_re "Initializegitrepository"]
+set re_install [letters_re "Installdependencies"]
+set re_ecosystem [letters_re "Selectecosystem"]
+set re_backend_ecosystem [letters_re "Selectbackendecosystem"]
+set re_ts_frontend [letters_re "SelectTypeScriptwebfrontend"]
+set re_workspace [letters_re "Chooseworkspacelayout"]
+set re_select [letters_re "Select"]
+set re_project_created [letters_re "Projectcreated"]
+set re_builder_ready [letters_re "WebBuilderisready"]
+
+set did_continue 0
+set did_version 0
+set did_composition 0
+set did_scope 0
+set did_sections 0
+set did_ecosystem 0
+set did_backend_ecosystem 0
+set did_ts_frontend 0
+set did_workspace 0
+
+cd $workdir
+spawn node "$repo/apps/cli/dist/cli.mjs" create $project
+
+set finished 0
+while {$finished == 0} {
+  expect {
+    -re $re_continue {
+      if {$did_continue == 1} {
+        exp_continue
+      }
+      set did_continue 1
+      if {$scenario == "s4"} {
+        send "\r"
+      } else {
+        down 1
+        sleep 0.2
+        send "\r"
+      }
+      exp_continue
+    }
+    -re $re_version {
+      if {$did_version == 1} {
+        exp_continue
+      }
+      set did_version 1
+      send "\r"
+      exp_continue
+    }
+    -re $re_composition {
+      if {$did_composition == 1} {
+        exp_continue
+      }
+      set did_composition 1
+      if {$scenario == "s6"} {
+        down 1
+        sleep 0.2
+      }
+      send "\r"
+      exp_continue
+    }
+    -re $re_scope {
+      if {$did_scope == 1} {
+        exp_continue
+      }
+      set did_scope 1
+      choose_scope $scenario
+      exp_continue
+    }
+    -re $re_sections {
+      if {$did_sections == 1} {
+        exp_continue
+      }
+      set did_sections 1
+      choose_sections $scenario
+      exp_continue
+    }
+    -re $re_ai_docs {
+      choose_none_ai_docs
+      exp_continue
+    }
+    -re $re_git {
+      choose_no
+      exp_continue
+    }
+    -re $re_install {
+      choose_no
+      exp_continue
+    }
+    -re "Run .*\\?" {
+      choose_no
+      exp_continue
+    }
+    -re $re_ecosystem {
+      if {$did_ecosystem == 1} {
+        exp_continue
+      }
+      set did_ecosystem 1
+      if {$scenario == "s7"} {
+        down 2
+        sleep 0.2
+      }
+      send "\r"
+      exp_continue
+    }
+    -re $re_backend_ecosystem {
+      if {$did_backend_ecosystem == 1} {
+        exp_continue
+      }
+      set did_backend_ecosystem 1
+      send "\r"
+      exp_continue
+    }
+    -re $re_ts_frontend {
+      if {$did_ts_frontend == 1} {
+        exp_continue
+      }
+      set did_ts_frontend 1
+      send "\r"
+      exp_continue
+    }
+    -re $re_workspace {
+      if {$did_workspace == 1} {
+        exp_continue
+      }
+      set did_workspace 1
+      send "\r"
+      exp_continue
+    }
+    -re $re_select {
+      send "\r"
+      exp_continue
+    }
+    -re "$re_project_created|$re_builder_ready" {
+      set finished 1
+    }
+    timeout {
+      puts "TIMEOUT in $scenario"
+      exit 124
+    }
+    eof {
+      set finished 1
+    }
+  }
+}
+
+catch wait result
+set exit_code [lindex $result 3]
+exit $exit_code


### PR DESCRIPTION
## Problem

The interactive create flow asks ~40 prompts, which overwhelms new users running `bun create better-fullstack@latest`.

## Changes

**Web Builder handoff** — a bare interactive create run invoked via a package-manager create flow (`bun`/`npm`/`pnpm create`, detected by `npm_config_user_agent`) opens with a styled panel recommending the Web Builder, then a select: **Open the Web Builder** (opens browser, exits) or **Continue in the CLI**. Never shown with stack flags, `--yes`/`--yolo`/`--part`, config files, templates, from history, in CI, or non-TTY. `BFS_FORCE_BUILDER_PROMPT=1` / `BFS_SKIP_BUILDER_PROMPT=1` env overrides for testing.

**Configuration scope** — after ecosystem selection, any bare interactive run asks:
- **Core** (default): structural essentials only — framework, backend, runtime, database, ORM, API, auth, db setup. Everything else uses the same defaults as `--yes`.
- **Full**: today's complete walkthrough.
- **Custom**: space-to-toggle multi-select of sections (e.g. "Payments & Email", "Testing & Observability", "Deployment"); essentials are always included.

Works in both solo and multi-ecosystem modes, with back-navigation. Scope/section choices are prompting concerns only — they never enter `ProjectConfig`, `bts.jsonc`, or the reproducible command.

## Implementation notes

- Per-ecosystem section registry in `apps/cli/src/prompts/config-scope.ts`. A compile-enforced `Record<PromptGroupKey, true>` plus a coverage test guarantee every new prompt must be classified (core / section / always) or the build fails.
- Skipped prompts resolve through `getDefaultConfig()`; prompts belonging to other ecosystems still resolve through their own ecosystem guards, so e.g. a rust Core run cannot leak TypeScript frontend defaults (covered by e2e s7).
- The hono server-deploy prompt previously resolved silently to "none" in interactive runs; it now prompts with the full option set (railway/fly/render/netlify/docker/sst/vercel).
- `openUrl` failures now bubble so the existing "Please visit {URL}" fallbacks in `docs`/`builder` actually fire.
- Skipped shadcn options carry the default option set, keeping the reproducible command valid (uiLibrary defaults to shadcn-ui).

## Testing

- Unit: registry coverage/duplicates, builder-gate matrix, scope-delegation semantics (`config-scope.test.ts`, `builder-recommendation.test.ts`).
- Interactive e2e (`testing/cli-scope-e2e-2026-07-07/run.sh`, expect-driven against the built CLI): 7/7 PASS — Core skips extras, Custom asks only toggled sections, Full completes, builder opens & exits, no-user-agent skips panel but keeps scope, multi-ecosystem Core completes, rust Core has zero TS leakage in bts.jsonc.
- Reproducible command from a Core run round-trips through the CLI successfully.
- `bun run --filter=create-better-fullstack build` + `check-types` green.