### PR TITLE
docs(cli): switch Roo Code references to Zoo Code

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -83,7 +83,7 @@ claude mcp add --transport stdio better-fullstack -- npx create-better-fullstack
 }
 ```
 
-**Cline / Roo Code** (MCP settings):
+**Cline / [Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code)** (MCP settings):
 
 ```json
 {

--- a/apps/cli/src/helpers/addons/ruler-setup.ts
+++ b/apps/cli/src/helpers/addons/ruler-setup.ts
@@ -52,7 +52,7 @@ export async function setupRuler(config: ProjectConfig) {
       opencode: { label: "OpenCode" },
       openhands: { label: "Open Hands" },
       qwen: { label: "Qwen" },
-      roo: { label: "RooCode" },
+      roo: { label: "Zoo Code" },
       trae: { label: "Trae AI" },
       warp: { label: "Warp" },
       windsurf: { label: "Windsurf" },

--- a/apps/cli/src/helpers/addons/skills-setup.ts
+++ b/apps/cli/src/helpers/addons/skills-setup.ts
@@ -52,7 +52,7 @@ const AVAILABLE_AGENTS: AgentOption[] = [
   { value: "opencode", label: "OpenCode" },
   { value: "windsurf", label: "Windsurf" },
   { value: "goose", label: "Goose" },
-  { value: "roo", label: "Roo Code" },
+  { value: "roo", label: "Zoo Code" },
   { value: "kilo", label: "Kilo Code" },
   { value: "gemini-cli", label: "Gemini CLI" },
   { value: "antigravity", label: "Antigravity" },

--- a/apps/cli/src/helpers/addons/ultracite-setup.ts
+++ b/apps/cli/src/helpers/addons/ultracite-setup.ts
@@ -82,7 +82,7 @@ const AGENTS = {
   augmentcode: { label: "AugmentCode" },
   "kilo-code": { label: "Kilo Code" },
   goose: { label: "Goose" },
-  "roo-code": { label: "Roo Code" },
+  "roo-code": { label: "Zoo Code" },
   warp: { label: "Warp" },
   droid: { label: "Droid" },
   opencode: { label: "OpenCode" },


### PR DESCRIPTION
## Summary

- replace the MCP documentation's Roo Code reference with a linked Zoo Code reference
- rename the Zoo Code labels shown by the skills, Ruler, and Ultracite setup prompts
- preserve the existing `roo` and `roo-code` integration identifiers for compatibility

Roo Code has been archived. Its [archival disclaimer](https://github.com/RooCodeInc/Roo-Code#disclaimer) identifies [Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code) as the community successor.

## Scope

This PR changes four user-facing strings across four files. It does not change integration behavior, generated files, formatting, deployment configuration, or compatibility identifiers.

## Validation

- repository-wide case-insensitive Roo Code reference inventory
- changed-file formatting and diff checks
- CLI lint, build, and test suite
- release guard and link validation
