### PR TITLE
fix(templates): type Intlayer locale from provider

### DIFF
--- a/apps/cli/test/i18n.test.ts
+++ b/apps/cli/test/i18n.test.ts
@@ -95,9 +95,7 @@ describe("i18n Options", () => {
       expectSuccess(result);
 
       const nextConfig = await readWebFile(result.projectDir!, "next.config.ts");
-      expect(nextConfig).toContain(
-        'import { paraglideWebpackPlugin } from "@inlang/paraglide-js"',
-      );
+      expect(nextConfig).toContain('import { paraglideWebpackPlugin } from "@inlang/paraglide-js"');
       expect(nextConfig).toContain("webpackConfig.plugins.push(");
       expect(nextConfig).toContain("paraglideWebpackPlugin({");
       expect(nextConfig).toContain('outdir: "./src/paraglide"');
@@ -105,6 +103,26 @@ describe("i18n Options", () => {
   });
 
   describe("Intlayer", () => {
+    test("uses the Next.js provider locale prop type", async () => {
+      const result = await runTRPCTest(
+        createCustomConfig({
+          projectName: "intlayer-next",
+          frontend: ["next"],
+          backend: "self",
+          runtime: "none",
+          api: "trpc",
+          i18n: "intlayer",
+        }),
+      );
+      expectSuccess(result);
+
+      const provider = await readWebFile(result.projectDir!, "src/i18n/provider.tsx");
+      expect(provider).toContain(
+        'locale?: ComponentProps<typeof IntlayerClientProvider>["locale"]',
+      );
+      expect(provider).not.toContain('import type { Locales } from "intlayer"');
+    });
+
     test("generates Intlayer setup for TanStack Router", async () => {
       const result = await runTRPCTest(
         createCustomConfig({

--- a/packages/template-generator/templates/i18n/intlayer/web/base/src/i18n/provider.tsx.hbs
+++ b/packages/template-generator/templates/i18n/intlayer/web/base/src/i18n/provider.tsx.hbs
@@ -1,8 +1,7 @@
 {{#if (eq frontend.[0] "next")}}"use client";
 
-import type { Locales } from "intlayer";
 import { IntlayerClientProvider } from "next-intlayer";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 /**
  * Wrap your Next.js App Router tree with this provider so that client
@@ -14,7 +13,7 @@ export function I18nProvider({
   locale,
 }: {
   children: ReactNode;
-  locale?: Locales;
+  locale?: ComponentProps<typeof IntlayerClientProvider>["locale"];
 }) {
   return (
     <IntlayerClientProvider locale={locale}>{children}</IntlayerClientProvider>


### PR DESCRIPTION
## Summary

- derive the Intlayer locale prop type from IntlayerClientProvider
- avoid importing Intlayer Locales namespace as a TypeScript type
- add focused Next.js generation coverage

## Verification

- bun test apps/cli/test/i18n.test.ts
- bun run test:release