### PR TITLE
fix(ci): restore template dependency updates

### DIFF
--- a/.github/workflows/dep-freshness.yaml
+++ b/.github/workflows/dep-freshness.yaml
@@ -1,4 +1,4 @@
-name: Dependency Freshness Check
+name: Weekly Security Audit
 
 on:
   schedule:
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   security-audit:
@@ -35,87 +34,3 @@ jobs:
         with:
           name: security-audit-report
           path: audit-report.txt
-
-  update-template-deps:
-    name: Update Template Dependency Versions
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install Dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Audit Before Update
-        run: bun run scripts/check-dep-versions.ts 2>&1 | tee dep-report.txt
-
-      - name: Apply Minor/Patch Updates
-        run: bun run scripts/check-dep-versions.ts --update
-
-      - name: Build Workspace Packages
-        run: |
-          bun run --cwd packages/types build
-          bun run --cwd packages/template-generator build
-
-      - name: Regenerate Snapshots
-        run: bun test apps/cli/test/template-snapshots.test.ts --update-snapshots
-
-      - name: Verify Dependency Channel Resolution
-        run: |
-          bun test apps/cli/test/dependency-version-channel.test.ts
-          bun test apps/cli/test/generated-command-contract.test.ts
-
-      - name: Check For Changes
-        id: changes
-        run: |
-          if git diff --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create Pull Request
-        if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.PAT_WORKFLOW }}
-          branch: chore/template-dep-updates
-          delete-branch: true
-          title: "chore(deps): update template dependency versions"
-          body: |
-            Automated weekly update of hardcoded dependency versions in scaffold templates.
-
-            ## What changed
-            Minor and patch version bumps across all ecosystems:
-            - **npm** — `packages/template-generator/src/utils/add-deps.ts`
-            - **Rust** — `templates/rust-base/Cargo.toml.hbs`
-            - **Go** — `templates/go-base/go.mod.hbs`
-            - **Python** — `templates/python-base/pyproject.toml.hbs`
-            - **Java** — `templates/java-base/pom.xml.hbs` and `templates/java-base/build.gradle.kts.hbs`
-            - **Elixir** — `templates/elixir-base/mix.exs.hbs`
-            - **.NET** — `templates/dotnet-base/*.csproj.hbs`
-
-            Major version bumps are **not** included — they are listed in the
-            `dep-freshness-report` artifact for manual review.
-
-            ## Validation
-            - Template generator rebuilt
-            - Template snapshots regenerated
-            - No type-check or lint failures expected (version strings only)
-          labels: |
-            dependencies
-            automated
-          commit-message: "chore(deps): update template dependency versions"
-
-      - name: Upload Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dep-freshness-report
-          path: dep-report.txt

--- a/apps/cli/test/generated-command-contract.test.ts
+++ b/apps/cli/test/generated-command-contract.test.ts
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import fs from "fs-extra";
 
+import { dependencyVersionMap } from "@better-fullstack/template-generator";
 import {
   DEFAULT_STACK_SELECTION,
   generateStackSelectionCommand,
@@ -408,6 +409,9 @@ describe("generated beta dependency invariants", () => {
   it(
     "keeps Turborepo at the stable template floor for beta scaffolds",
     async () => {
+      const turboTemplateFloor = dependencyVersionMap.turbo;
+      const turboStableVersion = turboTemplateFloor.replace(/^[~^]/, "");
+
       global.fetch = mock(async (input: string | URL | Request) => {
         const url = String(input);
         const packageName = decodeURIComponent(url.split("/").pop() ?? "");
@@ -416,12 +420,12 @@ describe("generated beta dependency invariants", () => {
           return new Response(
             JSON.stringify({
               "dist-tags": {
-                latest: "2.10.0",
+                latest: turboStableVersion,
                 next: "0.9.0-next.22",
               },
               versions: {
                 "0.9.0-next.22": {},
-                "2.10.0": {},
+                [turboStableVersion]: {},
               },
             }),
             {
@@ -469,7 +473,7 @@ describe("generated beta dependency invariants", () => {
       expectSuccess(result);
 
       const packageJson = await fs.readJson(join(result.projectDir!, "package.json"));
-      expect(packageJson.devDependencies.turbo).toBe("^2.10.0");
+      expect(packageJson.devDependencies.turbo).toBe(turboTemplateFloor);
       expect(packageJson.scripts["db:generate"]).toContain("turbo");
     },
     { timeout: 60_000 },


### PR DESCRIPTION
## Summary

- derive the Turborepo beta invariant from the canonical template dependency map
- keep the Wednesday security audit while removing its duplicate template updater
- leave the Monday dependency version workflow as the single template-update owner
- reduce the retained audit workflow permissions to read-only contents

## Root cause

The primary updater changed the canonical Turborepo version while its contract test asserted an old literal. A second overlapping updater also failed on PR-creation hooks and could produce competing dependency branches.

## Validation

- built packages/types
- built packages/template-generator
- bun test apps/cli/test/generated-command-contract.test.ts
- parsed both affected workflow YAML files
- pre-commit monorepo lint passed