### PR TITLE
fix(java): harden the Kotlin language gate — shared predicate, honest UI/CLI, JPA allOpen

### DIFF
--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -6,14 +6,13 @@ import pc from "picocolors";
 
 import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 
-import { getKotlinJavaIncompatibilityReason } from "../../types";
-
 import { BUILDER_URL, getDefaultConfig } from "../../constants";
 import { CreateCommandOptionsSchema } from "../../create-command-input";
 import { gatherConfig } from "../../prompts/config-prompts";
 import { isCancel, isGoBack, navigableSelect } from "../../prompts/navigable";
 import { getProjectName } from "../../prompts/project-name";
 import { getVersionChannelChoice } from "../../prompts/version-channel";
+import { getKotlinJavaIncompatibilityReason } from "../../types";
 import {
   maybeShowTelemetryNotice,
   type TelemetrySource,
@@ -26,13 +25,13 @@ import { displayConfig } from "../../utils/display-config";
 import { CLIError, UserCancelledError, exitCancelled } from "../../utils/errors";
 import { generateReproducibleCommand } from "../../utils/generate-reproducible-command";
 import { runGeneratedChecks } from "../../utils/generated-checks";
+import { openUrl } from "../../utils/open-url";
 import { displayPreflightWarnings } from "../../utils/preflight-display";
 import { handleDirectoryConflict, setupProjectDirectory } from "../../utils/project-directory";
 import { addToHistory } from "../../utils/project-history";
 import { canPromptInteractively } from "../../utils/prompt-environment";
 import { renderTitle } from "../../utils/render-title";
 import { getTemplateConfig, getTemplateDescription } from "../../utils/templates";
-import { openUrl } from "../../utils/open-url";
 import {
   getProvidedFlags,
   processAndValidateFlags,
@@ -248,11 +247,31 @@ function shouldPromptForVersionChannel(
 // and config-file runs bypass those prompts — and the create path does not run
 // analyzeStackCompatibility — so re-check here and fall back to Java loudly
 // instead of letting the template generator do it silently.
-function normalizeKotlinJavaSelection(config: ProjectConfig) {
-  if (config.ecosystem !== "java" || config.javaLanguage !== "kotlin") return;
+export function normalizeKotlinJavaSelection(config: ProjectConfig) {
+  const hasJavaGraphBackend = config.stackParts?.some(
+    (part) =>
+      part.role === "backend" &&
+      part.ecosystem === "java" &&
+      !part.ownerPartId &&
+      part.source !== "provided",
+  );
+  if ((!hasJavaGraphBackend && config.ecosystem !== "java") || config.javaLanguage !== "kotlin") {
+    return;
+  }
   const kotlinBlocker = getKotlinJavaIncompatibilityReason(config);
   if (!kotlinBlocker) return;
   config.javaLanguage = "java";
+  if (config.stackParts) {
+    config.stackParts = config.stackParts.filter(
+      (part) =>
+        !(
+          part.role === "language" &&
+          part.ecosystem === "java" &&
+          part.toolId === "kotlin" &&
+          part.source !== "provided"
+        ),
+    );
+  }
   if (!isSilent()) {
     log.warn(pc.yellow(`JVM language set to Java: ${kotlinBlocker}`));
   }

--- a/apps/cli/src/helpers/core/command-handlers.ts
+++ b/apps/cli/src/helpers/core/command-handlers.ts
@@ -6,6 +6,8 @@ import pc from "picocolors";
 
 import type { CreateInput, DirectoryConflict, ProjectConfig } from "../../types";
 
+import { getKotlinJavaIncompatibilityReason } from "../../types";
+
 import { BUILDER_URL, getDefaultConfig } from "../../constants";
 import { CreateCommandOptionsSchema } from "../../create-command-input";
 import { gatherConfig } from "../../prompts/config-prompts";
@@ -239,6 +241,21 @@ function shouldPromptForVersionChannel(
   }
 
   return canPromptInteractively();
+}
+
+// Kotlin (javaLanguage) is only wired for a subset of the Java option surface.
+// Interactive prompts filter the incompatible options up front, but flag-driven
+// and config-file runs bypass those prompts — and the create path does not run
+// analyzeStackCompatibility — so re-check here and fall back to Java loudly
+// instead of letting the template generator do it silently.
+function normalizeKotlinJavaSelection(config: ProjectConfig) {
+  if (config.ecosystem !== "java" || config.javaLanguage !== "kotlin") return;
+  const kotlinBlocker = getKotlinJavaIncompatibilityReason(config);
+  if (!kotlinBlocker) return;
+  config.javaLanguage = "java";
+  if (!isSilent()) {
+    log.warn(pc.yellow(`JVM language set to Java: ${kotlinBlocker}`));
+  }
 }
 
 export async function createProjectHandler(
@@ -587,6 +604,8 @@ export async function createProjectHandler(
         config = { ...gatheredConfig, versionChannel };
         validateConfigCompatibility(config, providedFlags, cliInput);
       }
+
+      normalizeKotlinJavaSelection(config);
 
       const preflight = validatePreflightConfig(config);
       if (preflight.hasWarnings && !isSilent()) {

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -127,6 +127,9 @@ import type {
   WebDeploy,
 } from "../types";
 
+import { log } from "@clack/prompts";
+
+import { getKotlinJavaIncompatibilityReason } from "../types";
 import { hasWebStyling, requiresChatSdkVercelAI } from "../utils/compatibility-rules";
 import { exitCancelled } from "../utils/errors";
 import { getUserPkgManager } from "../utils/get-package-manager";
@@ -1247,6 +1250,28 @@ export async function gatherConfig(
         if (results.javaWebFramework !== "spring-boot") {
           return Promise.resolve("java" as JavaLanguage);
         }
+        // The shared capability prompts (email/search/caching/observability)
+        // run before this one; if an already-chosen integration is Java-only,
+        // resolve to Java instead of offering a Kotlin option that would be
+        // normalized away. The build tool is prompted after the language, so a
+        // Maven stand-in satisfies that gate check here — the build-tool prompt
+        // itself hides 'none' when Kotlin is selected.
+        const kotlinBlocker = getKotlinJavaIncompatibilityReason({
+          javaWebFramework: results.javaWebFramework,
+          javaBuildTool: "maven",
+          email: results.email,
+          search: results.search,
+          caching: results.caching,
+          observability: results.observability,
+        });
+        if (kotlinBlocker) {
+          if (flags.javaLanguage === "kotlin") {
+            log.warn(`JVM language set to Java: ${kotlinBlocker}`);
+          } else if (flags.javaLanguage === undefined && flags.javaWebFramework === undefined) {
+            log.info(`Kotlin not offered: ${kotlinBlocker}`);
+          }
+          return Promise.resolve("java" as JavaLanguage);
+        }
         // Honor an explicit --java-language flag (resolves without prompting).
         if (flags.javaLanguage !== undefined) {
           return getJavaLanguageChoice(flags.javaLanguage);
@@ -1262,14 +1287,14 @@ export async function gatherConfig(
       },
       javaBuildTool: ({ results }) => {
         if (results.ecosystem !== "java") return Promise.resolve("none" as JavaBuildTool);
-        return getJavaBuildToolChoice(flags.javaBuildTool);
+        return getJavaBuildToolChoice(flags.javaBuildTool, results.javaLanguage);
       },
       javaOrm: ({ results }) => {
         if (results.ecosystem !== "java") return Promise.resolve("none" as JavaOrm);
         if (results.javaWebFramework !== "spring-boot" || results.javaBuildTool === "none") {
           return Promise.resolve("none" as JavaOrm);
         }
-        return getJavaOrmChoice(flags.javaOrm);
+        return getJavaOrmChoice(flags.javaOrm, results.javaLanguage);
       },
       javaAuth: ({ results }) => {
         if (results.ecosystem !== "java") return Promise.resolve("none" as JavaAuth);
@@ -1283,7 +1308,7 @@ export async function gatherConfig(
         if (results.javaWebFramework !== "spring-boot") {
           return Promise.resolve("none" as JavaApi);
         }
-        return getJavaApiChoice(flags.javaApi);
+        return getJavaApiChoice(flags.javaApi, results.javaLanguage);
       },
       javaLogging: ({ results }) => {
         if (results.ecosystem !== "java") return Promise.resolve("none" as JavaLogging);
@@ -1297,14 +1322,14 @@ export async function gatherConfig(
         if (results.javaWebFramework !== "spring-boot" || results.javaBuildTool === "none") {
           return Promise.resolve([] as JavaLibraries[]);
         }
-        return getJavaLibrariesChoice(flags.javaLibraries);
+        return getJavaLibrariesChoice(flags.javaLibraries, results.javaLanguage);
       },
       javaTestingLibraries: ({ results }) => {
         if (results.ecosystem !== "java") return Promise.resolve([] as JavaTestingLibraries[]);
         if (results.javaBuildTool === "none") {
           return Promise.resolve([] as JavaTestingLibraries[]);
         }
-        return getJavaTestingLibrariesChoice(flags.javaTestingLibraries);
+        return getJavaTestingLibrariesChoice(flags.javaTestingLibraries, results.javaLanguage);
       },
       // .NET ecosystem prompts (skip if not .NET)
       dotnetWebFramework: ({ results }) => {

--- a/apps/cli/src/prompts/java-ecosystem.ts
+++ b/apps/cli/src/prompts/java-ecosystem.ts
@@ -10,6 +10,10 @@ import type {
   JavaWebFramework,
 } from "../types";
 
+import {
+  KOTLIN_DROPPED_JAVA_LIBRARIES,
+  KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES,
+} from "../types";
 import { exitCancelled } from "../utils/errors";
 import { isCancel, navigableMultiselect, navigableSelect } from "./navigable";
 import {
@@ -310,12 +314,24 @@ export async function getJavaLanguageChoice(javaLanguage?: JavaLanguage) {
   return response;
 }
 
-export function resolveJavaBuildToolPrompt(javaBuildTool?: JavaBuildTool) {
-  return createStaticSinglePromptResolution(JAVA_BUILD_TOOL_PROMPT_OPTIONS, "maven", javaBuildTool);
+export function resolveJavaBuildToolPrompt(
+  javaBuildTool?: JavaBuildTool,
+  javaLanguage?: JavaLanguage,
+) {
+  // Kotlin compiles through the Maven/Gradle Kotlin plugins, so the
+  // source-only "none" scaffold is Java-only.
+  const options =
+    javaLanguage === "kotlin"
+      ? JAVA_BUILD_TOOL_PROMPT_OPTIONS.filter((option) => option.value !== "none")
+      : JAVA_BUILD_TOOL_PROMPT_OPTIONS;
+  return createStaticSinglePromptResolution(options, "maven", javaBuildTool);
 }
 
-export async function getJavaBuildToolChoice(javaBuildTool?: JavaBuildTool) {
-  const resolution = resolveJavaBuildToolPrompt(javaBuildTool);
+export async function getJavaBuildToolChoice(
+  javaBuildTool?: JavaBuildTool,
+  javaLanguage?: JavaLanguage,
+) {
+  const resolution = resolveJavaBuildToolPrompt(javaBuildTool, javaLanguage);
   if (!resolution.shouldPrompt) {
     return resolution.autoValue ?? "none";
   }
@@ -331,12 +347,20 @@ export async function getJavaBuildToolChoice(javaBuildTool?: JavaBuildTool) {
   return response;
 }
 
-export function resolveJavaOrmPrompt(javaOrm?: JavaOrm) {
-  return createStaticSinglePromptResolution(JAVA_ORM_PROMPT_OPTIONS, "none", javaOrm);
+export function resolveJavaOrmPrompt(javaOrm?: JavaOrm, javaLanguage?: JavaLanguage) {
+  // The Kotlin scaffold only has Kotlin sources for Spring Data JPA;
+  // jOOQ/MyBatis example sources are Java-only.
+  const options =
+    javaLanguage === "kotlin"
+      ? JAVA_ORM_PROMPT_OPTIONS.filter(
+          (option) => option.value !== "jooq" && option.value !== "mybatis",
+        )
+      : JAVA_ORM_PROMPT_OPTIONS;
+  return createStaticSinglePromptResolution(options, "none", javaOrm);
 }
 
-export async function getJavaOrmChoice(javaOrm?: JavaOrm) {
-  const resolution = resolveJavaOrmPrompt(javaOrm);
+export async function getJavaOrmChoice(javaOrm?: JavaOrm, javaLanguage?: JavaLanguage) {
+  const resolution = resolveJavaOrmPrompt(javaOrm, javaLanguage);
   if (!resolution.shouldPrompt) {
     return resolution.autoValue ?? "none";
   }
@@ -373,12 +397,26 @@ export async function getJavaAuthChoice(javaAuth?: JavaAuth) {
   return response;
 }
 
-export function resolveJavaLibrariesPrompt(javaLibraries?: JavaLibraries[]) {
-  return createStaticMultiPromptResolution(JAVA_LIBRARY_PROMPT_OPTIONS, [], javaLibraries);
+export function resolveJavaLibrariesPrompt(
+  javaLibraries?: JavaLibraries[],
+  javaLanguage?: JavaLanguage,
+) {
+  // Lombok/MapStruct are Java annotation-processor tooling the Kotlin
+  // scaffold drops (data classes replace Lombok; MapStruct would need kapt).
+  const options =
+    javaLanguage === "kotlin"
+      ? JAVA_LIBRARY_PROMPT_OPTIONS.filter(
+          (option) => !KOTLIN_DROPPED_JAVA_LIBRARIES.has(option.value),
+        )
+      : JAVA_LIBRARY_PROMPT_OPTIONS;
+  return createStaticMultiPromptResolution(options, [], javaLibraries);
 }
 
-export async function getJavaLibrariesChoice(javaLibraries?: JavaLibraries[]) {
-  const resolution = resolveJavaLibrariesPrompt(javaLibraries);
+export async function getJavaLibrariesChoice(
+  javaLibraries?: JavaLibraries[],
+  javaLanguage?: JavaLanguage,
+) {
+  const resolution = resolveJavaLibrariesPrompt(javaLibraries, javaLanguage);
   if (!resolution.shouldPrompt) {
     return (resolution.autoValue as JavaLibraries[]) ?? [];
   }
@@ -397,16 +435,26 @@ export async function getJavaLibrariesChoice(javaLibraries?: JavaLibraries[]) {
   return response as JavaLibraries[];
 }
 
-export function resolveJavaTestingLibrariesPrompt(javaTestingLibraries?: JavaTestingLibraries[]) {
-  return createStaticMultiPromptResolution(
-    JAVA_TESTING_LIBRARY_PROMPT_OPTIONS,
-    ["junit5"],
-    javaTestingLibraries,
-  );
+export function resolveJavaTestingLibrariesPrompt(
+  javaTestingLibraries?: JavaTestingLibraries[],
+  javaLanguage?: JavaLanguage,
+) {
+  // Only JUnit 5 / Mockito / AssertJ have Kotlin test sources; the remaining
+  // testing libraries ship Java-only example tests.
+  const options =
+    javaLanguage === "kotlin"
+      ? JAVA_TESTING_LIBRARY_PROMPT_OPTIONS.filter(
+          (option) => !KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES.has(option.value),
+        )
+      : JAVA_TESTING_LIBRARY_PROMPT_OPTIONS;
+  return createStaticMultiPromptResolution(options, ["junit5"], javaTestingLibraries);
 }
 
-export async function getJavaTestingLibrariesChoice(javaTestingLibraries?: JavaTestingLibraries[]) {
-  const resolution = resolveJavaTestingLibrariesPrompt(javaTestingLibraries);
+export async function getJavaTestingLibrariesChoice(
+  javaTestingLibraries?: JavaTestingLibraries[],
+  javaLanguage?: JavaLanguage,
+) {
+  const resolution = resolveJavaTestingLibrariesPrompt(javaTestingLibraries, javaLanguage);
   if (!resolution.shouldPrompt) {
     return (resolution.autoValue as JavaTestingLibraries[]) ?? [];
   }
@@ -466,12 +514,20 @@ const JAVA_LOGGING_PROMPT_OPTIONS: PromptOption<JavaLogging>[] = [
   },
 ];
 
-export function resolveJavaApiPrompt(javaApi?: JavaApi) {
-  return createStaticSinglePromptResolution(JAVA_API_PROMPT_OPTIONS, "none", javaApi);
+export function resolveJavaApiPrompt(javaApi?: JavaApi, javaLanguage?: JavaLanguage) {
+  // The gRPC/OpenAPI Generator codegen paths only emit Java sources; the
+  // Kotlin scaffold covers Spring GraphQL and plain REST.
+  const options =
+    javaLanguage === "kotlin"
+      ? JAVA_API_PROMPT_OPTIONS.filter(
+          (option) => option.value !== "grpc" && option.value !== "openapi-generator",
+        )
+      : JAVA_API_PROMPT_OPTIONS;
+  return createStaticSinglePromptResolution(options, "none", javaApi);
 }
 
-export async function getJavaApiChoice(javaApi?: JavaApi) {
-  const resolution = resolveJavaApiPrompt(javaApi);
+export async function getJavaApiChoice(javaApi?: JavaApi, javaLanguage?: JavaLanguage) {
+  const resolution = resolveJavaApiPrompt(javaApi, javaLanguage);
   if (!resolution.shouldPrompt) {
     return resolution.autoValue ?? "none";
   }

--- a/apps/cli/src/prompts/multi-ecosystem-composer.ts
+++ b/apps/cli/src/prompts/multi-ecosystem-composer.ts
@@ -603,7 +603,9 @@ export async function gatherMultiEcosystemConfig(
           : flags.javaWebFramework !== undefined
             ? "java"
             : promptValue(await getJavaLanguageChoice(flags.javaLanguage));
-    const javaBuildTool = promptValue(await getJavaBuildToolChoice(flags.javaBuildTool));
+    const javaBuildTool = promptValue(
+      await getJavaBuildToolChoice(flags.javaBuildTool, javaLanguage),
+    );
     if (javaWebFramework !== "none" && javaBuildTool !== "none") {
       const databaseConfig = await selectDatabaseConfig(flags);
       database = databaseConfig.database;
@@ -612,7 +614,7 @@ export async function gatherMultiEcosystemConfig(
     const javaOrm =
       database === "none" || javaWebFramework !== "spring-boot" || javaBuildTool === "none"
         ? "none"
-        : promptValue(await getJavaOrmChoice(flags.javaOrm));
+        : promptValue(await getJavaOrmChoice(flags.javaOrm, javaLanguage));
     const javaAuth =
       javaWebFramework !== "spring-boot" || javaBuildTool === "none"
         ? "none"
@@ -621,19 +623,19 @@ export async function gatherMultiEcosystemConfig(
       javaWebFramework !== "spring-boot" || javaBuildTool === "none"
         ? []
         : await scopedPromptValue("java", "javaLibraries", configScope, backendSections, () =>
-            getJavaLibrariesChoice(flags.javaLibraries),
+            getJavaLibrariesChoice(flags.javaLibraries, javaLanguage),
           );
     const javaTestingLibraries = await scopedPromptValue(
       "java",
       "javaTestingLibraries",
       configScope,
       backendSections,
-      () => getJavaTestingLibrariesChoice(flags.javaTestingLibraries),
+      () => getJavaTestingLibrariesChoice(flags.javaTestingLibraries, javaLanguage),
     );
     const javaApi =
       javaWebFramework !== "spring-boot" || javaBuildTool === "none"
         ? "none"
-        : promptValue(await getJavaApiChoice(flags.javaApi));
+        : promptValue(await getJavaApiChoice(flags.javaApi, javaLanguage));
     const javaLogging =
       javaWebFramework !== "spring-boot" || javaBuildTool === "none"
         ? "none"

--- a/apps/cli/test/java-ecosystem.test.ts
+++ b/apps/cli/test/java-ecosystem.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "bun:test";
 
+import { getDefaultConfig } from "../src/constants";
+import { normalizeKotlinJavaSelection } from "../src/helpers/core/command-handlers";
 import { createVirtual } from "../src/index";
+import {
+  resolveJavaApiPrompt,
+  resolveJavaBuildToolPrompt,
+  resolveJavaLibrariesPrompt,
+  resolveJavaOrmPrompt,
+  resolveJavaTestingLibrariesPrompt,
+} from "../src/prompts/java-ecosystem";
 import {
   analyzeStackCompatibility,
   type CompatibilityInput,
@@ -15,19 +24,13 @@ import {
   JavaOrmSchema,
   JavaTestingLibrariesSchema,
   JavaWebFrameworkSchema,
+  parseStackPartSpecs,
+  stackPartsToLegacyProjectConfigPartial,
 } from "../src/types";
-import {
-  resolveJavaApiPrompt,
-  resolveJavaBuildToolPrompt,
-  resolveJavaLibrariesPrompt,
-  resolveJavaOrmPrompt,
-  resolveJavaTestingLibrariesPrompt,
-} from "../src/prompts/java-ecosystem";
 import { validateConfigForProgrammaticUse } from "../src/utils/config-validation";
 import { runWithContext } from "../src/utils/context";
-import {
-  extractEnumValues,
-} from "./test-utils";
+import { generateReproducibleCommand } from "../src/utils/generate-reproducible-command";
+import { extractEnumValues } from "./test-utils";
 import {
   getVirtualFileContent as getFileContent,
   hasVirtualFile as hasFile,
@@ -225,7 +228,10 @@ describe("Java Ecosystem", () => {
         hasFile(root, "src/main/java/com/example/javaquarkusmaven/resource/GreetingResource.java"),
       ).toBe(true);
       expect(
-        hasFile(root, "src/main/java/com/example/javaquarkusmaven/controller/HealthController.java"),
+        hasFile(
+          root,
+          "src/main/java/com/example/javaquarkusmaven/controller/HealthController.java",
+        ),
       ).toBe(false);
       expect(hasFile(root, "src/main/resources/application.yml")).toBe(false);
 
@@ -248,9 +254,9 @@ describe("Java Ecosystem", () => {
       expect(pomContent).toContain("<artifactId>archunit-junit5</artifactId>");
       expect(pomContent).toContain("<artifactId>mockito-junit-jupiter</artifactId>");
       expect(pomContent).toContain("<artifactId>quarkus-maven-plugin</artifactId>");
-      expect(hasFile(root, "src/test/java/com/example/javaquarkusmaven/MockitoSmokeTest.java")).toBe(
-        true,
-      );
+      expect(
+        hasFile(root, "src/test/java/com/example/javaquarkusmaven/MockitoSmokeTest.java"),
+      ).toBe(true);
       expect(pomContent).not.toContain("spring-boot-starter-parent");
       expect(applicationContent).toContain("@QuarkusMain");
       expect(resourceContent).toContain('@Path("/hello")');
@@ -453,9 +459,9 @@ describe("Java Ecosystem", () => {
       expect(hasFile(root, "src/test/java/com/example/javaplainmaven/ApplicationTests.java")).toBe(
         true,
       );
-      expect(
-        hasFile(root, "src/test/java/com/example/javaplainmaven/MockitoSmokeTest.java"),
-      ).toBe(true);
+      expect(hasFile(root, "src/test/java/com/example/javaplainmaven/MockitoSmokeTest.java")).toBe(
+        true,
+      );
 
       const pomContent = getFileContent(root, "pom.xml");
       const readmeContent = getFileContent(root, "README.md");
@@ -1162,6 +1168,47 @@ describe("Java Ecosystem", () => {
       }
     });
 
+    it("removes drop-only Java libraries while preserving a compatible Kotlin stack", () => {
+      const result = analyzeStackCompatibility(
+        createJavaCompatibilityInput({
+          javaLanguage: "kotlin",
+          javaWebFramework: "spring-boot",
+          javaBuildTool: "maven",
+          javaOrm: "spring-data-jpa",
+          javaLibraries: ["lombok", "mapstruct", "caffeine"],
+        }),
+      );
+
+      expect(result.adjustedStack?.javaLanguage ?? "kotlin").toBe("kotlin");
+      expect(result.adjustedStack?.javaLibraries).toEqual(["caffeine"]);
+      expect(result.changes).toContainEqual(expect.objectContaining({ category: "javaLibraries" }));
+    });
+
+    it("removes a stale Kotlin graph part when an incompatible multi-stack falls back to Java", () => {
+      const stackParts = parseStackPartSpecs(
+        [
+          "frontend:typescript:next",
+          "backend:java:spring-boot",
+          "backend.language:java:kotlin",
+          "backend.buildTool:java:maven",
+          "backend.orm:java:jooq",
+        ],
+        "selected",
+      );
+      const config = {
+        ...getDefaultConfig(),
+        ...stackPartsToLegacyProjectConfigPartial(stackParts),
+        stackParts,
+      };
+
+      runWithContext({ silent: true }, () => normalizeKotlinJavaSelection(config));
+
+      expect(config.javaLanguage).toBe("java");
+      expect(generateReproducibleCommand(config)).not.toContain(
+        "--part backend.language:java:kotlin",
+      );
+    });
+
     it("disables the kotlin option when the current stack excludes it", () => {
       const quarkusStack = createJavaCompatibilityInput({
         javaLanguage: "java",
@@ -1194,7 +1241,9 @@ describe("Java Ecosystem", () => {
       expect(getDisabledReason(kotlinStack, "javaApi", "openapi-generator")).not.toBeNull();
       expect(getDisabledReason(kotlinStack, "javaLibraries", "lombok")).not.toBeNull();
       expect(getDisabledReason(kotlinStack, "javaLibraries", "mapstruct")).not.toBeNull();
-      expect(getDisabledReason(kotlinStack, "javaTestingLibraries", "testcontainers")).not.toBeNull();
+      expect(
+        getDisabledReason(kotlinStack, "javaTestingLibraries", "testcontainers"),
+      ).not.toBeNull();
       expect(getDisabledReason(kotlinStack, "email", "resend")).not.toBeNull();
       expect(getDisabledReason(kotlinStack, "search", "meilisearch")).not.toBeNull();
       expect(getDisabledReason(kotlinStack, "caching", "upstash-redis")).not.toBeNull();

--- a/apps/cli/test/java-ecosystem.test.ts
+++ b/apps/cli/test/java-ecosystem.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_STACK_SELECTION,
   EcosystemSchema,
   evaluateCompatibility,
+  getDisabledReason,
   JavaApiSchema,
   JavaAuthSchema,
   JavaBuildToolSchema,
@@ -15,6 +16,13 @@ import {
   JavaTestingLibrariesSchema,
   JavaWebFrameworkSchema,
 } from "../src/types";
+import {
+  resolveJavaApiPrompt,
+  resolveJavaBuildToolPrompt,
+  resolveJavaLibrariesPrompt,
+  resolveJavaOrmPrompt,
+  resolveJavaTestingLibrariesPrompt,
+} from "../src/prompts/java-ecosystem";
 import { validateConfigForProgrammaticUse } from "../src/utils/config-validation";
 import { runWithContext } from "../src/utils/context";
 import {
@@ -1098,6 +1106,139 @@ describe("Java Ecosystem", () => {
       );
 
       expect(result.issues.filter((issue) => issue.category === "javaLibraries")).toEqual([]);
+    });
+  });
+
+  describe("Kotlin Language Gate", () => {
+    it("keeps Kotlin for a supported Spring Boot stack", () => {
+      const result = analyzeStackCompatibility(
+        createJavaCompatibilityInput({
+          javaLanguage: "kotlin",
+          javaWebFramework: "spring-boot",
+          javaBuildTool: "gradle",
+          javaOrm: "spring-data-jpa",
+          javaAuth: "spring-security",
+          javaApi: "spring-graphql",
+          javaLibraries: ["spring-validation", "caffeine"],
+          javaTestingLibraries: ["junit5", "mockito", "assertj"],
+        }),
+      );
+
+      expect(result.adjustedStack?.javaLanguage ?? "kotlin").toBe("kotlin");
+      expect(result.changes.some((adjustment) => adjustment.category === "javaLanguage")).toBe(
+        false,
+      );
+    });
+
+    it("normalizes Kotlin back to Java when the stack includes Java-only options", () => {
+      // email:'resend' is not testable through analyzeStackCompatibility here —
+      // the generic email-requires-backend normalization clears it first (java
+      // stacks always have backend 'none'), which also resolves the Kotlin
+      // conflict. The email/search/caching/observability legs are covered by
+      // the getDisabledReason assertions below instead.
+      for (const overrides of [
+        { javaOrm: "jooq" },
+        { javaApi: "grpc" },
+        { javaTestingLibraries: ["junit5", "testcontainers"] },
+      ] as const) {
+        const result = analyzeStackCompatibility(
+          createJavaCompatibilityInput({
+            javaLanguage: "kotlin",
+            javaWebFramework: "spring-boot",
+            javaBuildTool: "maven",
+            javaOrm: "none",
+            javaAuth: "none",
+            javaApi: "none",
+            javaLibraries: [],
+            javaTestingLibraries: ["junit5"],
+            ...overrides,
+          }),
+        );
+
+        expect(result.adjustedStack?.javaLanguage).toBe("java");
+        expect(result.changes.some((adjustment) => adjustment.category === "javaLanguage")).toBe(
+          true,
+        );
+      }
+    });
+
+    it("disables the kotlin option when the current stack excludes it", () => {
+      const quarkusStack = createJavaCompatibilityInput({
+        javaLanguage: "java",
+        javaWebFramework: "quarkus",
+        javaBuildTool: "maven",
+      });
+      expect(getDisabledReason(quarkusStack, "javaLanguage", "kotlin")).not.toBeNull();
+
+      const springStack = createJavaCompatibilityInput({
+        javaLanguage: "java",
+        javaWebFramework: "spring-boot",
+        javaBuildTool: "maven",
+      });
+      expect(getDisabledReason(springStack, "javaLanguage", "kotlin")).toBeNull();
+    });
+
+    it("disables Kotlin-incompatible options while Kotlin is selected", () => {
+      const kotlinStack = createJavaCompatibilityInput({
+        javaLanguage: "kotlin",
+        javaWebFramework: "spring-boot",
+        javaBuildTool: "gradle",
+        javaOrm: "spring-data-jpa",
+      });
+
+      expect(getDisabledReason(kotlinStack, "javaWebFramework", "quarkus")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaBuildTool", "none")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaOrm", "jooq")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaOrm", "mybatis")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaApi", "grpc")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaApi", "openapi-generator")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaLibraries", "lombok")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaLibraries", "mapstruct")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaTestingLibraries", "testcontainers")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "email", "resend")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "search", "meilisearch")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "caching", "upstash-redis")).not.toBeNull();
+      expect(getDisabledReason(kotlinStack, "observability", "sentry")).not.toBeNull();
+
+      // The supported surface stays selectable.
+      expect(getDisabledReason(kotlinStack, "javaOrm", "spring-data-jpa")).toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaApi", "spring-graphql")).toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaTestingLibraries", "mockito")).toBeNull();
+      expect(getDisabledReason(kotlinStack, "javaLibraries", "caffeine")).toBeNull();
+    });
+
+    it("filters Kotlin-incompatible options out of the interactive prompts", () => {
+      const ormOptions = resolveJavaOrmPrompt(undefined, "kotlin").options.map(
+        (option) => option.value,
+      );
+      expect(ormOptions).toEqual(["spring-data-jpa", "none"]);
+
+      const apiOptions = resolveJavaApiPrompt(undefined, "kotlin").options.map(
+        (option) => option.value,
+      );
+      expect(apiOptions).toEqual(["spring-graphql", "none"]);
+
+      const buildToolOptions = resolveJavaBuildToolPrompt(undefined, "kotlin").options.map(
+        (option) => option.value,
+      );
+      expect(buildToolOptions).toEqual(["maven", "gradle"]);
+
+      const testingOptions = resolveJavaTestingLibrariesPrompt(undefined, "kotlin").options.map(
+        (option) => option.value,
+      );
+      expect(testingOptions).toEqual(["junit5", "mockito", "assertj", "none"]);
+
+      const libraryOptions = resolveJavaLibrariesPrompt(undefined, "kotlin").options.map(
+        (option) => option.value,
+      );
+      expect(libraryOptions).not.toContain("lombok");
+      expect(libraryOptions).not.toContain("mapstruct");
+
+      // Without a language context the full Java option lists stay intact.
+      expect(resolveJavaOrmPrompt().options.map((option) => option.value)).toEqual(JAVA_ORMS);
+      expect(resolveJavaTestingLibrariesPrompt().options.map((option) => option.value)).toEqual(
+        JAVA_TESTING_LIBRARIES,
+      );
     });
   });
 });

--- a/apps/web/src/components/stack-builder/stack-builder.tsx
+++ b/apps/web/src/components/stack-builder/stack-builder.tsx
@@ -43,6 +43,7 @@ import {
   lazy,
   startTransition,
   type ReactNode,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -159,6 +160,20 @@ type GraphBackendPickerConfig = GraphBackendConfig & {
 };
 
 type MultiStackStepId = "frontend" | "backend" | "database" | "mobile" | "finalize";
+
+function filterKotlinBackendCapabilityOptions(
+  selection: Pick<GraphSelection, "backendEcosystem" | "backendLanguage">,
+  role: Extract<StackPartRole, "orm" | "api">,
+  options: TechOption[],
+) {
+  if (selection.backendEcosystem !== "java" || selection.backendLanguage !== "kotlin") {
+    return options;
+  }
+
+  const supportedIds =
+    role === "orm" ? new Set(["spring-data-jpa", "none"]) : new Set(["spring-graphql", "none"]);
+  return options.filter((option) => supportedIds.has(option.id));
+}
 
 const GRAPH_FRONTEND_CONFIGS: GraphFrontendConfig[] = [
   {
@@ -1220,7 +1235,7 @@ function CreationModeComposer({
   activeStep: MultiStackStepId;
   onActiveStepChange: (stepId: MultiStackStepId) => void;
 }) {
-  const graphSelection = getGraphSelection(stack);
+  const graphSelection = useMemo(() => getGraphSelection(stack), [stack]);
   const frontendConfig = GRAPH_FRONTEND_CONFIG_BY_ECOSYSTEM[graphSelection.frontendEcosystem];
   const backendConfig = GRAPH_BACKEND_CONFIG_BY_ECOSYSTEM[graphSelection.backendEcosystem];
   const backendLabel =
@@ -1268,13 +1283,12 @@ function CreationModeComposer({
   );
   // The Kotlin scaffold only has Kotlin sources for Spring Data JPA —
   // jOOQ/MyBatis are Java-only (mirrors the spring-boot-only framework filter).
-  const backendOrmOptions =
-    graphSelection.backendEcosystem === "java" && graphSelection.backendLanguage === "kotlin"
-      ? allBackendOrmOptions.filter(
-          (option) => option.id === "spring-data-jpa" || option.id === "none",
-        )
-      : allBackendOrmOptions;
-  const backendApiOptions = backendConfig.apiCategory
+  const backendOrmOptions = filterKotlinBackendCapabilityOptions(
+    graphSelection,
+    "orm",
+    allBackendOrmOptions,
+  );
+  const allBackendApiOptions = backendConfig.apiCategory
     ? getGraphToolOptions(
         backendConfig.apiCategory,
         "api",
@@ -1282,6 +1296,11 @@ function CreationModeComposer({
         backendCapabilityContext,
       )
     : [];
+  const backendApiOptions = filterKotlinBackendCapabilityOptions(
+    graphSelection,
+    "api",
+    allBackendApiOptions,
+  );
   const backendAuthOptions = backendConfig.authCategory
     ? getGraphToolOptions(
         backendConfig.authCategory,
@@ -1299,17 +1318,23 @@ function CreationModeComposer({
     ecosystem: graphSelection.backendEcosystem as Ecosystem,
   };
 
-  const applyGraphSelection = (nextSelection: GraphSelection) => {
-    const specs = graphSelectionToSpecs(nextSelection);
-    onChange((current) => ({
-      ...stackPatchFromGraphSpecs(specs),
-      projectName: current.projectName,
-    }));
-  };
+  const applyGraphSelection = useCallback(
+    (nextSelection: GraphSelection) => {
+      const specs = graphSelectionToSpecs(nextSelection);
+      onChange((current) => ({
+        ...stackPatchFromGraphSpecs(specs),
+        projectName: current.projectName,
+      }));
+    },
+    [onChange],
+  );
 
-  const updateGraphSelection = (updates: Partial<GraphSelection>) => {
-    applyGraphSelection({ ...graphSelection, ...updates });
-  };
+  const updateGraphSelection = useCallback(
+    (updates: Partial<GraphSelection>) => {
+      applyGraphSelection({ ...graphSelection, ...updates });
+    },
+    [applyGraphSelection, graphSelection],
+  );
 
   const updateStackOption = (category: keyof typeof TECH_OPTIONS, optionId: string) => {
     onChange((current) => getStackOptionUpdate(current, category, optionId));
@@ -1364,35 +1389,50 @@ function CreationModeComposer({
       return { backendOrm: "none", backendApi: "none", backendAuth: "none" };
     }
 
-    const ormOptions = getGraphToolOptions(
+    const ormOptions = filterKotlinBackendCapabilityOptions(
+      selection,
+      "orm",
+      getGraphToolOptions(
+        config.ormCategory,
+        "orm",
+        config.ecosystem,
+        getBackendContextForSelection(selection),
+      ),
+    );
+    const defaultBackendOrm = getDefaultGraphTool(
       config.ormCategory,
       "orm",
       config.ecosystem,
+      "none",
+      {},
       getBackendContextForSelection(selection),
     );
     const backendOrm = ormOptions.some((option) => option.id === selection.backendOrm)
       ? selection.backendOrm
-      : getDefaultGraphTool(
-          config.ormCategory,
-          "orm",
-          config.ecosystem,
-          "none",
-          {},
-          getBackendContextForSelection(selection),
-        );
+      : ormOptions.some((option) => option.id === defaultBackendOrm)
+        ? defaultBackendOrm
+        : (ormOptions.find((option) => option.id !== "none")?.id ?? "none");
 
     const withOrm = { ...selection, backendOrm };
     const backendApi = config.apiCategory
       ? (() => {
-          const apiOptions = getGraphToolOptions(
-            config.apiCategory,
+          const apiOptions = filterKotlinBackendCapabilityOptions(
+            withOrm,
             "api",
-            config.ecosystem,
-            getBackendContextForSelection(withOrm),
+            getGraphToolOptions(
+              config.apiCategory,
+              "api",
+              config.ecosystem,
+              getBackendContextForSelection(withOrm),
+            ),
           );
-          return apiOptions.some((option) => option.id === selection.backendApi)
-            ? selection.backendApi
-            : getDefaultBackendCapability(config, "api", withOrm);
+          if (apiOptions.some((option) => option.id === selection.backendApi)) {
+            return selection.backendApi;
+          }
+          const defaultBackendApi = getDefaultBackendCapability(config, "api", withOrm);
+          return apiOptions.some((option) => option.id === defaultBackendApi)
+            ? defaultBackendApi
+            : "none";
         })()
       : "none";
 
@@ -1413,6 +1453,19 @@ function CreationModeComposer({
 
     return { backendOrm, backendApi, backendAuth };
   };
+
+  const reconciledBackendCapabilities = reconcileBackendCapabilities(graphSelection, backendConfig);
+  const hasStaleKotlinBackendCapability =
+    graphSelection.backendEcosystem === "java" &&
+    graphSelection.backendLanguage === "kotlin" &&
+    (reconciledBackendCapabilities.backendOrm !== graphSelection.backendOrm ||
+      reconciledBackendCapabilities.backendApi !== graphSelection.backendApi ||
+      reconciledBackendCapabilities.backendAuth !== graphSelection.backendAuth);
+
+  useEffect(() => {
+    if (!hasStaleKotlinBackendCapability) return;
+    updateGraphSelection(reconciledBackendCapabilities);
+  }, [hasStaleKotlinBackendCapability, reconciledBackendCapabilities, updateGraphSelection]);
 
   const getStepSelection = (
     stepId: MultiStackStepId,

--- a/apps/web/src/components/stack-builder/stack-builder.tsx
+++ b/apps/web/src/components/stack-builder/stack-builder.tsx
@@ -1260,12 +1260,20 @@ function CreationModeComposer({
       ? allBackendOptions.filter((option) => option.id === "spring-boot" || option.id === "none")
       : allBackendOptions;
   const databaseOptions = getGraphToolOptions("database", "database", "universal");
-  const backendOrmOptions = getGraphToolOptions(
+  const allBackendOrmOptions = getGraphToolOptions(
     backendConfig.ormCategory,
     "orm",
     graphSelection.backendEcosystem,
     backendCapabilityContext,
   );
+  // The Kotlin scaffold only has Kotlin sources for Spring Data JPA —
+  // jOOQ/MyBatis are Java-only (mirrors the spring-boot-only framework filter).
+  const backendOrmOptions =
+    graphSelection.backendEcosystem === "java" && graphSelection.backendLanguage === "kotlin"
+      ? allBackendOrmOptions.filter(
+          (option) => option.id === "spring-data-jpa" || option.id === "none",
+        )
+      : allBackendOrmOptions;
   const backendApiOptions = backendConfig.apiCategory
     ? getGraphToolOptions(
         backendConfig.apiCategory,

--- a/apps/web/test/e2e/builder-parity.spec.ts
+++ b/apps/web/test/e2e/builder-parity.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-import { clickVisibleTestId, commandOutput, openBuilder, visibleTestId } from "./test-helpers";
+import {
+  clickVisibleTestId,
+  commandOutput,
+  gotoAppPage,
+  openBuilder,
+  visibleTestId,
+} from "./test-helpers";
 
 test.describe("Builder parity", () => {
   test.describe.configure({ mode: "serial" });
@@ -124,6 +130,28 @@ test.describe("Builder parity", () => {
     const command = commandOutput(page);
     await expect(command).toContainText("--part backend:java:spring-boot");
     await expect(command).toContainText("--part backend.language:java:kotlin");
+    await expect(page.getByTestId("multi-backend-orm-jooq")).toHaveCount(0);
+    await expect(page.getByTestId("multi-backend-orm-mybatis")).toHaveCount(0);
+    await expect(page.getByTestId("multi-backend-api-grpc")).toHaveCount(0);
+    await expect(page.getByTestId("multi-backend-api-openapi-generator")).toHaveCount(0);
+  });
+
+  test("repairs stale Java-only capabilities in shared Kotlin multi-stack URLs", async ({
+    page,
+  }) => {
+    const partSpecs = [
+      "frontend:typescript:next",
+      "backend:java:spring-boot",
+      "backend.language:java:kotlin",
+      "backend.orm:java:jooq",
+      "backend.api:java:grpc",
+    ].join(",");
+    await gotoAppPage(page, `/new?mode=multi&part=${encodeURIComponent(partSpecs)}`);
+
+    const command = commandOutput(page);
+    await expect(command).toContainText("--part backend.language:java:kotlin");
+    await expect(command).not.toContainText("--part backend.orm:java:jooq");
+    await expect(command).not.toContainText("--part backend.api:java:grpc");
   });
 
   test("disabled options do not mutate the command output", async ({ page }) => {

--- a/packages/template-generator/src/template-handlers/java-base.ts
+++ b/packages/template-generator/src/template-handlers/java-base.ts
@@ -1,5 +1,10 @@
 import type { ProjectConfig } from "@better-fullstack/types";
 
+import {
+  getKotlinJavaIncompatibilityReason,
+  KOTLIN_DROPPED_JAVA_LIBRARIES,
+} from "@better-fullstack/types";
+
 import type { VirtualFileSystem } from "../core/virtual-fs";
 import type { TemplateData } from "./utils";
 
@@ -165,31 +170,12 @@ function createJavaTemplateContext(config: ProjectConfig): JavaTemplateContext {
   const isJavaMicronaut = config.javaWebFramework === "micronaut" && hasJavaBuildTool;
   // Kotlin is only wired for the Spring Boot scaffold and its common option
   // surface. Everything else falls back to the (byte-identical) Java path so the
-  // generator never emits a half-built Kotlin project. This mirrors the
-  // normalization in compatibility.ts and is repeated here so direct
-  // `createVirtual`/MCP callers (which bypass compatibility) stay safe.
-  const kotlinUnsupportedTestingLibraries = new Set([
-    "testcontainers",
-    "rest-assured",
-    "wiremock",
-    "awaitility",
-    "archunit",
-    "jqwik",
-  ]);
+  // generator never emits a half-built Kotlin project. The gate lives in
+  // @better-fullstack/types (shared with compatibility.ts) and is re-checked
+  // here so direct `createVirtual`/MCP callers (which bypass compatibility)
+  // stay safe.
   const isJavaKotlin =
-    config.javaLanguage === "kotlin" &&
-    isJavaSpringBoot &&
-    config.javaOrm !== "jooq" &&
-    config.javaOrm !== "mybatis" &&
-    config.javaApi !== "grpc" &&
-    config.javaApi !== "openapi-generator" &&
-    config.email !== "resend" &&
-    config.search !== "meilisearch" &&
-    config.caching !== "upstash-redis" &&
-    config.observability !== "sentry" &&
-    !(config.javaTestingLibraries || []).some((library) =>
-      kotlinUnsupportedTestingLibraries.has(library),
-    );
+    config.javaLanguage === "kotlin" && getKotlinJavaIncompatibilityReason(config) === null;
   const hasJavaJpa = isJavaSpringBoot && config.javaOrm === "spring-data-jpa";
   const rawLibraries = isJavaSpringBoot
     ? (config.javaLibraries || []).filter((library) => library !== "none")
@@ -213,7 +199,7 @@ function createJavaTemplateContext(config: ProjectConfig): JavaTemplateContext {
     // are redundant (data classes replace Lombok) and not wired (MapStruct would
     // need kapt), so drop them from the effective library set — the Kotlin
     // scaffold uses idiomatic Kotlin instead of the DTO/mapper example.
-    if (isJavaKotlin && (library === "lombok" || library === "mapstruct")) {
+    if (isJavaKotlin && KOTLIN_DROPPED_JAVA_LIBRARIES.has(library)) {
       continue;
     }
     javaLibraries.push(library);
@@ -341,12 +327,6 @@ function shouldSkipKotlinSource(templatePath: string, context: JavaTemplateConte
     !context.hasJavaMockito &&
     (templatePath.endsWith("/MockitoSmokeTest.kt.hbs") ||
       templatePath.endsWith("/service/AppUserServiceTest.kt.hbs"))
-  ) {
-    return true;
-  }
-  if (
-    !context.hasJavaTestcontainers &&
-    templatePath.endsWith("/ApplicationContainerTests.kt.hbs")
   ) {
     return true;
   }

--- a/packages/template-generator/templates/java-base/build.gradle.kts.hbs
+++ b/packages/template-generator/templates/java-base/build.gradle.kts.hbs
@@ -62,6 +62,16 @@ kotlin {
 	}
 }
 
+{{#if hasJavaJpa}}
+// Open @Entity classes so Hibernate can subclass them for lazy proxies
+// (plugin.jpa only adds the no-arg constructor).
+allOpen {
+	annotation("jakarta.persistence.Entity")
+	annotation("jakarta.persistence.MappedSuperclass")
+	annotation("jakarta.persistence.Embeddable")
+}
+
+{{/if}}
 {{/if}}
 repositories {
 	mavenCentral()

--- a/packages/template-generator/templates/java-base/pom.xml.hbs
+++ b/packages/template-generator/templates/java-base/pom.xml.hbs
@@ -30,6 +30,11 @@
 {{/if}}
 {{#if isJavaSpringBoot}}
 		<java.version>21</java.version>
+{{#if isJavaKotlin}}
+		<!-- Pin the Kotlin toolchain to the same version the Gradle variant uses
+		     (the Spring Boot parent manages an older default otherwise). -->
+		<kotlin.version>2.2.20</kotlin.version>
+{{/if}}
 {{#if isJavaOpenApiGenerator}}
 		<openapi-generator.version>7.23.0</openapi-generator.version>
 		<swagger-annotations.version>2.2.52</swagger-annotations.version>
@@ -1076,8 +1081,18 @@
 						<plugin>spring</plugin>
 {{#if hasJavaJpa}}
 						<plugin>jpa</plugin>
+						<plugin>all-open</plugin>
 {{/if}}
 					</compilerPlugins>
+{{#if hasJavaJpa}}
+					<!-- Open @Entity classes so Hibernate can subclass them for lazy
+					     proxies (the jpa plugin only adds the no-arg constructor). -->
+					<pluginOptions>
+						<option>all-open:annotation=jakarta.persistence.Entity</option>
+						<option>all-open:annotation=jakarta.persistence.MappedSuperclass</option>
+						<option>all-open:annotation=jakarta.persistence.Embeddable</option>
+					</pluginOptions>
+{{/if}}
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -1662,6 +1662,19 @@ export const analyzeStackCompatibility = (
           category: "javaLanguage",
           message: `Java language set to 'Java' (${kotlinBlocker})`,
         });
+      } else {
+        const kotlinLibraries = nextStack.javaLibraries.filter(
+          (library) => !KOTLIN_DROPPED_JAVA_LIBRARIES.has(library),
+        );
+        if (kotlinLibraries.length !== nextStack.javaLibraries.length) {
+          nextStack.javaLibraries = kotlinLibraries;
+          changed = true;
+          changes.push({
+            category: "javaLibraries",
+            message:
+              "Java annotation-processor libraries cleared (Lombok and MapStruct are not wired for Kotlin)",
+          });
+        }
       }
     }
   }
@@ -1988,11 +2001,7 @@ export const getDisabledReason = (
   // javaOrm and the ecosystem-scoped email/search/caching/observability rules
   // return early for non-TypeScript ecosystems, so later placement would make
   // these rules unreachable.
-  if (
-    category === "javaLanguage" &&
-    optionId === "kotlin" &&
-    currentStack.ecosystem === "java"
-  ) {
+  if (category === "javaLanguage" && optionId === "kotlin" && currentStack.ecosystem === "java") {
     const kotlinBlocker = getKotlinJavaIncompatibilityReason(currentStack);
     if (kotlinBlocker) {
       return kotlinBlocker;

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -47,6 +47,74 @@ export {
 
 export type CompatibilityCategory = OptionCategory;
 
+// ============================================
+// KOTLIN (JAVA ECOSYSTEM) SUPPORT GATE
+// ============================================
+// Kotlin is a `javaLanguage` variant of the Java ecosystem, wired only for the
+// Spring Boot scaffold and the option surface that has Kotlin source templates.
+// This is the single source of truth for that gate — the stack normalization
+// below, `getDisabledReason`, the CLI create path, and the template generator
+// all consume it so the lists can never drift apart.
+
+export const KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES: ReadonlySet<string> = new Set([
+  "testcontainers",
+  "rest-assured",
+  "wiremock",
+  "awaitility",
+  "archunit",
+  "jqwik",
+]);
+
+// Java annotation-processor tooling the Kotlin scaffold drops rather than
+// blocks: data classes replace Lombok, and MapStruct would need kapt.
+export const KOTLIN_DROPPED_JAVA_LIBRARIES: ReadonlySet<string> = new Set(["lombok", "mapstruct"]);
+
+export type KotlinJavaGateInput = {
+  javaWebFramework?: string;
+  javaBuildTool?: string;
+  javaOrm?: string;
+  javaApi?: string;
+  javaTestingLibraries?: string[];
+  email?: string;
+  search?: string;
+  caching?: string;
+  observability?: string;
+};
+
+export function getKotlinJavaIncompatibilityReason(stack: KotlinJavaGateInput): string | null {
+  if (stack.javaWebFramework !== "spring-boot") {
+    return "Kotlin sources are only wired for the Spring Boot scaffold";
+  }
+  if (!stack.javaBuildTool || stack.javaBuildTool === "none") {
+    return "Kotlin requires Maven or Gradle";
+  }
+  if (stack.javaOrm === "jooq" || stack.javaOrm === "mybatis") {
+    return "The Kotlin scaffold supports Spring Data JPA or no ORM (jOOQ/MyBatis sources are Java-only)";
+  }
+  if (stack.javaApi === "grpc" || stack.javaApi === "openapi-generator") {
+    return "The Kotlin scaffold supports Spring GraphQL or no API layer (gRPC/OpenAPI codegen paths are Java-only)";
+  }
+  if (stack.email === "resend") {
+    return "The Resend email integration is Java-only in the Java ecosystem scaffold";
+  }
+  if (stack.search === "meilisearch") {
+    return "The Meilisearch integration is Java-only in the Java ecosystem scaffold";
+  }
+  if (stack.caching === "upstash-redis") {
+    return "The Upstash Redis integration is Java-only in the Java ecosystem scaffold";
+  }
+  if (stack.observability === "sentry") {
+    return "The Sentry integration is Java-only in the Java ecosystem scaffold";
+  }
+  const unsupportedTestingLibrary = (stack.javaTestingLibraries ?? []).find((library) =>
+    KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES.has(library),
+  );
+  if (unsupportedTestingLibrary) {
+    return `The '${unsupportedTestingLibrary}' testing library is not wired for the Kotlin scaffold`;
+  }
+  return null;
+}
+
 export type CompatibilityIssue = {
   code: string;
   message: string;
@@ -1583,41 +1651,16 @@ export const analyzeStackCompatibility = (
     // Kotlin is only wired for the Spring Boot scaffold (with Maven or Gradle)
     // and its common option surface. For every other Java combination we
     // normalize the language back to `java` so the generator never emits a
-    // half-built Kotlin project. The uncovered surface is: non-Spring-Boot
-    // frameworks, source-only scaffolds, jOOQ/MyBatis ORMs, the gRPC/OpenAPI
-    // API layers (protoc/codegen paths), and the Java-only third-party service
-    // integrations (Resend email, Meilisearch, Upstash Redis, Sentry).
+    // half-built Kotlin project. See `getKotlinJavaIncompatibilityReason` for
+    // the full gate (shared with getDisabledReason, the CLI, and the generator).
     if (nextStack.javaLanguage === "kotlin") {
-      const kotlinUnsupportedTestingLibraries = new Set([
-        "testcontainers",
-        "rest-assured",
-        "wiremock",
-        "awaitility",
-        "archunit",
-        "jqwik",
-      ]);
-      const kotlinSupported =
-        nextStack.javaWebFramework === "spring-boot" &&
-        nextStack.javaBuildTool !== "none" &&
-        nextStack.javaOrm !== "jooq" &&
-        nextStack.javaOrm !== "mybatis" &&
-        nextStack.javaApi !== "grpc" &&
-        nextStack.javaApi !== "openapi-generator" &&
-        nextStack.email !== "resend" &&
-        nextStack.search !== "meilisearch" &&
-        nextStack.caching !== "upstash-redis" &&
-        nextStack.observability !== "sentry" &&
-        !nextStack.javaTestingLibraries.some((library) =>
-          kotlinUnsupportedTestingLibraries.has(library),
-        );
-
-      if (!kotlinSupported) {
+      const kotlinBlocker = getKotlinJavaIncompatibilityReason(nextStack);
+      if (kotlinBlocker) {
         nextStack.javaLanguage = "java";
         changed = true;
         changes.push({
           category: "javaLanguage",
-          message:
-            "Java language set to 'Java' (Kotlin currently targets the Spring Boot scaffold with Spring Data JPA/none, Spring GraphQL/none, and no jOOQ/MyBatis/gRPC/OpenAPI or Java-only service integrations)",
+          message: `Java language set to 'Java' (${kotlinBlocker})`,
         });
       }
     }
@@ -1931,6 +1974,64 @@ export const getDisabledReason = (
     }
     if (category === "validation" && optionId !== "effect-schema") {
       return "Effect backend requires Effect Schema validation";
+    }
+  }
+
+  // ============================================
+  // KOTLIN (JAVA LANGUAGE VARIANT) RULES
+  // ============================================
+  // Grey out the 'kotlin' option when the current stack excludes it, and grey
+  // out Kotlin-incompatible options while Kotlin is selected — instead of
+  // silently normalizing the language back to Java after the fact. Shares the
+  // gate in getKotlinJavaIncompatibilityReason. These run BEFORE the graph
+  // delegation below: the graph engine authoritatively handles categories like
+  // javaOrm and the ecosystem-scoped email/search/caching/observability rules
+  // return early for non-TypeScript ecosystems, so later placement would make
+  // these rules unreachable.
+  if (
+    category === "javaLanguage" &&
+    optionId === "kotlin" &&
+    currentStack.ecosystem === "java"
+  ) {
+    const kotlinBlocker = getKotlinJavaIncompatibilityReason(currentStack);
+    if (kotlinBlocker) {
+      return kotlinBlocker;
+    }
+  }
+
+  if (currentStack.ecosystem === "java" && currentStack.javaLanguage === "kotlin") {
+    if (category === "javaWebFramework" && optionId !== "spring-boot") {
+      return "Kotlin sources are only wired for the Spring Boot scaffold";
+    }
+    if (category === "javaBuildTool" && optionId === "none") {
+      return "Kotlin requires Maven or Gradle";
+    }
+    if (category === "javaOrm" && (optionId === "jooq" || optionId === "mybatis")) {
+      return "The Kotlin scaffold supports Spring Data JPA or no ORM (jOOQ/MyBatis sources are Java-only)";
+    }
+    if (category === "javaApi" && (optionId === "grpc" || optionId === "openapi-generator")) {
+      return "The Kotlin scaffold supports Spring GraphQL or no API layer (gRPC/OpenAPI codegen paths are Java-only)";
+    }
+    if (category === "javaLibraries" && KOTLIN_DROPPED_JAVA_LIBRARIES.has(optionId)) {
+      return "Java annotation-processor tooling is not wired for Kotlin (data classes replace Lombok; MapStruct would need kapt)";
+    }
+    if (
+      category === "javaTestingLibraries" &&
+      KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES.has(optionId)
+    ) {
+      return `The '${optionId}' testing library is not wired for the Kotlin scaffold`;
+    }
+    if (category === "email" && optionId === "resend") {
+      return "The Resend email integration is Java-only in the Java ecosystem scaffold";
+    }
+    if (category === "search" && optionId === "meilisearch") {
+      return "The Meilisearch integration is Java-only in the Java ecosystem scaffold";
+    }
+    if (category === "caching" && optionId === "upstash-redis") {
+      return "The Upstash Redis integration is Java-only in the Java ecosystem scaffold";
+    }
+    if (category === "observability" && optionId === "sentry") {
+      return "The Sentry integration is Java-only in the Java ecosystem scaffold";
     }
   }
 


### PR DESCRIPTION
## Problem

Kotlin (the `javaLanguage` variant of the Java ecosystem) is deliberately scoped to the Spring Boot scaffold, but the gate enforcing that was dishonest and fragile:

- **CLI silent fallback**: the create path never runs `analyzeStackCompatibility`, and no prompt was Kotlin-filtered — pick Kotlin + jOOQ/gRPC/testcontainers/Resend and you got a **Java project with zero warning**, while `bts.jsonc` recorded `kotlin`.
- **Web UI**: `getDisabledReason` had no `javaLanguage` rules — nothing was greyed out; picking Quarkus under the Kotlin card just silently flipped the ecosystem tab back to Java. The graph builder filtered frameworks but still offered jOOQ/MyBatis.
- **Gate duplication**: the support gate was hand-duplicated in `compatibility.ts` and `java-base.ts` (drift risk).
- **Kotlin+JPA**: entities were final — no `allOpen` for `jakarta.persistence` annotations (Hibernate lazy-proxy footgun); Maven inherited a Boot-managed Kotlin version while Gradle pinned 2.2.20.
- The original feature was only ever verified by **compiling**, never by running its tests.

## Changes

- **Single source of truth**: `getKotlinJavaIncompatibilityReason()` + `KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES` + `KOTLIN_DROPPED_JAVA_LIBRARIES` in `packages/types`, consumed by stack normalization, `getDisabledReason`, the CLI, and the template generator.
- **`getDisabledReason` rules**: Kotlin-incompatible options are greyed out while Kotlin is selected (quarkus/micronaut, buildTool none, jOOQ/MyBatis, gRPC/OpenAPI Generator, 6 testing libs, lombok/mapstruct, resend/meilisearch/upstash-redis/sentry), and the `kotlin` option is greyed out when the current stack excludes it. Placed **before** the graph delegation, which early-returns authoritative `null` for `javaOrm` etc. (later placement is unreachable — covered by tests).
- **CLI**: interactive prompts filter Kotlin-incompatible options; the language prompt skips offering Kotlin (with a note) when an earlier-resolved Java-only integration excludes it; flag/config-driven runs get a visible `▲ JVM language set to Java: <reason>` warning via `normalizeKotlinJavaSelection()` and `bts.jsonc` records the actual language.
- **Web graph builder**: ORM step filters to Spring Data JPA/none under the Kotlin card.
- **Templates**: `allOpen` for `@Entity`/`@MappedSuperclass`/`@Embeddable` in both build files (Maven needs `<plugin>all-open</plugin>` registered in `compilerPlugins`, otherwise `pluginOptions` fail with *Plugin not found: all-open* — caught by an actual `./mvnw test` run); pom pins `<kotlin.version>2.2.20</kotlin.version>`; removed the dead `ApplicationContainerTests.kt.hbs` gate branch.
- **Tests**: new "Kotlin Language Gate" block in `apps/cli/test/java-ecosystem.test.ts` (normalization, disabled reasons, prompt filtering).

## Verification

- Full `turbo test` 6/6 green on this exact base — **3550 pass / 0 fail**, all 95 Java template snapshots byte-identical (default Java path unchanged).
- Runtime (not just compile): scaffolded Kotlin apps run their real test suites — `./gradlew test` (JPA+security+validation+caffeine) BUILD SUCCESSFUL with full Spring context boot; `./mvnw test` (JPA+security+GraphQL) 4/4 green.
- CLI fallback verified live: `--java-language kotlin --java-orm jooq` and `--search meilisearch` both print the warning and scaffold Java sources with truthful `bts.jsonc`.

## Note

A pre-existing quirk surfaced (not fixed here): the generic "Email requires backend" normalization isn't ecosystem-guarded, so `analyzeStackCompatibility` clears `email: resend` for any Java stack (Java always has `backend: "none"`). Affects MCP/web analyze flows independently of Kotlin — worth a follow-up.