### PR TITLE
chore(release): 2.3.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Scaffold production-ready fullstack apps in TypeScript, React Native, Rust, Go, Python, Java, .NET, and Elixir — visual builder, CLI, and MCP server, with every integration wired together.",
   "keywords": [
     "ai-agent",
@@ -145,8 +145,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@better-fullstack/template-generator": "^2.3.0",
-    "@better-fullstack/types": "^2.3.0",
+    "@better-fullstack/template-generator": "^2.3.1",
+    "@better-fullstack/types": "^2.3.1",
     "@clack/core": "^0.5.0",
     "@clack/prompts": "^1.7.0",
     "@orpc/server": "^1.14.8",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -80,6 +80,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.3.0"
+    "create-better-fullstack": "^2.3.1"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -62,7 +62,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.3.0",
+    "@better-fullstack/types": "^2.3.1",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-fullstack",
   "displayName": "Better Fullstack",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-fullstack",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack",


### PR DESCRIPTION
Patch release: nuxt 4.4.8 pin, npm 10 @vitejs/devtools override, Resend React types for frontend-less stacks (#345), pip-backed --verify + python package-manager fixes, torii+rusqlite gate, dependency updates (#348, #349).