### PR TITLE
fix(template-generator): add React types for Resend in frontend-less stacks

### DIFF
--- a/apps/cli/test/email.test.ts
+++ b/apps/cli/test/email.test.ts
@@ -2,10 +2,45 @@ import { describe, it, expect } from "bun:test";
 
 import type { Backend, Frontend, Email } from "../src/types";
 
+import { createVirtual } from "../src/index";
 import { expectSuccess, runTRPCTest, type TestConfig } from "./test-utils";
+import { readVirtualFileContent } from "./virtual-tree-utils";
 
 describe("Email Configurations", () => {
   describe("Resend Email", () => {
+    it("adds React types for the frontend-less Fastify smoke stack", async () => {
+      const result = await createVirtual({
+        projectName: "typescript-fastify-ts-rest-scss-1e1ww1",
+        frontend: ["none"],
+        backend: "fastify",
+        runtime: "bun",
+        api: "ts-rest",
+        database: "none",
+        orm: "none",
+        auth: "none",
+        email: "resend",
+        logging: "winston",
+        analytics: "umami",
+        stateManagement: "zustand",
+        validation: "none",
+        testing: "vitest-playwright",
+        cssFramework: "scss",
+        addons: ["none"],
+        examples: ["none"],
+        dbSetup: "none",
+        webDeploy: "none",
+        serverDeploy: "none",
+      });
+
+      expect(result.success).toBe(true);
+      const root = result.tree!.root;
+      const serverPackage = JSON.parse(readVirtualFileContent(root, "apps/server/package.json"));
+      const emailSource = readVirtualFileContent(root, "apps/server/src/lib/email.ts");
+
+      expect(emailSource).toContain("React.ReactElement");
+      expect(serverPackage.devDependencies?.["@types/react"]).toBeDefined();
+    });
+
     it("should work with resend + hono backend", async () => {
       const result = await runTRPCTest({
         projectName: "resend-hono",

--- a/packages/template-generator/src/processors/email-deps.ts
+++ b/packages/template-generator/src/processors/email-deps.ts
@@ -97,15 +97,7 @@ export function processEmailDeps(vfs: VirtualFileSystem, config: ProjectConfig):
 
   // Add React Email components for resend and react-email options (not nodemailer)
   const hasReactWeb = frontend.some((f) =>
-    [
-      "tanstack-router",
-      "react-router",
-      "react-vite",
-      "tanstack-start",
-      "next",
-      "vinext",
-      "redwood",
-    ].includes(f),
+    ["tanstack-router", "react-router", "react-vite", "tanstack-start", "next", "vinext", "redwood"].includes(f),
   );
 
   if (hasReactWeb && vfs.exists(targetPath) && (email === "resend" || email === "react-email")) {

--- a/packages/template-generator/src/processors/email-deps.ts
+++ b/packages/template-generator/src/processors/email-deps.ts
@@ -36,6 +36,7 @@ export function processEmailDeps(vfs: VirtualFileSystem, config: ProjectConfig):
       vfs,
       packagePath: targetPath,
       dependencies: ["resend"],
+      devDependencies: ["@types/react"],
     });
   }
 

--- a/packages/template-generator/src/processors/email-deps.ts
+++ b/packages/template-generator/src/processors/email-deps.ts
@@ -30,7 +30,7 @@ export function processEmailDeps(vfs: VirtualFileSystem, config: ProjectConfig):
 
   if (!targetPath) return;
 
-  // Add Resend SDK for resend option
+  // Add Resend SDK and React types for resend option
   if (email === "resend") {
     addPackageDependency({
       vfs,
@@ -97,7 +97,15 @@ export function processEmailDeps(vfs: VirtualFileSystem, config: ProjectConfig):
 
   // Add React Email components for resend and react-email options (not nodemailer)
   const hasReactWeb = frontend.some((f) =>
-    ["tanstack-router", "react-router", "react-vite", "tanstack-start", "next", "vinext", "redwood"].includes(f),
+    [
+      "tanstack-router",
+      "react-router",
+      "react-vite",
+      "tanstack-start",
+      "next",
+      "vinext",
+      "redwood",
+    ].includes(f),
   );
 
   if (hasReactWeb && vfs.exists(targetPath) && (email === "resend" || email === "react-email")) {


### PR DESCRIPTION
## Summary

Fix the frontend-less Resend scaffold failure exposed by [Smoke Test run 30014133236](https://github.com/Marve10s/Better-Fullstack/actions/runs/30014133236) with seed `b43b19948931cd889ebfee1dd85d6dd214d45591`.

The generated `typescript-fastify-ts-rest-scss-1e1ww1` server emits `react?: React.ReactElement` in `src/lib/email.ts`, but the dependency processor previously added `@types/react` only when a React frontend was selected. With `frontend=none`, `tsc` failed with `TS2503: Cannot find namespace 'React'`.

## Changes

- Add `@types/react` to Resend server dev dependencies at the template-generator dependency boundary.
- Preserve the existing Resend helper API and runtime dependencies.
- Add focused virtual-generation coverage for the exact failing Fastify, ts-rest, Resend, Winston, Umami, Zustand, Vitest/Playwright, and SCSS combination.

## Causal Evidence

- Before the fix, the exact generated server contained `React.ReactElement` but no `@types/react`, reproducing `TS2503`.
- As the smallest counterfactual, adding only `@types/react` to that unchanged generated server made both workspace `check-types` tasks pass.
- After the generator fix, the same seed and combination installs and typechecks successfully while retaining `React.ReactElement`.

## Validation

- `bun test apps/cli/test/email.test.ts`: 84 passed
- `bun run --cwd packages/template-generator lint`: passed (pre-existing warnings only)
- `bun run --cwd packages/template-generator build`: passed
- `bun run --cwd apps/cli build`: passed
- `bun run test:release`: passed
- Exact reproduction: `bun run testing/smoke-test.ts --seed b43b19948931cd889ebfee1dd85d6dd214d45591 --count 14 --output testing/.smoke-output`
- Exact target result after fix: install passed and typecheck passed. The full local matrix still reported unrelated environment/current-registry failures, including missing non-TypeScript toolchains and `tsdown` resolving without `unrun`.
- Upstream CI: all 18 code, build, test, release, and smoke checks passed. Vercel preview deployment requires project-team authorization for the fork and is not a code failure.
