### PR TITLE
chore(release): 2.1.7

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Scaffold production-ready fullstack apps in seconds. Pick your stack from 425 options — the CLI wires everything together.",
   "keywords": [
     "algolia",
@@ -128,8 +128,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@better-fullstack/template-generator": "^2.1.6",
-    "@better-fullstack/types": "^2.1.6",
+    "@better-fullstack/template-generator": "^2.1.7",
+    "@better-fullstack/types": "^2.1.7",
     "@clack/core": "^0.5.0",
     "@clack/prompts": "^1.6.0",
     "@orpc/server": "^1.14.6",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -80,6 +80,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.1.6"
+    "create-better-fullstack": "^2.1.7"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -62,7 +62,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.1.6",
+    "@better-fullstack/types": "^2.1.7",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-fullstack",
   "displayName": "Better Fullstack",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-fullstack",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack",


### PR DESCRIPTION
Bumps all publishable packages and plugin manifests to 2.1.7. The CLI package build, publint, plugin validation, and full release verification lane pass locally.