### PR TITLE
feat(web): capture builder failures

### DIFF
--- a/apps/web/src/components/stack-builder/run-panel.tsx
+++ b/apps/web/src/components/stack-builder/run-panel.tsx
@@ -27,6 +27,13 @@ import {
   type RunnableProject,
   type RunnableSourceFile,
 } from "@/lib/project-runner";
+import {
+  classifyBuilderRunFailure,
+  failureDurationMs,
+  shouldReportBuilderRunFailure,
+  type BuilderRunFailure,
+  type BuilderRunFailureStage,
+} from "@/lib/builder-failure-analytics";
 import { getStackRunSupport } from "@/lib/run-support";
 import { cn } from "@/lib/utils";
 import * as m from "@/paraglide/messages";
@@ -56,6 +63,7 @@ interface RunPanelProps {
   onCopy: () => void;
   onRunStarted?: (rerun: boolean) => void;
   onRunReady?: (rerun: boolean) => void;
+  onRunFailed?: (failure: BuilderRunFailure) => void;
 }
 
 const MAX_LOG_LENGTH = 60_000;
@@ -203,6 +211,7 @@ export function RunPanel({
   onCopy,
   onRunStarted,
   onRunReady,
+  onRunFailed,
 }: RunPanelProps) {
   const support = useMemo(() => getStackRunSupport(stack), [stack]);
   const stackSignature = JSON.stringify(stack);
@@ -222,13 +231,36 @@ export function RunPanel({
   const runtimeMountedRef = useRef(false);
   const dependenciesInstalledRef = useRef(false);
   const hasCompletedRunRef = useRef(false);
+  const lastReportedFailureRunIdRef = useRef(-1);
+  const generationSignatureRef = useRef<string | null>(null);
+  const generationAttemptRef = useRef(0);
   const consoleRef = useRef<HTMLPreElement>(null);
   const selectedFilePathRef = useRef(selectedFilePath);
   const onSelectFileRef = useRef(onSelectFile);
+  const onRunFailedRef = useRef(onRunFailed);
   selectedFilePathRef.current = selectedFilePath;
   onSelectFileRef.current = onSelectFile;
+  onRunFailedRef.current = onRunFailed;
+
+  const reportRunFailure = useCallback(
+    (runId: number, failure: BuilderRunFailure) => {
+      if (
+        !shouldReportBuilderRunFailure(
+          runIdRef.current,
+          runId,
+          lastReportedFailureRunIdRef.current,
+        )
+      ) {
+        return;
+      }
+      lastReportedFailureRunIdRef.current = runId;
+      onRunFailedRef.current?.(failure);
+    },
+    [],
+  );
 
   const prepareWorkspace = useCallback(async () => {
+    const startedAt = Date.now();
     const runId = runIdRef.current + 1;
     runIdRef.current = runId;
     runtimeMountedRef.current = false;
@@ -241,6 +273,13 @@ export function RunPanel({
     setPreviewUrl(null);
     setError(null);
     setBrowserUnsupported(false);
+
+    if (generationSignatureRef.current !== stackSignature) {
+      generationSignatureRef.current = stackSignature;
+      generationAttemptRef.current = 0;
+    }
+    const isRegeneration = generationAttemptRef.current > 0;
+    generationAttemptRef.current += 1;
 
     if (!support.supported) {
       onSelectFileRef.current(null);
@@ -268,10 +307,16 @@ export function RunPanel({
       setStatus("idle");
     } catch (generationError) {
       if (runIdRef.current !== runId) return;
+      const failure = classifyBuilderRunFailure("generation", generationError);
+      reportRunFailure(runId, {
+        ...failure,
+        durationMs: failureDurationMs(startedAt),
+        rerun: isRegeneration,
+      });
       setError(errorMessage(generationError));
       setStatus("error");
     }
-  }, [stackSignature, support.supported]);
+  }, [reportRunFailure, stackSignature, support.supported]);
 
   useEffect(() => {
     void import("@/lib/webcontainer-runtime").then(({ stopDevelopmentServer }) => {
@@ -333,6 +378,7 @@ export function RunPanel({
   const runProject = async () => {
     if (!support.supported || !project || busy) return;
 
+    const startedAt = Date.now();
     const isRerun = hasCompletedRunRef.current;
     onRunStarted?.(isRerun);
     const runId = runIdRef.current + 1;
@@ -346,23 +392,35 @@ export function RunPanel({
       if (runIdRef.current !== runId) throw new Error("Run cancelled");
     };
 
+    let failureStage: BuilderRunFailureStage = "runtime_boot";
+
     try {
       const runtimeModule = await import("@/lib/webcontainer-runtime");
+      failureStage = "browser_support";
       if (!runtimeModule.canBootBrowserRuntime()) {
+        const failure = classifyBuilderRunFailure(failureStage);
+        reportRunFailure(runId, {
+          ...failure,
+          durationMs: failureDurationMs(startedAt),
+          rerun: isRerun,
+        });
         setBrowserUnsupported(true);
         setStatus("error");
         return;
       }
 
       setStatus("booting");
+      failureStage = "runtime_boot";
       const runtime = await runtimeModule.getBrowserRuntime();
       ensureCurrentRun();
 
       if (!runtimeMountedRef.current) {
+        failureStage = "project_mount";
         await runtimeModule.mountRunnableProject(runtime, project.files);
         runtimeMountedRef.current = true;
       } else {
         runtimeModule.stopDevelopmentServer();
+        failureStage = "source_sync";
         await runtimeModule.syncRunnableSourceFiles(runtime, currentFiles);
       }
       ensureCurrentRun();
@@ -371,12 +429,14 @@ export function RunPanel({
       if (!dependenciesInstalledRef.current || dependenciesChanged) {
         dependenciesInstalledRef.current = false;
         setStatus("installing");
+        failureStage = "dependency_install";
         await runtimeModule.installRunnableProject(runtime, appendOutput);
         dependenciesInstalledRef.current = true;
         ensureCurrentRun();
       }
 
       setStatus("starting");
+      failureStage = "server_start";
       const url = await runtimeModule.startDevelopmentServer(
         runtime,
         project.script,
@@ -384,6 +444,12 @@ export function RunPanel({
         appendOutput,
         (exitCode) => {
           if (runIdRef.current !== runId) return;
+          const failure = classifyBuilderRunFailure("server_exit");
+          reportRunFailure(runId, {
+            ...failure,
+            durationMs: failureDurationMs(startedAt),
+            rerun: isRerun,
+          });
           setPreviewUrl(null);
           setError(`Development server exited with code ${exitCode}.`);
           setStatus("error");
@@ -397,6 +463,12 @@ export function RunPanel({
       onRunReady?.(isRerun);
     } catch (runError) {
       if (runIdRef.current !== runId) return;
+      const failure = classifyBuilderRunFailure(failureStage, runError);
+      reportRunFailure(runId, {
+        ...failure,
+        durationMs: failureDurationMs(startedAt),
+        rerun: isRerun,
+      });
       setError(errorMessage(runError));
       setStatus("error");
     }

--- a/apps/web/src/components/stack-builder/stack-builder.tsx
+++ b/apps/web/src/components/stack-builder/stack-builder.tsx
@@ -76,6 +76,12 @@ import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { clearBuilderMode, publishBuilderMode } from "@/lib/builder-mode-bridge";
 import {
+  classifyBuilderZipFailure,
+  failureDurationMs,
+  type BuilderRunFailure,
+  type BuilderZipFailureStage,
+} from "@/lib/builder-failure-analytics";
+import {
   stackAnalyticsProperties,
   trackCampaignEvent,
 } from "@/lib/campaign-analytics";
@@ -2224,6 +2230,7 @@ const StackBuilder = ({ initialStack }: { initialStack?: StackState }) => {
 
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const downloadAttemptRef = useRef(0);
   const lastAppliedStackString = useRef<string>("");
   const lastAppliedEcosystemRef = useRef<Ecosystem>(stack.ecosystem);
   const suppressCompatibilityToastRef = useRef(false);
@@ -2268,11 +2275,16 @@ const StackBuilder = ({ initialStack }: { initialStack?: StackState }) => {
   const handleDownloadProject = async () => {
     if (isDownloadingProject) return;
 
+    const startedAt = Date.now();
+    const isRetry = downloadAttemptRef.current > 0;
+    downloadAttemptRef.current += 1;
+    let failureStage: BuilderZipFailureStage = "archive_generation";
     setIsDownloadingProject(true);
     try {
       const { createStackProjectArchive, downloadProjectArchive } =
         await import("@/lib/project-download");
       const archive = await createStackProjectArchive(adjustedStack || stack);
+      failureStage = "browser_download";
       downloadProjectArchive(archive);
       trackCampaignEvent(
         "builder_zip_downloaded",
@@ -2281,6 +2293,17 @@ const StackBuilder = ({ initialStack }: { initialStack?: StackState }) => {
       toast.success(m.builderDownloadComplete({ fileName: archive.fileName }));
       promptForShare("download");
     } catch (downloadError) {
+      const failure = classifyBuilderZipFailure(failureStage);
+      trackCampaignEvent(
+        "builder_zip_failed",
+        stackAnalyticsProperties(adjustedStack || stack, {
+          campaign,
+          stage: failure.stage,
+          reason: failure.reason,
+          duration_ms: failureDurationMs(startedAt),
+          rerun: isRetry,
+        }),
+      );
       console.error("Project ZIP download failed", downloadError);
       toast.error(m.builderDownloadFailed());
     } finally {
@@ -2491,6 +2514,22 @@ const StackBuilder = ({ initialStack }: { initialStack?: StackState }) => {
       promptForShare("run");
     },
     [adjustedStack, campaign, promptForShare, stack],
+  );
+
+  const handleRunFailed = useCallback(
+    (failure: BuilderRunFailure) => {
+      trackCampaignEvent(
+        "builder_run_failed",
+        stackAnalyticsProperties(adjustedStack || stack, {
+          campaign,
+          stage: failure.stage,
+          reason: failure.reason,
+          duration_ms: failure.durationMs,
+          rerun: failure.rerun,
+        }),
+      );
+    },
+    [adjustedStack, campaign, stack],
   );
 
   // ─── Handlers ───────────────────────────────────────────────────────────
@@ -3919,6 +3958,7 @@ const StackBuilder = ({ initialStack }: { initialStack?: StackState }) => {
                       onCopy={copyToClipboard}
                       onRunStarted={handleRunStarted}
                       onRunReady={handleRunReady}
+                      onRunFailed={handleRunFailed}
                     />
                   </Suspense>
                 </div>

--- a/apps/web/src/lib/builder-failure-analytics.ts
+++ b/apps/web/src/lib/builder-failure-analytics.ts
@@ -1,0 +1,126 @@
+export type BuilderRunFailureStage =
+  | "generation"
+  | "browser_support"
+  | "runtime_boot"
+  | "project_mount"
+  | "source_sync"
+  | "dependency_install"
+  | "server_start"
+  | "server_timeout"
+  | "server_exit";
+
+export type BuilderRunFailureReason =
+  | "generation_failed"
+  | "browser_runtime_unsupported"
+  | "runtime_boot_failed"
+  | "project_mount_failed"
+  | "source_sync_failed"
+  | "dependency_install_failed"
+  | "dependency_install_exit"
+  | "server_start_failed"
+  | "server_ready_timeout"
+  | "server_process_exit";
+
+export type BuilderZipFailureStage = "archive_generation" | "browser_download";
+
+export type BuilderZipFailureReason =
+  | "archive_generation_failed"
+  | "browser_download_failed";
+
+export interface BuilderRunFailure {
+  stage: BuilderRunFailureStage;
+  reason: BuilderRunFailureReason;
+  durationMs: number;
+  rerun: boolean;
+}
+
+export interface BuilderZipFailure {
+  stage: BuilderZipFailureStage;
+  reason: BuilderZipFailureReason;
+  durationMs: number;
+}
+
+type BrowserRuntimeFailureCode =
+  | "dependency_install_exit"
+  | "server_ready_timeout"
+  | "server_process_exit";
+
+function runtimeFailureCode(error: unknown): BrowserRuntimeFailureCode | null {
+  if (!error || typeof error !== "object" || !("code" in error)) return null;
+
+  const code = (error as { code?: unknown }).code;
+  if (
+    code === "dependency_install_exit" ||
+    code === "server_ready_timeout" ||
+    code === "server_process_exit"
+  ) {
+    return code;
+  }
+
+  return null;
+}
+
+/**
+ * Turns an internal failure into a deliberately small analytics vocabulary.
+ * Error messages, stack traces, generated source, and runtime output never
+ * leave this boundary.
+ */
+export function classifyBuilderRunFailure(
+  stage: BuilderRunFailureStage,
+  error?: unknown,
+): Pick<BuilderRunFailure, "stage" | "reason"> {
+  const runtimeCode = runtimeFailureCode(error);
+
+  if (runtimeCode === "dependency_install_exit") {
+    return { stage: "dependency_install", reason: runtimeCode };
+  }
+  if (runtimeCode === "server_ready_timeout") {
+    return { stage: "server_timeout", reason: runtimeCode };
+  }
+  if (runtimeCode === "server_process_exit") {
+    return { stage: "server_exit", reason: runtimeCode };
+  }
+
+  switch (stage) {
+    case "generation":
+      return { stage, reason: "generation_failed" };
+    case "browser_support":
+      return { stage, reason: "browser_runtime_unsupported" };
+    case "runtime_boot":
+      return { stage, reason: "runtime_boot_failed" };
+    case "project_mount":
+      return { stage, reason: "project_mount_failed" };
+    case "source_sync":
+      return { stage, reason: "source_sync_failed" };
+    case "dependency_install":
+      return { stage, reason: "dependency_install_failed" };
+    case "server_timeout":
+      return { stage, reason: "server_ready_timeout" };
+    case "server_exit":
+      return { stage, reason: "server_process_exit" };
+    case "server_start":
+      return { stage, reason: "server_start_failed" };
+  }
+}
+
+export function classifyBuilderZipFailure(
+  stage: BuilderZipFailureStage,
+): Pick<BuilderZipFailure, "stage" | "reason"> {
+  return {
+    stage,
+    reason: stage === "archive_generation" ? "archive_generation_failed" : "browser_download_failed",
+  };
+}
+
+export function failureDurationMs(startedAt: number, endedAt = Date.now()): number {
+  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) return 0;
+  return Math.max(0, Math.round(endedAt - startedAt));
+}
+
+export function shouldReportBuilderRunFailure(
+  activeRunId: number,
+  failedRunId: number,
+  lastReportedRunId: number,
+): boolean {
+  return activeRunId === failedRunId && lastReportedRunId !== failedRunId;
+}

--- a/apps/web/src/lib/campaign-analytics.ts
+++ b/apps/web/src/lib/campaign-analytics.ts
@@ -8,7 +8,9 @@ export type CampaignEvent =
   | "campaign_preset_opened"
   | "builder_run_started"
   | "builder_run_ready"
+  | "builder_run_failed"
   | "builder_zip_downloaded"
+  | "builder_zip_failed"
   | "builder_share_prompted"
   | "builder_stack_shared"
   | "builder_github_clicked";

--- a/apps/web/src/lib/webcontainer-runtime.ts
+++ b/apps/web/src/lib/webcontainer-runtime.ts
@@ -11,6 +11,21 @@ let runtimePromise: Promise<WebContainer> | null = null;
 let activeServerProcess: WebContainerProcess | null = null;
 let activeInstallProcess: WebContainerProcess | null = null;
 
+export type BrowserRuntimeFailureCode =
+  | "dependency_install_exit"
+  | "server_ready_timeout"
+  | "server_process_exit";
+
+export class BrowserRuntimeError extends Error {
+  readonly code: BrowserRuntimeFailureCode;
+
+  constructor(code: BrowserRuntimeFailureCode, message: string) {
+    super(message);
+    this.name = "BrowserRuntimeError";
+    this.code = code;
+  }
+}
+
 export function normalizeRuntimeOutput(chunk: string): string {
   return chunk
     .replace(ANSI_OSC_SEQUENCE, "")
@@ -97,7 +112,10 @@ export async function installRunnableProject(
   await output;
 
   if (exitCode !== 0) {
-    throw new Error(`Dependency installation exited with code ${exitCode}.`);
+    throw new BrowserRuntimeError(
+      "dependency_install_exit",
+      `Dependency installation exited with code ${exitCode}.`,
+    );
   }
 }
 
@@ -141,7 +159,12 @@ export async function startDevelopmentServer(
       settled = true;
       unsubscribe();
       process.kill();
-      reject(new Error("The development server did not become ready in time."));
+      reject(
+        new BrowserRuntimeError(
+          "server_ready_timeout",
+          "The development server did not become ready in time.",
+        ),
+      );
     }, 120_000);
 
     unsubscribe = runtime.on("server-ready", (_port, url) => {
@@ -157,7 +180,12 @@ export async function startDevelopmentServer(
         settled = true;
         clearTimeout(timeoutId);
         unsubscribe();
-        reject(new Error(`The development server exited with code ${exitCode}.`));
+        reject(
+          new BrowserRuntimeError(
+            "server_process_exit",
+            `The development server exited with code ${exitCode}.`,
+          ),
+        );
         return undefined;
       }
       onExit(exitCode);

--- a/apps/web/test/builder-failure-analytics.test.ts
+++ b/apps/web/test/builder-failure-analytics.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  classifyBuilderRunFailure,
+  classifyBuilderZipFailure,
+  failureDurationMs,
+  shouldReportBuilderRunFailure,
+  type BuilderRunFailureReason,
+  type BuilderRunFailureStage,
+} from "../src/lib/builder-failure-analytics";
+import { BrowserRuntimeError } from "../src/lib/webcontainer-runtime";
+
+describe("builder failure analytics", () => {
+  it("maps each operation to a stable, low-cardinality reason", () => {
+    const cases: [BuilderRunFailureStage, BuilderRunFailureReason][] = [
+      ["generation", "generation_failed"],
+      ["browser_support", "browser_runtime_unsupported"],
+      ["runtime_boot", "runtime_boot_failed"],
+      ["project_mount", "project_mount_failed"],
+      ["source_sync", "source_sync_failed"],
+      ["dependency_install", "dependency_install_failed"],
+      ["server_start", "server_start_failed"],
+      ["server_timeout", "server_ready_timeout"],
+      ["server_exit", "server_process_exit"],
+    ];
+
+    for (const [stage, reason] of cases) {
+      expect(classifyBuilderRunFailure(stage)).toEqual({ stage, reason });
+    }
+  });
+
+  it("uses typed runtime codes to separate install exits, timeouts, and server exits", () => {
+    expect(
+      classifyBuilderRunFailure(
+        "dependency_install",
+        new BrowserRuntimeError("dependency_install_exit", "npm exited with private output"),
+      ),
+    ).toEqual({ stage: "dependency_install", reason: "dependency_install_exit" });
+    expect(classifyBuilderRunFailure("server_start", { code: "server_ready_timeout" })).toEqual({
+      stage: "server_timeout",
+      reason: "server_ready_timeout",
+    });
+    expect(classifyBuilderRunFailure("server_start", { code: "server_process_exit" })).toEqual({
+      stage: "server_exit",
+      reason: "server_process_exit",
+    });
+  });
+
+  it("never exposes exception messages or other unrecognized fields", () => {
+    const classified = classifyBuilderRunFailure("runtime_boot", {
+      message: "secret environment value",
+      stack: "/private/project/source.ts",
+      code: "unrecognized_internal_code",
+    });
+
+    expect(classified).toEqual({ stage: "runtime_boot", reason: "runtime_boot_failed" });
+    expect(JSON.stringify(classified)).not.toContain("secret");
+    expect(JSON.stringify(classified)).not.toContain("/private");
+  });
+
+  it("classifies archive and browser download failures separately", () => {
+    expect(classifyBuilderZipFailure("archive_generation")).toEqual({
+      stage: "archive_generation",
+      reason: "archive_generation_failed",
+    });
+    expect(classifyBuilderZipFailure("browser_download")).toEqual({
+      stage: "browser_download",
+      reason: "browser_download_failed",
+    });
+  });
+
+  it("normalizes duration and rejects stale or duplicate run failures", () => {
+    expect(failureDurationMs(100.2, 142.8)).toBe(43);
+    expect(failureDurationMs(200, 100)).toBe(0);
+    expect(failureDurationMs(Number.NaN, 100)).toBe(0);
+
+    expect(shouldReportBuilderRunFailure(7, 7, 6)).toBe(true);
+    expect(shouldReportBuilderRunFailure(8, 7, 6)).toBe(false);
+    expect(shouldReportBuilderRunFailure(7, 7, 7)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add automatic `builder_run_failed` and `builder_zip_failed` analytics
- classify failures with stable, low-cardinality stage and reason codes
- include duration, retry/rerun state, campaign attribution, and existing stack dimensions
- suppress duplicate, stale, cancelled, unmounted, and manually stopped attempts
- keep raw exceptions, runtime logs, generated source, paths, environment data, and exit codes out of analytics

## Why

The browser runner and ZIP flow previously exposed success events but provided no passive signal when generation, runtime boot, installation, server startup, or download failed. This adds enough structured telemetry to find activation blockers without requiring user reports or collecting sensitive debugging data.

## Validation

- `bun test ./test/builder-failure-analytics.test.ts` — 5 passed
- `bun run lint` in `apps/web` — passed; existing warnings only
- `git diff --check` — passed