### PR TITLE
fix(seo): derive JSON-LD counts, complete partial route heads, normalize stack-share paths

### DIFF
--- a/apps/web/content/blog/scaffbench-2.mdx
+++ b/apps/web/content/blog/scaffbench-2.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ScaffBench 2: ten configs, five ecosystems, and whether a model can scaffold from a prompt"
+title: "ScaffBench 2: nine configs, five ecosystems, and whether a model can scaffold from a prompt"
 description: "ScaffBench 2 runs Opus, GPT-5.5, and free models through five hard fullstack specs to test whether prompt-only scaffolds actually build."
 date: 2026-06-26
 authors:
@@ -126,7 +126,7 @@ print a fake ±.
 
 ## Across configs: who can build from scratch?
 
-To see whether raw capability moves the needle, we ran the same five specs across ten configs:
+To see whether raw capability moves the needle, we ran the same five specs across nine configs:
 **Opus 4.8, 4.7, 4.6, and 4.5** (Claude Code), **GPT-5.5 at low / medium / xhigh** (via a new Codex
 adapter), and **two free models** (via a new opencode/Kilo adapter). Same specs, same prompt-only
 lane, same scoring.

--- a/apps/web/src/lib/project-stats.ts
+++ b/apps/web/src/lib/project-stats.ts
@@ -64,3 +64,17 @@ export const COMPARISON_COUNTS = {
     (category) => category === "uiLibrary" || category === "mobileUI",
   ),
 };
+
+export const SOFTWARE_APPLICATION_COUNTS = {
+  frontendFrameworks: countUniqueSelectableOptions((category) => category.endsWith("Frontend")),
+  backendFrameworks: countUniqueSelectableOptions(
+    (category) => category === "backend" || category.endsWith("WebFramework"),
+  ),
+  databases: COMPARISON_COUNTS.databases,
+  orms: COMPARISON_COUNTS.orms,
+  authProviders: COMPARISON_COUNTS.authProviders,
+  paymentIntegrations: COMPARISON_COUNTS.paymentProviders,
+  aiIntegrations: COMPARISON_COUNTS.aiIntegrations,
+  apiOptions: COMPARISON_COUNTS.apis,
+  deploymentTargets: COMPARISON_COUNTS.deployTargets,
+};

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,6 +1,10 @@
 import { m } from "@/paraglide/messages.js";
 
-import { ECOSYSTEM_NAMES, OPTION_COUNT_LABEL } from "./project-stats";
+import {
+  ECOSYSTEM_NAMES,
+  OPTION_COUNT_LABEL,
+  SOFTWARE_APPLICATION_COUNTS,
+} from "./project-stats";
 
 export const SITE_NAME = "Better Fullstack";
 export const SITE_URL = "https://better-fullstack.dev";
@@ -20,6 +24,52 @@ export const DEFAULT_ROBOTS =
 export function canonicalUrl(path = "/") {
   const normalized = path.startsWith("/") ? path : `/${path}`;
   return new URL(normalized, SITE_URL).toString();
+}
+
+type PageHeadOptions = {
+  title: string;
+  description: string;
+  path: string;
+  image?: string;
+  twitterImage?: string;
+  imageAlt?: string;
+  ogType?: "article" | "website";
+  robots?: string;
+};
+
+export function buildPageHead({
+  title,
+  description,
+  path,
+  image = DEFAULT_OG_IMAGE_URL,
+  twitterImage = DEFAULT_X_IMAGE_URL,
+  imageAlt = DEFAULT_OG_IMAGE_ALT,
+  ogType = "website",
+  robots = DEFAULT_ROBOTS,
+}: PageHeadOptions) {
+  const url = canonicalUrl(path);
+
+  return {
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { name: "robots", content: robots },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { property: "og:type", content: ogType },
+      { property: "og:url", content: url },
+      { property: "og:image", content: image },
+      { property: "og:image:alt", content: imageAlt },
+      { property: "og:image:width", content: String(DEFAULT_OG_IMAGE_WIDTH) },
+      { property: "og:image:height", content: String(DEFAULT_OG_IMAGE_HEIGHT) },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: title },
+      { name: "twitter:description", content: description },
+      { name: "twitter:image", content: twitterImage },
+      { name: "twitter:image:alt", content: imageAlt },
+    ],
+    links: [{ rel: "canonical", href: url }],
+  };
 }
 
 export function getDefaultDescription() {
@@ -94,20 +144,20 @@ export function getSiteJsonLd() {
         description,
         programmingLanguage: ECOSYSTEM_NAMES,
         featureList: [
-          "15 frontend frameworks",
-          "17 backend frameworks",
-          "6 databases",
-          "13 ORMs",
-          "7 auth providers",
-          "5 payment integrations",
-          "13 AI integrations",
-          "7 type-safe API options",
+          `${SOFTWARE_APPLICATION_COUNTS.frontendFrameworks} frontend frameworks`,
+          `${SOFTWARE_APPLICATION_COUNTS.backendFrameworks} backend frameworks`,
+          `${SOFTWARE_APPLICATION_COUNTS.databases} databases`,
+          `${SOFTWARE_APPLICATION_COUNTS.orms} ORMs`,
+          `${SOFTWARE_APPLICATION_COUNTS.authProviders} auth providers`,
+          `${SOFTWARE_APPLICATION_COUNTS.paymentIntegrations} payment integrations`,
+          `${SOFTWARE_APPLICATION_COUNTS.aiIntegrations} AI integrations`,
+          `${SOFTWARE_APPLICATION_COUNTS.apiOptions} type-safe API options`,
           "Visual web stack builder",
           "Monorepo support via Turborepo",
           "Desktop apps via Tauri",
           "Mobile apps via Expo / React Native",
           "PWA support",
-          "5 deployment targets",
+          `${SOFTWARE_APPLICATION_COUNTS.deploymentTargets} deployment targets`,
         ],
         image: DEFAULT_OG_IMAGE_URL,
         screenshot: DEFAULT_OG_IMAGE_URL,

--- a/apps/web/src/lib/sitemap-core.ts
+++ b/apps/web/src/lib/sitemap-core.ts
@@ -20,6 +20,7 @@ const staticSitemapEntries: SitemapEntry[] = [
   { path: "/benchmark", changefreq: "weekly", priority: 0.8 },
   { path: "/compare", changefreq: "weekly", priority: 0.8 },
   { path: "/mcp", changefreq: "weekly", priority: 0.7 },
+  { path: "/run", changefreq: "weekly", priority: 0.7 },
 ];
 
 function escapeXml(value: string) {

--- a/apps/web/src/lib/stack-share-paths.ts
+++ b/apps/web/src/lib/stack-share-paths.ts
@@ -91,7 +91,7 @@ export function parseStackShareSlug(slug: string): StackState | null {
   }
 
   for (const [ecosystem, shareSlug] of Object.entries(ECOSYSTEM_SHARE_SLUGS)) {
-    if (shareSlug.toLowerCase() === normalizedSlug || ecosystem === normalizedSlug) {
+    if (shareSlug === normalizedSlug || ecosystem === normalizedSlug) {
       return createEcosystemShareStack(ecosystem as StackState["ecosystem"]);
     }
   }

--- a/apps/web/src/lib/stack-share-slugs.ts
+++ b/apps/web/src/lib/stack-share-slugs.ts
@@ -6,24 +6,38 @@ import type { StackState } from "@/lib/stack-defaults";
  * compatibility engine / stack-translation bundle into the app entry chunk.
  */
 export const ECOSYSTEM_SHARE_SLUGS = {
-  typescript: "TypeScript",
-  "react-native": "React-Native",
-  rust: "Rust",
-  python: "Python",
-  go: "Go",
-  java: "Java",
-  elixir: "Elixir",
-} as const satisfies Partial<Record<StackState["ecosystem"], string>>;
+  typescript: "typescript",
+  "react-native": "react-native",
+  rust: "rust",
+  python: "python",
+  go: "go",
+  java: "java",
+  elixir: "elixir",
+  dotnet: "dotnet",
+} as const satisfies Record<StackState["ecosystem"], string>;
 
-export function isStackShareSlug(slug: string): boolean {
+export type StackShareSlug =
+  | (typeof ECOSYSTEM_SHARE_SLUGS)[keyof typeof ECOSYSTEM_SHARE_SLUGS]
+  | "multi-ecosystem";
+
+export function normalizeStackShareSlug(slug: string): StackShareSlug | null {
   const normalizedSlug = slug.toLowerCase();
-  if (normalizedSlug === "multi-ecosystem") return true;
+  if (normalizedSlug === "multi-ecosystem") return "multi-ecosystem";
 
   for (const [ecosystem, shareSlug] of Object.entries(ECOSYSTEM_SHARE_SLUGS)) {
-    if (shareSlug.toLowerCase() === normalizedSlug || ecosystem === normalizedSlug) {
-      return true;
+    if (shareSlug === normalizedSlug || ecosystem === normalizedSlug) {
+      return shareSlug;
     }
   }
 
-  return false;
+  return null;
+}
+
+export function getCanonicalStackSharePath(slug: string): string | null {
+  const canonicalSlug = normalizeStackShareSlug(slug);
+  return canonicalSlug ? `/${canonicalSlug}` : null;
+}
+
+export function isStackShareSlug(slug: string): boolean {
+  return normalizeStackShareSlug(slug) !== null;
 }

--- a/apps/web/src/routes/$stackShare.tsx
+++ b/apps/web/src/routes/$stackShare.tsx
@@ -1,9 +1,24 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 
 import { StackBuilderPage } from "@/components/stack-builder/stack-builder-page";
-import { canonicalUrl, SITE_NAME } from "@/lib/seo";
+import { buildPageHead, SITE_NAME } from "@/lib/seo";
 import { parseStackShareSlug } from "@/lib/stack-share-paths";
-import { m } from "@/paraglide/messages.js";
+import {
+  getCanonicalStackSharePath,
+  normalizeStackShareSlug,
+} from "@/lib/stack-share-slugs";
+
+const STACK_SHARE_LABELS = {
+  typescript: "TypeScript",
+  "react-native": "React Native",
+  rust: "Rust",
+  python: "Python",
+  go: "Go",
+  java: "Java",
+  elixir: "Elixir",
+  dotnet: ".NET",
+  "multi-ecosystem": "Multi-ecosystem",
+} as const;
 
 export const Route = createFileRoute("/$stackShare")({
   loader: ({ params }) => {
@@ -12,25 +27,16 @@ export const Route = createFileRoute("/$stackShare")({
     return { stack };
   },
   head: ({ params }) => {
-    const title = `${params.stackShare} Stack | ${SITE_NAME}`;
-    const description = m.shortStackSeoDescription();
+    const canonicalSlug = normalizeStackShareSlug(params.stackShare);
+    const label = canonicalSlug ? STACK_SHARE_LABELS[canonicalSlug] : "Shared";
+    const title = `${label} Stack | ${SITE_NAME}`;
+    const description = `Open the Better Fullstack ${label} builder configuration.`;
 
-    return {
-      meta: [
-        { title },
-        {
-          name: "description",
-          content: description,
-        },
-        { property: "og:title", content: title },
-        {
-          property: "og:description",
-          content: description,
-        },
-        { property: "og:url", content: canonicalUrl(`/${params.stackShare}`) },
-      ],
-      links: [{ rel: "canonical", href: canonicalUrl(`/${params.stackShare}`) }],
-    };
+    return buildPageHead({
+      title,
+      description,
+      path: getCanonicalStackSharePath(params.stackShare) ?? `/${params.stackShare.toLowerCase()}`,
+    });
   },
   component: StackSharePage,
 });

--- a/apps/web/src/routes/run.tsx
+++ b/apps/web/src/routes/run.tsx
@@ -3,43 +3,15 @@ import { ArrowRight, ArrowUpRight, Check, Copy } from "lucide-react";
 import { useCallback, useState, type CSSProperties } from "react";
 
 import Footer from "@/components/home/footer";
-import {
-  DEFAULT_OG_IMAGE_ALT,
-  DEFAULT_OG_IMAGE_HEIGHT,
-  DEFAULT_OG_IMAGE_URL,
-  DEFAULT_OG_IMAGE_WIDTH,
-  DEFAULT_ROBOTS,
-  DEFAULT_X_IMAGE_URL,
-  canonicalUrl,
-} from "@/lib/seo";
+import { buildPageHead, SITE_NAME } from "@/lib/seo";
 import { cn } from "@/lib/utils";
 import { m } from "@/paraglide/messages.js";
 
 export const Route = createFileRoute("/run")({
   head: () => {
-    const title = m.runSeoTitle();
+    const title = `${m.runSeoTitle()} | ${SITE_NAME}`;
     const description = m.runSeoDescription();
-    return {
-      meta: [
-        { title: `${title} — Better-Fullstack` },
-        { name: "description", content: description },
-        { name: "robots", content: DEFAULT_ROBOTS },
-        { property: "og:title", content: title },
-        { property: "og:description", content: description },
-        { property: "og:type", content: "website" },
-        { property: "og:url", content: canonicalUrl("/run") },
-        { property: "og:image", content: DEFAULT_OG_IMAGE_URL },
-        { property: "og:image:alt", content: DEFAULT_OG_IMAGE_ALT },
-        { property: "og:image:width", content: String(DEFAULT_OG_IMAGE_WIDTH) },
-        { property: "og:image:height", content: String(DEFAULT_OG_IMAGE_HEIGHT) },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:title", content: title },
-        { name: "twitter:description", content: description },
-        { name: "twitter:image", content: DEFAULT_X_IMAGE_URL },
-        { name: "twitter:image:alt", content: DEFAULT_OG_IMAGE_ALT },
-      ],
-      links: [{ rel: "canonical", href: canonicalUrl("/run") }],
-    };
+    return buildPageHead({ title, description, path: "/run" });
   },
   component: RunPage,
 });

--- a/apps/web/src/routes/stack.tsx
+++ b/apps/web/src/routes/stack.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { StackBuilderPage } from "@/components/stack-builder/stack-builder-page";
-import { canonicalUrl } from "@/lib/seo";
+import { buildPageHead } from "@/lib/seo";
 import { m } from "@/paraglide/messages.js";
 
 export const Route = createFileRoute("/stack")({
@@ -9,22 +9,7 @@ export const Route = createFileRoute("/stack")({
     const title = m.sharedStackSeoTitle();
     const description = m.sharedStackSeoDescription();
 
-    return {
-      meta: [
-        { title },
-        {
-          name: "description",
-          content: description,
-        },
-        { property: "og:title", content: title },
-        {
-          property: "og:description",
-          content: description,
-        },
-        { property: "og:url", content: canonicalUrl("/stack") },
-      ],
-      links: [{ rel: "canonical", href: canonicalUrl("/stack") }],
-    };
+    return buildPageHead({ title, description, path: "/stack" });
   },
   component: StackBuilderPage,
 });

--- a/apps/web/test/project-stats.test.ts
+++ b/apps/web/test/project-stats.test.ts
@@ -10,7 +10,21 @@ import {
   ECOSYSTEM_NAMES,
   OPTION_ENTRY_COUNT,
   PROJECT_ECOSYSTEM_COPY,
+  SOFTWARE_APPLICATION_COUNTS,
 } from "../src/lib/project-stats";
+
+function countUniqueOptions(categoryMatches: (category: string) => boolean) {
+  const optionIds = new Set<string>();
+
+  for (const [category, metadata] of Object.entries(OPTION_CATEGORY_METADATA)) {
+    if (!categoryMatches(category)) continue;
+    for (const option of metadata.options) {
+      if (option.id !== "none") optionIds.add(option.id);
+    }
+  }
+
+  return optionIds.size;
+}
 
 describe("dynamic project statistics", () => {
   it("derives ecosystem and option totals from canonical metadata", () => {
@@ -30,6 +44,17 @@ describe("dynamic project statistics", () => {
     expect(Object.values(COMPARISON_COUNTS).every((count) => count > 0)).toBe(true);
     expect(COMPARISON_COUNTS.databases).toBe(
       OPTION_CATEGORY_METADATA.database.options.filter((option) => option.id !== "none").length,
+    );
+  });
+
+  it("derives application frontend and backend counts across every ecosystem", () => {
+    expect(SOFTWARE_APPLICATION_COUNTS.frontendFrameworks).toBe(
+      countUniqueOptions((category) => category.endsWith("Frontend")),
+    );
+    expect(SOFTWARE_APPLICATION_COUNTS.backendFrameworks).toBe(
+      countUniqueOptions(
+        (category) => category === "backend" || category.endsWith("WebFramework"),
+      ),
     );
   });
 

--- a/apps/web/test/seo-contract.test.ts
+++ b/apps/web/test/seo-contract.test.ts
@@ -1,17 +1,38 @@
+import { OPTION_CATEGORY_METADATA } from "@better-fullstack/types";
 import { describe, expect, it } from "bun:test";
 
+import { blogPostHead } from "../src/lib/blog/seo";
 import { docsPageHead } from "../src/lib/docs/seo";
+import { guidePageHead } from "../src/lib/guides/seo";
 import { generateLlmsTxt } from "../src/lib/llms";
 import { OPTION_COUNT_LABEL } from "../src/lib/project-stats";
 import { NOINDEX_ROBOTS } from "../src/lib/robots";
-import { canonicalUrl } from "../src/lib/seo";
+import { buildPageHead, canonicalUrl, getSiteJsonLd, SITE_NAME } from "../src/lib/seo";
 import {
   generateSitemapXmlFromEntries,
   getSitemapEntriesFromPages,
 } from "../src/lib/sitemap-core";
 
+function countUniqueOptions(categoryMatches: (category: string) => boolean) {
+  const optionIds = new Set<string>();
+
+  for (const [category, metadata] of Object.entries(OPTION_CATEGORY_METADATA)) {
+    if (!categoryMatches(category)) continue;
+    for (const option of metadata.options) {
+      if (option.id !== "none") optionIds.add(option.id);
+    }
+  }
+
+  return optionIds.size;
+}
+
+function matchesCategoryFamily(category: string, family: string) {
+  const suffix = `${family.charAt(0).toUpperCase()}${family.slice(1)}`;
+  return category === family || category.endsWith(suffix);
+}
+
 describe("SEO contracts", () => {
-  it("includes docs, guides, and MCP in the dynamic sitemap", () => {
+  it("includes docs, guides, MCP, and the benchmark runner in the dynamic sitemap", () => {
     const entries = getSitemapEntriesFromPages({
       docsPages: [
         { slug: [], frontmatter: { updated: "2026-05-12" } },
@@ -31,10 +52,106 @@ describe("SEO contracts", () => {
     expect(paths).toContain("/docs/cli/create");
     expect(paths).toContain("/guides/typescript/create-tanstack-start-project");
     expect(paths).toContain("/mcp");
+    expect(paths).toContain("/run");
+    expect(paths).not.toContain("/stack");
     expect(paths).not.toContain("/analytics");
     expect(xml).toContain(canonicalUrl("/docs/cli/create"));
     expect(xml).toContain(canonicalUrl("/guides/typescript/create-tanstack-start-project"));
     expect(xml).not.toContain(canonicalUrl("/analytics"));
+  });
+
+  it("builds complete page heads with matching canonical and social metadata", () => {
+    const head = buildPageHead({
+      title: `Shared Stack | ${SITE_NAME}`,
+      description: "Open a shared Better Fullstack builder configuration.",
+      path: "/stack",
+    });
+
+    expect(head.links).toContainEqual({ rel: "canonical", href: canonicalUrl("/stack") });
+    expect(head.meta).toContainEqual({ name: "robots", content: expect.any(String) });
+    expect(head.meta).toContainEqual({ property: "og:type", content: "website" });
+    expect(head.meta).toContainEqual({ property: "og:image", content: expect.any(String) });
+    expect(head.meta).toContainEqual({ name: "twitter:card", content: "summary_large_image" });
+    expect(head.meta).toContainEqual({ name: "twitter:image", content: expect.any(String) });
+  });
+
+  it("keeps every SoftwareApplication feature count derived from option metadata", () => {
+    const expectedCounts = {
+      "frontend frameworks": countUniqueOptions((category) => category.endsWith("Frontend")),
+      "backend frameworks": countUniqueOptions(
+        (category) => category === "backend" || category.endsWith("WebFramework"),
+      ),
+      databases: countUniqueOptions((category) => category === "database"),
+      ORMs: countUniqueOptions((category) => matchesCategoryFamily(category, "orm")),
+      "auth providers": countUniqueOptions((category) => matchesCategoryFamily(category, "auth")),
+      "payment integrations": countUniqueOptions((category) => category === "payments"),
+      "AI integrations": countUniqueOptions((category) => matchesCategoryFamily(category, "ai")),
+      "type-safe API options": countUniqueOptions((category) =>
+        matchesCategoryFamily(category, "api"),
+      ),
+      "deployment targets": countUniqueOptions((category) => category.endsWith("Deploy")),
+    };
+    const softwareApplication = getSiteJsonLd()["@graph"].find(
+      (entry) => entry["@type"] === "SoftwareApplication",
+    ) as { featureList: string[] };
+    const renderedCounts = Object.fromEntries(
+      softwareApplication.featureList.flatMap((feature) => {
+        const match = /^(\d+) (.+)$/.exec(feature);
+        return match ? [[match[2], Number(match[1])]] : [];
+      }),
+    );
+
+    expect(renderedCounts).toEqual(expectedCounts);
+  });
+
+  it("renders complete metadata and JSON-LD for docs, guides, and blog posts", () => {
+    const pages = [
+      {
+        title: `Create Command | ${SITE_NAME}`,
+        url: "/docs/cli/create",
+        head: docsPageHead({
+          url: "/docs/cli/create",
+          frontmatter: {
+            title: "Create Command",
+            description: "Full reference for create-better-fullstack flags.",
+          },
+        }),
+      },
+      {
+        title: `Create a TanStack Start Project | ${SITE_NAME}`,
+        url: "/guides/typescript/create-tanstack-start-project",
+        head: guidePageHead({
+          url: "/guides/typescript/create-tanstack-start-project",
+          frontmatter: {
+            title: "Create a TanStack Start Project",
+            description: "Create a TanStack Start app with Better Fullstack.",
+          },
+        }),
+      },
+      {
+        title: `ScaffBench 2 | ${SITE_NAME}`,
+        url: "/blog/scaffbench-2",
+        head: blogPostHead({
+          url: "/blog/scaffbench-2",
+          frontmatter: {
+            title: "ScaffBench 2",
+            description: "Benchmarking fullstack scaffolding agents.",
+            date: "2026-06-26",
+          },
+        }),
+      },
+    ];
+
+    for (const page of pages) {
+      const canonical = canonicalUrl(page.url);
+
+      expect(page.head.meta).toContainEqual({ title: page.title });
+      expect(page.head.links).toContainEqual({ rel: "canonical", href: canonical });
+      expect(page.head.meta).toContainEqual({ property: "og:title", content: page.title });
+      expect(page.head.meta).toContainEqual({ property: "og:url", content: canonical });
+      expect(page.head.meta).toContainEqual({ property: "og:image", content: expect.any(String) });
+      expect(page.head.meta.some((meta) => "script:ld+json" in meta)).toBe(true);
+    }
   });
 
   it("keeps docs canonical URLs page-specific", () => {

--- a/apps/web/test/stack-state-contract.test.ts
+++ b/apps/web/test/stack-state-contract.test.ts
@@ -22,6 +22,7 @@ import {
   getStackSharePath,
   parseStackShareSlug,
 } from "../src/lib/stack-share-paths";
+import { getCanonicalStackSharePath } from "../src/lib/stack-share-slugs";
 import { getInitialBuilderState } from "../src/lib/stack-url-state";
 import { generateStackSharingUrl } from "../src/lib/stack-utils";
 
@@ -124,9 +125,20 @@ describe("StackState contract", () => {
     const multiStack = createDefaultMultiEcosystemShareStack();
 
     expect(elixirStack?.ecosystem).toBe("elixir");
-    expect(getStackSharePath(elixirStack as typeof DEFAULT_STACK)).toBe("/Elixir");
+    expect(getStackSharePath(elixirStack as typeof DEFAULT_STACK)).toBe("/elixir");
     expect(getStackSharePath(multiStack)).toBe("/multi-ecosystem");
     expect(parseStackShareSlug("multi-ecosystem")).toEqual(multiStack);
+  });
+
+  it("canonicalizes compact ecosystem share paths to lowercase", () => {
+    const dotnetStack = parseStackShareSlug("DotNet");
+
+    expect(getCanonicalStackSharePath("TypeScript")).toBe("/typescript");
+    expect(getCanonicalStackSharePath("React-Native")).toBe("/react-native");
+    expect(getCanonicalStackSharePath("Elixir")).toBe("/elixir");
+    expect(getCanonicalStackSharePath("DotNet")).toBe("/dotnet");
+    expect(dotnetStack?.ecosystem).toBe("dotnet");
+    expect(getStackSharePath(dotnetStack as typeof DEFAULT_STACK)).toBe("/dotnet");
   });
 
   it("keeps compact share paths out of default generated share URLs", () => {


### PR DESCRIPTION
Part of the growth work (task 1: GEO fixes). Implemented by GPT-5.6 Sol from a Sol audit that was adversarially verified by a fable-5 pass (every stat recounted and confirmed exact) — this PR is the verdict's 'safe now' subset.

## What
- **SoftwareApplication JSON-LD**: featureList numbers now derived from `OPTION_CATEGORY_METADATA` — the hardcoded values were badly stale (claimed 15 frontends / 17 backends; metadata says 23 / 48). New test asserts JSON-LD numbers always equal metadata-derived counts.
- **Shared `buildPageHead()` helper** in `lib/seo.ts` that always emits the complete head set; `/stack`, `/$stackShare`, and `/run` (previously partial: missing OG image, twitter card, robots, or with inconsistent branding) now use it.
- **Stack-share URLs**: canonical paths normalized to lowercase (`/typescript`, `/react-native`, …), parsing stays case-insensitive so old capitalized links keep working; added the missing `/dotnet` slug. All consumers derive from the same constant, so generated share links are consistent everywhere. `stack-state-contract` test updated deliberately for the new policy.
- **Sitemap**: `/run` added (was a full indexable page absent from the sitemap).
- **ScaffBench 2 post**: title/body said "ten configs" while listing nine — corrected to nine.
- **New regression tests**: head completeness + JSON-LD presence for docs/guide/blog heads.

Explicitly out of scope (tracked for follow-up): hreflang/locale URLs (architecture project), llms.txt restructure, stack-share landing-page content, benchmark dataset publication.

## Verification
- `bun run typecheck` exit 0
- `bun run test` — 326 pass / 0 fail (was 321; 5 new)
- `bun run lint` exit 0