### PR TITLE
Add telemetry decision room

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -159,26 +159,6 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=6144"
 
-      - name: Performance Budget Check
-        run: bun run --cwd apps/web perf:check
-
-      - name: Upload Performance Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: web-performance-report
-          path: apps/web/reports/performance
-          if-no-files-found: warn
-
-      - name: Publish Performance Summary
-        if: always()
-        run: |
-          if [ -f apps/web/reports/performance/summary.md ]; then
-            cat apps/web/reports/performance/summary.md >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Performance summary was not generated." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Build All Packages
         run: bun run build
         env:

--- a/apps/web/src/components/analytics/telemetry-decision-dashboard.tsx
+++ b/apps/web/src/components/analytics/telemetry-decision-dashboard.tsx
@@ -1,0 +1,535 @@
+import type { RankedSignal, TelemetryDashboardData } from "@/lib/telemetry-dashboard";
+
+import { cn } from "@/lib/utils";
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+const compactFormatter = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short",
+});
+
+const PANEL = "border border-[#deddd5] bg-[#faf9f5] dark:border-white/10 dark:bg-[#11110f]";
+const MUTED = "text-[#706e66] dark:text-[#929087]";
+const GRID_LINE = "border-[#deddd5] dark:border-white/10";
+
+function formatCount(value: number): string {
+  return value >= 10_000 ? compactFormatter.format(value) : numberFormatter.format(value);
+}
+
+function formatRate(value: number | null): string {
+  return value === null ? "—" : `${Math.round(value * 100)}%`;
+}
+
+function PanelHeading({ index, title, detail }: { index: string; title: string; detail: string }) {
+  return (
+    <div
+      className={cn("flex flex-col gap-3 border-b px-5 py-4 sm:flex-row sm:items-end", GRID_LINE)}
+    >
+      <span className="font-mono text-[10px] font-semibold tracking-[0.2em] text-[#8da526] dark:text-[#c6e853]">
+        {index}
+      </span>
+      <div className="min-w-0 flex-1">
+        <h2 className="font-mono text-sm font-semibold uppercase tracking-[0.13em]">{title}</h2>
+        <p className={cn("mt-1 text-xs leading-relaxed", MUTED)}>{detail}</p>
+      </div>
+    </div>
+  );
+}
+
+function SignalCell({
+  step,
+  label,
+  value,
+  detail,
+  accent = false,
+}: {
+  step: string;
+  label: string;
+  value: string;
+  detail: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="relative min-h-40 px-5 py-5">
+      <div className="flex items-center justify-between gap-3">
+        <span className={cn("font-mono text-[10px] uppercase tracking-[0.18em]", MUTED)}>
+          {label}
+        </span>
+        <span className="font-mono text-[10px] tabular-nums text-[#8da526] dark:text-[#c6e853]">
+          {step}
+        </span>
+      </div>
+      <div
+        className={cn(
+          "mt-6 font-mono text-4xl font-semibold tracking-[-0.06em] tabular-nums sm:text-5xl",
+          accent && "text-[#789018] dark:text-[#c6e853]",
+        )}
+      >
+        {value}
+      </div>
+      <p className={cn("mt-4 max-w-52 text-xs leading-relaxed", MUTED)}>{detail}</p>
+    </div>
+  );
+}
+
+function RankedList({
+  items,
+  empty = "No classified signals yet",
+}: {
+  items: RankedSignal[];
+  empty?: string;
+}) {
+  if (items.length === 0) {
+    return <p className={cn("px-5 py-8 font-mono text-xs", MUTED)}>{empty}</p>;
+  }
+
+  const max = items[0]?.value ?? 1;
+  return (
+    <ol className="divide-y divide-[#deddd5] dark:divide-white/10">
+      {items.map((item, index) => (
+        <li
+          key={item.name}
+          className="grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 px-5 py-3"
+        >
+          <span className={cn("font-mono text-[10px] tabular-nums", MUTED)}>
+            {String(index + 1).padStart(2, "0")}
+          </span>
+          <div className="min-w-0">
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="truncate font-mono text-xs font-medium" title={item.name}>
+                {item.name}
+              </span>
+              <span className={cn("font-mono text-[10px] tabular-nums", MUTED)}>
+                {Math.round(item.share * 100)}%
+              </span>
+            </div>
+            <div className="mt-2 h-1 overflow-hidden bg-black/[0.06] dark:bg-white/[0.07]">
+              <div
+                className="h-full bg-[#9ebd28] dark:bg-[#c6e853]"
+                style={{ width: `${Math.max((item.value / max) * 100, 2)}%` }}
+              />
+            </div>
+          </div>
+          <span className="w-12 text-right font-mono text-xs font-semibold tabular-nums">
+            {formatCount(item.value)}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function ActivityChart({ data }: { data: TelemetryDashboardData["activity"] }) {
+  const max = Math.max(...data.map((day) => day.totalEvents), 1);
+
+  return (
+    <div className="overflow-x-auto px-5 py-6">
+      <figure
+        className="flex h-52 min-w-[680px] items-end gap-1.5"
+        aria-label="Daily telemetry activity"
+      >
+        {data.map((day, index) => {
+          const height = Math.max((day.totalEvents / max) * 100, day.totalEvents > 0 ? 3 : 0);
+          const projectShare = day.totalEvents > 0 ? day.projects / day.totalEvents : 0;
+          const failedShare = day.totalEvents > 0 ? day.failed / day.totalEvents : 0;
+          const showLabel = index === 0 || index === data.length - 1 || index % 7 === 0;
+          return (
+            <div key={day.date} className="group flex h-full min-w-4 flex-1 flex-col justify-end">
+              <div className="relative flex flex-1 items-end">
+                <div
+                  className="relative w-full bg-[#d8d7d0] transition-colors group-hover:bg-[#c9c8c0] dark:bg-white/10 dark:group-hover:bg-white/15"
+                  style={{ height: `${height}%` }}
+                  title={`${day.date}: ${day.totalEvents} events, ${day.projects} projects, ${day.failed} failures`}
+                >
+                  <div
+                    className="absolute inset-x-0 bottom-0 bg-[#9ebd28] dark:bg-[#c6e853]"
+                    style={{ height: `${projectShare * 100}%` }}
+                  />
+                  {failedShare > 0 ? (
+                    <div
+                      className="absolute inset-x-0 top-0 bg-[#c9453d]"
+                      style={{ height: `${failedShare * 100}%` }}
+                    />
+                  ) : null}
+                </div>
+              </div>
+              <span className={cn("mt-2 h-3 font-mono text-[8px] tabular-nums", MUTED)}>
+                {showLabel ? day.date.slice(5) : ""}
+              </span>
+            </div>
+          );
+        })}
+      </figure>
+      <div
+        className={cn(
+          "mt-4 flex flex-wrap gap-x-5 gap-y-2 border-t pt-3 font-mono text-[9px] uppercase tracking-[0.14em]",
+          GRID_LINE,
+          MUTED,
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <span aria-hidden="true" className="h-2 w-2 bg-[#d8d7d0] dark:bg-white/10" />
+          events
+        </span>
+        <span className="flex items-center gap-2">
+          <span aria-hidden="true" className="h-2 w-2 bg-[#9ebd28] dark:bg-[#c6e853]" />
+          projects
+        </span>
+        <span className="flex items-center gap-2">
+          <span aria-hidden="true" className="h-2 w-2 bg-[#c9453d]" />
+          failed events
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function OperationTable({ data }: { data: TelemetryDashboardData["operations"] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[620px] border-collapse text-left">
+        <thead>
+          <tr
+            className={cn(
+              "border-b font-mono text-[9px] uppercase tracking-[0.16em]",
+              GRID_LINE,
+              MUTED,
+            )}
+          >
+            <th className="px-5 py-3 font-medium">Operation</th>
+            <th className="px-3 py-3 text-right font-medium">Attempts</th>
+            <th className="px-3 py-3 text-right font-medium">Passed</th>
+            <th className="px-3 py-3 text-right font-medium">Failed</th>
+            <th className="px-3 py-3 text-right font-medium">Cancelled</th>
+            <th className="px-5 py-3 text-right font-medium">Reliability</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[#deddd5] dark:divide-white/10">
+          {data.map((operation) => (
+            <tr key={operation.id} className="font-mono text-xs">
+              <th className="px-5 py-4 font-semibold">{operation.label}</th>
+              <td className="px-3 py-4 text-right tabular-nums">
+                {formatCount(operation.attempts)}
+              </td>
+              <td className="px-3 py-4 text-right tabular-nums">
+                {formatCount(operation.succeeded)}
+              </td>
+              <td
+                className={cn(
+                  "px-3 py-4 text-right tabular-nums",
+                  operation.failed > 0 && "text-[#b7352e] dark:text-[#ff766d]",
+                )}
+              >
+                {formatCount(operation.failed)}
+              </td>
+              <td className="px-3 py-4 text-right tabular-nums">
+                {formatCount(operation.cancelled)}
+              </td>
+              <td className="px-5 py-4 text-right">
+                <span className="inline-flex min-w-14 justify-center bg-[#e7f2bd] px-2 py-1 font-semibold text-[#344000] dark:bg-[#c6e853]/15 dark:text-[#d9ef83]">
+                  {formatRate(operation.successRate)}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function BrowserMetric({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="px-5 py-4">
+      <span className={cn("font-mono text-[9px] uppercase tracking-[0.16em]", MUTED)}>{label}</span>
+      <div className="mt-2 font-mono text-2xl font-semibold tracking-[-0.04em] tabular-nums">
+        {value}
+      </div>
+      <p className={cn("mt-1 text-[11px]", MUTED)}>{detail}</p>
+    </div>
+  );
+}
+
+export function TelemetryDecisionDashboard({ data }: { data: TelemetryDashboardData }) {
+  const setupClassified = data.setup.complete + data.setup.incomplete;
+
+  return (
+    <article className="text-[#1b1a17] dark:text-[#e4e2da]">
+      <header className={cn(PANEL, "relative overflow-hidden")}>
+        <div
+          className="pointer-events-none absolute inset-y-0 right-0 hidden w-[38%] opacity-35 lg:block"
+          aria-hidden="true"
+        >
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,transparent_0_46%,rgba(158,189,40,0.24)_46%_47%,transparent_47%_62%,rgba(158,189,40,0.12)_62%_63%,transparent_63%)]" />
+        </div>
+        <div className="relative grid gap-8 px-5 py-8 sm:px-8 lg:grid-cols-[1fr_auto] lg:items-end lg:px-10 lg:py-10">
+          <div>
+            <div className="flex items-center gap-3 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[#789018] dark:text-[#c6e853]">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-current motion-reduce:animate-none" />
+              Product signal / live aggregates
+            </div>
+            <h1
+              id="telemetry-title"
+              className="mt-5 max-w-3xl font-mono text-4xl font-semibold tracking-[-0.065em] sm:text-6xl lg:text-7xl"
+            >
+              Decision room
+            </h1>
+            <p className={cn("mt-5 max-w-2xl text-sm leading-6 sm:text-base", MUTED)}>
+              The lifecycle evidence behind what Better Fullstack should fix, deepen, or stop
+              building. Every number is aggregate-only and excludes project content.
+            </p>
+          </div>
+          <dl className="grid grid-cols-2 gap-x-8 gap-y-4 font-mono text-[10px] uppercase tracking-[0.14em] lg:text-right">
+            <div>
+              <dt className={MUTED}>Decision scope</dt>
+              <dd className="mt-1 font-semibold text-[#789018] dark:text-[#c6e853]">
+                {data.operationScopeLabel}
+              </dd>
+            </div>
+            <div>
+              <dt className={MUTED}>Coverage</dt>
+              <dd className="mt-1 font-semibold">{formatRate(data.decisionCoverage)}</dd>
+            </div>
+            <div>
+              <dt className={MUTED}>Last signal</dt>
+              <dd className="mt-1 normal-case tracking-normal">
+                {data.lastEventTime ? dateTimeFormatter.format(data.lastEventTime) : "No data"}
+              </dd>
+            </div>
+            <div>
+              <dt className={MUTED}>Rendered</dt>
+              <dd className="mt-1 normal-case tracking-normal">
+                {dateTimeFormatter.format(data.generatedAt)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </header>
+
+      <section className={cn(PANEL, "mt-5")} aria-labelledby="signal-chain-title">
+        <div
+          className={cn(
+            "flex flex-col gap-2 border-b px-5 py-4 sm:flex-row sm:items-center sm:justify-between",
+            GRID_LINE,
+          )}
+        >
+          <h2
+            id="signal-chain-title"
+            className="font-mono text-xs font-semibold uppercase tracking-[0.15em]"
+          >
+            Lifecycle signal chain
+          </h2>
+          <p className={cn("max-w-xl text-[11px] leading-relaxed sm:text-right", MUTED)}>
+            Comparable stages, not a person-level funnel: browser and CLI identifiers are
+            intentionally separate.
+          </p>
+        </div>
+        <div className="grid divide-y divide-[#deddd5] dark:divide-white/10 sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
+          <SignalCell
+            step="01"
+            label="Create"
+            value={formatCount(
+              data.operationScope === "window"
+                ? data.totalProjectsInWindow
+                : data.totalProjectsAllTime,
+            )}
+            detail={`Successful project generations · ${data.operationScopeLabel.toLowerCase()}`}
+            accent
+          />
+          <SignalCell
+            step="02"
+            label="Setup"
+            value={formatRate(data.setup.completionRate)}
+            detail={`${formatCount(data.setup.complete)} complete / ${formatCount(setupClassified)} classified setup runs`}
+          />
+          <SignalCell
+            step="03"
+            label="Browser run"
+            value={formatRate(data.browser.runReadyRate)}
+            detail={`${formatCount(data.browser.runReady)} ready / ${formatCount(data.browser.runStarted)} run starts`}
+          />
+          <SignalCell
+            step="04"
+            label="Return · 7d"
+            value={formatRate(data.repeatUse.repeat7dRate)}
+            detail={`${formatCount(data.repeatUse.repeat7d)} anonymous IDs active on 2+ distinct days`}
+          />
+        </div>
+      </section>
+
+      <div className="mt-5 grid gap-5 xl:grid-cols-[1.45fr_0.75fr]">
+        <section className={PANEL} aria-label="Lifecycle operations">
+          <PanelHeading
+            index="01 / RELIABILITY"
+            title="Lifecycle operations"
+            detail={`${data.operationScopeLabel} terminal outcomes; cancellations are excluded from the reliability denominator.`}
+          />
+          <OperationTable data={data.operations} />
+        </section>
+
+        <section className={PANEL} aria-label="Repeat use">
+          <PanelHeading
+            index="02 / HABIT"
+            title="Repeat use"
+            detail="An anonymous client ID is returning when it is active on more than one distinct UTC date in the window."
+          />
+          <div className="grid grid-cols-2 divide-x divide-y divide-[#deddd5] dark:divide-white/10">
+            <BrowserMetric
+              label="7d repeat share"
+              value={formatRate(data.repeatUse.repeat7dRate)}
+              detail={`${formatCount(data.repeatUse.repeat7d)} / ${formatCount(data.repeatUse.active7d)} active`}
+            />
+            <BrowserMetric
+              label="30d repeat share"
+              value={formatRate(data.repeatUse.repeat30dRate)}
+              detail={`${formatCount(data.repeatUse.repeat30d)} / ${formatCount(data.repeatUse.active30d)} active`}
+            />
+            <BrowserMetric
+              label="New · 30d"
+              value={formatCount(data.repeatUse.new30d)}
+              detail="First-seen anonymous IDs"
+            />
+            <BrowserMetric
+              label="Returning · all"
+              value={formatCount(data.repeatUse.returningMachines)}
+              detail={`${formatCount(data.repeatUse.uniqueMachines)} unique anonymous IDs`}
+            />
+          </div>
+        </section>
+      </div>
+
+      <section className={cn(PANEL, "mt-5")} aria-label="Daily activity">
+        <PanelHeading
+          index="03 / PULSE"
+          title="Daily activity"
+          detail={`${data.windowDays} UTC days. Lime is successful project generation; red marks failed terminal events.`}
+        />
+        <ActivityChart data={data.activity} />
+      </section>
+
+      <div className="mt-5 grid gap-5 lg:grid-cols-2">
+        <section className={PANEL} aria-label="Ecosystem adoption">
+          <PanelHeading
+            index="04 / DEMAND"
+            title="Ecosystem adoption"
+            detail={`${data.operationScopeLabel} successful project generations.`}
+          />
+          <RankedList items={data.adoption} empty="No ecosystem selections in this scope" />
+        </section>
+
+        <section className={PANEL} aria-label="Browser edit run and ZIP outcomes">
+          <PanelHeading
+            index="05 / BROWSER"
+            title="Edit, run, and ZIP"
+            detail={`${data.operationScopeLabel} builder outcomes. Ready and downloaded are the success gates.`}
+          />
+          <div className="grid grid-cols-2 divide-x divide-y divide-[#deddd5] dark:divide-white/10 sm:grid-cols-3">
+            <BrowserMetric
+              label="Run ready"
+              value={formatRate(data.browser.runReadyRate)}
+              detail={`${formatCount(data.browser.runReady)} of ${formatCount(data.browser.runStarted)} starts`}
+            />
+            <BrowserMetric
+              label="Run failed"
+              value={formatCount(data.browser.runFailed)}
+              detail="Classified failures"
+            />
+            <BrowserMetric
+              label="Files edited"
+              value={formatCount(data.browser.filesEdited)}
+              detail="Edit signals"
+            />
+            <BrowserMetric
+              label="ZIP success"
+              value={formatRate(data.browser.zipSuccessRate)}
+              detail={`${formatCount(data.browser.zipDownloaded)} of ${formatCount(data.browser.zipStarted)} starts`}
+            />
+            <BrowserMetric
+              label="ZIP failed"
+              value={formatCount(data.browser.zipFailed)}
+              detail="Archive/download failures"
+            />
+            <BrowserMetric
+              label="Commands copied"
+              value={formatCount(data.browser.commandsCopied)}
+              detail="CLI handoffs"
+            />
+          </div>
+        </section>
+      </div>
+
+      <div className="mt-5 grid gap-5 xl:grid-cols-3">
+        <section className={PANEL} aria-label="Failure reasons">
+          <PanelHeading
+            index="06A"
+            title="Failure reasons"
+            detail="Bounded reason vocabulary, grouped by action when available."
+          />
+          <RankedList items={data.failureReasons} />
+        </section>
+        <section className={PANEL} aria-label="Failure stages">
+          <PanelHeading
+            index="06B"
+            title="Failure stages"
+            detail="Where the workflow stopped, never the raw error message."
+          />
+          <RankedList items={data.failureStages} />
+        </section>
+        <section className={PANEL} aria-label="Setup failures">
+          <PanelHeading
+            index="06C"
+            title="Setup failures"
+            detail="All time · install and ecosystem verification steps that need hardening."
+          />
+          <RankedList items={data.setupFailures} />
+        </section>
+      </div>
+
+      <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_1fr_1.2fr]">
+        <section className={PANEL} aria-label="Invocation source">
+          <PanelHeading index="07A" title="Invocation source" detail={data.operationScopeLabel} />
+          <RankedList items={data.sources} />
+        </section>
+        <section className={PANEL} aria-label="Client split">
+          <PanelHeading index="07B" title="Client split" detail={data.operationScopeLabel} />
+          <RankedList items={data.clients} />
+        </section>
+        <section
+          className={cn(PANEL, "px-5 py-5 sm:px-6")}
+          aria-label="Telemetry interpretation notes"
+        >
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[#789018] dark:text-[#c6e853]">
+            Read before deciding
+          </span>
+          <ul className={cn("mt-4 space-y-3 text-xs leading-relaxed", MUTED)}>
+            <li>• Window metrics fall back to all-time when aggregate coverage is below 80%.</li>
+            <li>
+              • Setup completion excludes MCP generation, skipped installs, and unknown legacy rows.
+            </li>
+            <li>
+              • Repeat share is distinct-day usage, not cohort retention or an identity graph.
+            </li>
+            <li>
+              • Counts reflect telemetry-enabled clients and should guide priorities, not
+              market-size claims.
+            </li>
+          </ul>
+          <a
+            href="/docs/cli/telemetry"
+            className="mt-6 inline-flex border-b border-[#789018] pb-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-[#657a10] transition-colors hover:text-[#1b1a17] dark:border-[#c6e853] dark:text-[#c6e853] dark:hover:text-white"
+          >
+            Inspect the privacy contract →
+          </a>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/src/lib/telemetry-auth.server.ts
+++ b/apps/web/src/lib/telemetry-auth.server.ts
@@ -1,0 +1,100 @@
+const MIN_TELEMETRY_SECRET_LENGTH = 32;
+
+export const TELEMETRY_OWNER_USERNAME = "owner";
+
+export type TelemetryPageAccess = "authorized" | "unconfigured" | "unauthorized";
+
+function normalizeSecret(secret: string | undefined): string | undefined {
+  const normalized = secret?.trim();
+  return normalized && normalized.length >= MIN_TELEMETRY_SECRET_LENGTH ? normalized : undefined;
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  let equal = left.length === right.length;
+  const comparisons = Math.max(left.length, right.length);
+
+  for (let index = 0; index < comparisons; index += 1) {
+    if (left.charCodeAt(index) !== right.charCodeAt(index)) equal = false;
+  }
+
+  return equal;
+}
+
+function decodeBasicCredentials(authorization: string | null): [string, string] | undefined {
+  const encoded = authorization?.match(/^Basic ([A-Za-z0-9+/]+={0,2})$/i)?.[1];
+  if (!encoded) return undefined;
+
+  try {
+    const decoded = atob(encoded);
+    const separator = decoded.indexOf(":");
+    if (separator < 0) return undefined;
+    return [decoded.slice(0, separator), decoded.slice(separator + 1)];
+  } catch {
+    return undefined;
+  }
+}
+
+export function isTelemetryPageRequest(request: Request): boolean {
+  const pathname = new URL(request.url).pathname;
+  return pathname === "/telemetry" || pathname === "/telemetry/";
+}
+
+export function getTelemetryPageAccess(
+  request: Request,
+  secret: string | undefined,
+): TelemetryPageAccess {
+  const configuredSecret = normalizeSecret(secret);
+  if (!configuredSecret) return "unconfigured";
+
+  const credentials = decodeBasicCredentials(request.headers.get("Authorization"));
+  if (!credentials) return "unauthorized";
+
+  const [username, password] = credentials;
+  return constantTimeEqual(username, TELEMETRY_OWNER_USERNAME) &&
+    constantTimeEqual(password, configuredSecret)
+    ? "authorized"
+    : "unauthorized";
+}
+
+export function telemetryAuthFailureResponse(
+  access: Exclude<TelemetryPageAccess, "authorized">,
+): Response {
+  const unconfigured = access === "unconfigured";
+  const headers = new Headers({
+    "Cache-Control": "private, no-store",
+    "Content-Type": "text/plain; charset=utf-8",
+    Vary: "Authorization",
+    "X-Content-Type-Options": "nosniff",
+    "X-Robots-Tag": "noindex, nofollow, noarchive, nosnippet",
+  });
+  if (!unconfigured) {
+    headers.set("WWW-Authenticate", 'Basic realm="Better Fullstack telemetry", charset="UTF-8"');
+  }
+
+  return new Response(
+    unconfigured ? "Telemetry dashboard is not configured." : "Authentication required.",
+    { status: unconfigured ? 503 : 401, headers },
+  );
+}
+
+export function withPrivateTelemetryHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  const vary = new Set(
+    headers
+      .get("Vary")
+      ?.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean) ?? [],
+  );
+  vary.add("Authorization");
+  headers.set("Cache-Control", "private, no-store");
+  headers.set("Vary", [...vary].join(", "));
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet");
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/apps/web/src/lib/telemetry-dashboard.ts
+++ b/apps/web/src/lib/telemetry-dashboard.ts
@@ -1,0 +1,456 @@
+export type TelemetryDistribution = Record<string, number>;
+
+export type RawTelemetryStats = {
+  totalProjects: number;
+  lastEventTime: number;
+  ecosystem: TelemetryDistribution;
+  dimensions?: Record<string, TelemetryDistribution>;
+};
+
+export type RawProductInsights = {
+  totalEvents: number;
+  decisionEvents: number;
+  actions: TelemetryDistribution;
+  actionStatuses: TelemetryDistribution;
+  actionOutcomes: TelemetryDistribution;
+  clients: TelemetryDistribution;
+  sources: TelemetryDistribution;
+  errorNames: TelemetryDistribution;
+  failureStages: TelemetryDistribution;
+  failureReasons: TelemetryDistribution;
+  actionFailureStages: TelemetryDistribution;
+  actionFailureReasons: TelemetryDistribution;
+  setupFailureStats: TelemetryDistribution;
+  setupOutcomes: TelemetryDistribution;
+  installSelections: TelemetryDistribution;
+};
+
+export type RawDailyTelemetry = {
+  date: string;
+  count: number;
+  newMachines?: number;
+  totalEvents?: number;
+  successfulEvents?: number;
+  failedEvents?: number;
+  decisionEvents?: number;
+  actions?: TelemetryDistribution;
+  actionStatuses?: TelemetryDistribution;
+  actionOutcomes?: TelemetryDistribution;
+  clients?: TelemetryDistribution;
+  sources?: TelemetryDistribution;
+  ecosystems?: TelemetryDistribution;
+  setupOutcomes?: TelemetryDistribution;
+  installSelections?: TelemetryDistribution;
+  failureStages?: TelemetryDistribution;
+  failureReasons?: TelemetryDistribution;
+  actionFailureStages?: TelemetryDistribution;
+  actionFailureReasons?: TelemetryDistribution;
+};
+
+export type RawEngagement = {
+  uniqueMachines: number;
+  returningMachines: number;
+  trackedEvents: number;
+  newMachinesLast30d: number;
+  activeMachinesLast7d: number;
+  activeMachinesLast30d: number;
+  returningMachinesLast7d: number;
+  returningMachinesLast30d: number;
+};
+
+export type RankedSignal = {
+  name: string;
+  value: number;
+  share: number;
+};
+
+export type OperationReliability = {
+  id: string;
+  label: string;
+  attempts: number;
+  succeeded: number;
+  failed: number;
+  cancelled: number;
+  successRate: number | null;
+};
+
+export type TelemetryDashboardData = {
+  generatedAt: number;
+  lastEventTime: number | null;
+  windowDays: number;
+  operationScope: "window" | "all-time";
+  operationScopeLabel: string;
+  decisionCoverage: number;
+  totalEventsInWindow: number;
+  totalProjectsInWindow: number;
+  totalProjectsAllTime: number;
+  setup: {
+    complete: number;
+    incomplete: number;
+    notRequested: number;
+    generationOnly: number;
+    unknown: number;
+    completionRate: number | null;
+  };
+  installs: {
+    requested: number;
+    skipped: number;
+    generationOnly: number;
+    unknown: number;
+    requestRate: number | null;
+  };
+  browser: {
+    runStarted: number;
+    runReady: number;
+    runFailed: number;
+    runReadyRate: number | null;
+    zipStarted: number;
+    zipDownloaded: number;
+    zipFailed: number;
+    zipSuccessRate: number | null;
+    filesEdited: number;
+    commandsCopied: number;
+  };
+  repeatUse: {
+    uniqueMachines: number;
+    returningMachines: number;
+    active7d: number;
+    repeat7d: number;
+    repeat7dRate: number | null;
+    active30d: number;
+    repeat30d: number;
+    repeat30dRate: number | null;
+    new30d: number;
+  };
+  operations: OperationReliability[];
+  adoption: RankedSignal[];
+  sources: RankedSignal[];
+  clients: RankedSignal[];
+  failureReasons: RankedSignal[];
+  failureStages: RankedSignal[];
+  setupFailures: RankedSignal[];
+  activity: Array<{
+    date: string;
+    projects: number;
+    totalEvents: number;
+    succeeded: number;
+    failed: number;
+  }>;
+};
+
+type DecisionDistributions = Pick<
+  RawProductInsights,
+  | "actions"
+  | "actionStatuses"
+  | "actionOutcomes"
+  | "clients"
+  | "sources"
+  | "failureStages"
+  | "failureReasons"
+  | "actionFailureStages"
+  | "actionFailureReasons"
+  | "setupOutcomes"
+  | "installSelections"
+>;
+
+const ECOSYSTEM_LABELS: Record<string, string> = {
+  typescript: "TypeScript",
+  "react-native": "React Native",
+  rust: "Rust",
+  python: "Python",
+  go: "Go",
+  java: "Java",
+  dotnet: ".NET",
+  elixir: "Elixir",
+};
+
+const OPERATION_GROUPS = [
+  { id: "create", label: "Create", actions: ["create"] },
+  { id: "add", label: "Add", actions: ["add"] },
+  { id: "update", label: "Update", actions: ["update"] },
+  { id: "check", label: "Check", actions: ["check", "doctor"] },
+  { id: "gen", label: "Generate", actions: ["gen"] },
+] as const;
+
+function ratio(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) return null;
+  return Math.min(Math.max(numerator / denominator, 0), 1);
+}
+
+function sumDistribution(target: TelemetryDistribution, source?: TelemetryDistribution): void {
+  for (const [key, value] of Object.entries(source ?? {})) {
+    target[key] = (target[key] ?? 0) + value;
+  }
+}
+
+function emptyDecisionDistributions(): DecisionDistributions {
+  return {
+    actions: {},
+    actionStatuses: {},
+    actionOutcomes: {},
+    clients: {},
+    sources: {},
+    failureStages: {},
+    failureReasons: {},
+    actionFailureStages: {},
+    actionFailureReasons: {},
+    setupOutcomes: {},
+    installSelections: {},
+  };
+}
+
+function aggregateWindow(daily: readonly RawDailyTelemetry[]): DecisionDistributions {
+  const aggregate = emptyDecisionDistributions();
+  for (const day of daily) {
+    sumDistribution(aggregate.actions, day.actions);
+    sumDistribution(aggregate.actionStatuses, day.actionStatuses);
+    sumDistribution(aggregate.actionOutcomes, day.actionOutcomes);
+    sumDistribution(aggregate.clients, day.clients);
+    sumDistribution(aggregate.sources, day.sources);
+    sumDistribution(aggregate.failureStages, day.failureStages);
+    sumDistribution(aggregate.failureReasons, day.failureReasons);
+    sumDistribution(aggregate.actionFailureStages, day.actionFailureStages);
+    sumDistribution(aggregate.actionFailureReasons, day.actionFailureReasons);
+    sumDistribution(aggregate.setupOutcomes, day.setupOutcomes);
+    sumDistribution(aggregate.installSelections, day.installSelections);
+  }
+  return aggregate;
+}
+
+function displayIdentifier(value: string): string {
+  return value
+    .replaceAll("_", "-")
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function ranked(
+  distribution: TelemetryDistribution,
+  limit = 6,
+  labels: Record<string, string> = {},
+): RankedSignal[] {
+  const entries = Object.entries(distribution).filter(([, value]) => value > 0);
+  const total = entries.reduce((sum, [, value]) => sum + value, 0);
+  if (total === 0) return [];
+  return entries
+    .map(([name, value]) => ({
+      name: labels[name] ?? displayIdentifier(name),
+      value,
+      share: value / total,
+    }))
+    .sort((a, b) => b.value - a.value || a.name.localeCompare(b.name))
+    .slice(0, limit);
+}
+
+function rankedActionClassifications(distribution: TelemetryDistribution): RankedSignal[] {
+  const labels = Object.fromEntries(
+    Object.keys(distribution).map((key) => {
+      const separator = key.indexOf(":");
+      if (separator === -1) return [key, displayIdentifier(key)];
+      const action = displayIdentifier(key.slice(0, separator));
+      const classification = displayIdentifier(key.slice(separator + 1));
+      return [key, `${action} / ${classification}`];
+    }),
+  );
+  return ranked(distribution, 7, labels);
+}
+
+function includeUnattributedClassifications(
+  actionDistribution: TelemetryDistribution,
+  genericDistribution: TelemetryDistribution,
+): TelemetryDistribution {
+  const combined = { ...actionDistribution };
+  const attributedByClassification: TelemetryDistribution = {};
+  for (const [key, value] of Object.entries(actionDistribution)) {
+    const separator = key.indexOf(":");
+    if (separator === -1) continue;
+    const classification = key.slice(separator + 1);
+    attributedByClassification[classification] =
+      (attributedByClassification[classification] ?? 0) + value;
+  }
+  for (const [classification, total] of Object.entries(genericDistribution)) {
+    const unattributed = total - (attributedByClassification[classification] ?? 0);
+    if (unattributed > 0) combined[`unattributed:${classification}`] = unattributed;
+  }
+  return combined;
+}
+
+function valueForActions(
+  distribution: TelemetryDistribution,
+  actions: readonly string[],
+  suffix: string,
+): number {
+  return actions.reduce((sum, action) => sum + (distribution[`${action}:${suffix}`] ?? 0), 0);
+}
+
+function buildOperations(distributions: DecisionDistributions): OperationReliability[] {
+  return OPERATION_GROUPS.map(({ id, label, actions }) => {
+    const started = valueForActions(distributions.actionStatuses, actions, "started");
+    const succeeded = valueForActions(distributions.actionStatuses, actions, "succeeded");
+    const failed = valueForActions(distributions.actionStatuses, actions, "failed");
+    const cancelled = valueForActions(distributions.actionStatuses, actions, "cancelled");
+    const terminal = succeeded + failed + cancelled;
+    return {
+      id,
+      label,
+      attempts: Math.max(started, terminal),
+      succeeded,
+      failed,
+      cancelled,
+      successRate: ratio(succeeded, succeeded + failed),
+    };
+  });
+}
+
+function dateKey(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function buildActivity(
+  daily: readonly RawDailyTelemetry[],
+  days: number,
+  now: number,
+): TelemetryDashboardData["activity"] {
+  const byDate = new Map(daily.map((day) => [day.date, day]));
+  const activity: TelemetryDashboardData["activity"] = [];
+  for (let offset = days - 1; offset >= 0; offset -= 1) {
+    const date = dateKey(now - offset * 24 * 60 * 60 * 1000);
+    const day = byDate.get(date);
+    activity.push({
+      date,
+      projects: day?.count ?? 0,
+      totalEvents: day?.totalEvents ?? day?.count ?? 0,
+      succeeded: day?.successfulEvents ?? 0,
+      failed: day?.failedEvents ?? 0,
+    });
+  }
+  return activity;
+}
+
+export function buildTelemetryDashboard(
+  raw: {
+    stats: RawTelemetryStats;
+    insights: RawProductInsights;
+    daily: RawDailyTelemetry[];
+    engagement: RawEngagement;
+  },
+  options: { windowDays?: number; now?: number; minimumWindowCoverage?: number } = {},
+): TelemetryDashboardData {
+  const windowDays = Math.max(1, Math.round(options.windowDays ?? 30));
+  const generatedAt = options.now ?? Date.now();
+  const minimumWindowCoverage = options.minimumWindowCoverage ?? 0.8;
+  const totalEventsInWindow = raw.daily.reduce(
+    (sum, day) => sum + (day.totalEvents ?? day.count),
+    0,
+  );
+  const decisionEventsInWindow = raw.daily.reduce((sum, day) => sum + (day.decisionEvents ?? 0), 0);
+  const windowCoverage = ratio(decisionEventsInWindow, totalEventsInWindow) ?? 0;
+  const useWindow = totalEventsInWindow > 0 && windowCoverage >= minimumWindowCoverage;
+  const windowDistributions = aggregateWindow(raw.daily);
+  const distributions: DecisionDistributions = useWindow
+    ? windowDistributions
+    : {
+        actions: raw.insights.actions,
+        actionStatuses: raw.insights.actionStatuses,
+        actionOutcomes: raw.insights.actionOutcomes,
+        clients: raw.insights.clients,
+        sources: raw.insights.sources,
+        failureStages: raw.insights.failureStages,
+        failureReasons: raw.insights.failureReasons,
+        actionFailureStages: raw.insights.actionFailureStages,
+        actionFailureReasons: raw.insights.actionFailureReasons,
+        setupOutcomes: raw.insights.setupOutcomes,
+        installSelections: raw.insights.installSelections,
+      };
+  const allTimeCoverage = ratio(raw.insights.decisionEvents, raw.insights.totalEvents) ?? 0;
+  const setup = distributions.setupOutcomes;
+  const installs = distributions.installSelections;
+  const actions = distributions.actions;
+  const runStarted = actions["builder-run-started"] ?? 0;
+  const runReady = actions["builder-run-ready"] ?? 0;
+  const runFailed = actions["builder-run-failed"] ?? 0;
+  const zipStarted = actions["builder-zip-started"] ?? 0;
+  const zipDownloaded = actions["builder-zip-downloaded"] ?? 0;
+  const zipFailed = actions["builder-zip-failed"] ?? 0;
+  const ecosystemWindow = raw.daily.reduce<TelemetryDistribution>((aggregate, day) => {
+    sumDistribution(aggregate, day.ecosystems);
+    return aggregate;
+  }, {});
+  const failureReasonDistribution = includeUnattributedClassifications(
+    distributions.actionFailureReasons,
+    distributions.failureReasons,
+  );
+  const failureStageDistribution = includeUnattributedClassifications(
+    distributions.actionFailureStages,
+    distributions.failureStages,
+  );
+
+  return {
+    generatedAt,
+    lastEventTime: raw.stats.lastEventTime > 0 ? raw.stats.lastEventTime : null,
+    windowDays,
+    operationScope: useWindow ? "window" : "all-time",
+    operationScopeLabel: useWindow ? `Last ${windowDays} days` : "All time",
+    decisionCoverage: useWindow ? windowCoverage : allTimeCoverage,
+    totalEventsInWindow,
+    totalProjectsInWindow: raw.daily.reduce((sum, day) => sum + day.count, 0),
+    totalProjectsAllTime: raw.stats.totalProjects,
+    setup: {
+      complete: setup.complete ?? 0,
+      incomplete: setup.incomplete ?? 0,
+      notRequested: setup["not-requested"] ?? 0,
+      generationOnly: setup["generation-only"] ?? 0,
+      unknown: setup.unknown ?? 0,
+      completionRate: ratio(setup.complete ?? 0, (setup.complete ?? 0) + (setup.incomplete ?? 0)),
+    },
+    installs: {
+      requested: installs.requested ?? 0,
+      skipped: installs.skipped ?? 0,
+      generationOnly: installs["generation-only"] ?? 0,
+      unknown: installs.unknown ?? 0,
+      requestRate: ratio(
+        installs.requested ?? 0,
+        (installs.requested ?? 0) + (installs.skipped ?? 0),
+      ),
+    },
+    browser: {
+      runStarted,
+      runReady,
+      runFailed,
+      runReadyRate: ratio(runReady, runStarted),
+      zipStarted,
+      zipDownloaded,
+      zipFailed,
+      zipSuccessRate: ratio(zipDownloaded, zipStarted),
+      filesEdited: actions["builder-file-edited"] ?? 0,
+      commandsCopied: actions["builder-command-copied"] ?? 0,
+    },
+    repeatUse: {
+      uniqueMachines: raw.engagement.uniqueMachines,
+      returningMachines: raw.engagement.returningMachines,
+      active7d: raw.engagement.activeMachinesLast7d,
+      repeat7d: raw.engagement.returningMachinesLast7d,
+      repeat7dRate: ratio(
+        raw.engagement.returningMachinesLast7d,
+        raw.engagement.activeMachinesLast7d,
+      ),
+      active30d: raw.engagement.activeMachinesLast30d,
+      repeat30d: raw.engagement.returningMachinesLast30d,
+      repeat30dRate: ratio(
+        raw.engagement.returningMachinesLast30d,
+        raw.engagement.activeMachinesLast30d,
+      ),
+      new30d: raw.engagement.newMachinesLast30d,
+    },
+    operations: buildOperations(distributions),
+    adoption: ranked(useWindow ? ecosystemWindow : raw.stats.ecosystem, 8, ECOSYSTEM_LABELS),
+    sources: ranked(distributions.sources, 6),
+    clients: ranked(distributions.clients, 4),
+    failureReasons: rankedActionClassifications(failureReasonDistribution),
+    failureStages: rankedActionClassifications(failureStageDistribution),
+    setupFailures: ranked(raw.insights.setupFailureStats, 7),
+    activity: buildActivity(raw.daily, windowDays, generatedAt),
+  };
+}

--- a/apps/web/src/lib/telemetry-data.server.ts
+++ b/apps/web/src/lib/telemetry-data.server.ts
@@ -1,0 +1,75 @@
+import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
+
+import { getTelemetryPageAccess } from "@/lib/telemetry-auth.server";
+import {
+  buildTelemetryDashboard,
+  type RawDailyTelemetry,
+  type RawEngagement,
+  type RawProductInsights,
+  type RawTelemetryStats,
+  type TelemetryDashboardData,
+} from "@/lib/telemetry-dashboard";
+
+export type TelemetryLoaderResult =
+  | { status: "ready"; data: TelemetryDashboardData }
+  | { status: "unconfigured" | "empty" | "unavailable" | "unauthorized" };
+
+type TelemetryAggregateResponse = {
+  stats: RawTelemetryStats | null;
+  daily: RawDailyTelemetry[];
+  engagement: RawEngagement;
+  insights: RawProductInsights;
+};
+
+function dashboardEndpoint(): string | undefined {
+  const source = process.env.VITE_CONVEX_INGEST_URL ?? process.env.VITE_CONVEX_URL;
+  if (!source) return undefined;
+
+  try {
+    const url = new URL(source);
+    url.hostname = url.hostname.replace(/\.convex\.cloud$/, ".convex.site");
+    url.pathname = "/api/analytics/dashboard";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export async function loadTelemetryForOwner(): Promise<TelemetryLoaderResult> {
+  setResponseHeader("Cache-Control", "private, no-store");
+  setResponseHeader("Vary", "Authorization");
+  setResponseHeader("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet");
+
+  const secret = process.env.TELEMETRY_DASHBOARD_SECRET?.trim();
+  const pageAccess = getTelemetryPageAccess(getRequest(), secret);
+  if (pageAccess !== "authorized") return { status: pageAccess };
+
+  const endpoint = dashboardEndpoint();
+  if (!endpoint || !secret) return { status: "unconfigured" };
+
+  try {
+    const response = await fetch(endpoint, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${secret}`,
+      },
+      cache: "no-store",
+    });
+    if (response.status === 503) return { status: "unconfigured" };
+    if (response.status === 401 || response.status === 403) return { status: "unauthorized" };
+    if (!response.ok) return { status: "unavailable" };
+
+    const aggregate = (await response.json()) as TelemetryAggregateResponse;
+    const { stats } = aggregate;
+    if (!stats) return { status: "empty" };
+
+    return {
+      status: "ready",
+      data: buildTelemetryDashboard({ ...aggregate, stats }),
+    };
+  } catch {
+    return { status: "unavailable" };
+  }
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as SitemapDotmdRouteImport } from "./routes/sitemap[.]md";
 import { Route as SitemapDotxmlRouteImport } from "./routes/sitemap[.]xml";
 import { Route as StackRouteImport } from "./routes/stack";
 import { Route as StackComboSlugRouteImport } from "./routes/stack_.$comboSlug";
+import { Route as TelemetryRouteImport } from "./routes/telemetry";
 import { Route as TemplatesRouteImport } from "./routes/templates";
 
 const IndexRoute = IndexRouteImport.update({
@@ -114,6 +115,11 @@ const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
 const StackRoute = StackRouteImport.update({
   id: "/stack",
   path: "/stack",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const TelemetryRoute = TelemetryRouteImport.update({
+  id: "/telemetry",
+  path: "/telemetry",
   getParentRoute: () => rootRouteImport,
 } as any);
 const TemplatesRoute = TemplatesRouteImport.update({
@@ -213,6 +219,7 @@ export interface FileRoutesByFullPath {
   "/sitemap.md": typeof SitemapDotmdRoute;
   "/sitemap.xml": typeof SitemapDotxmlRoute;
   "/stack": typeof StackRoute;
+  "/telemetry": typeof TelemetryRoute;
   "/templates": typeof TemplatesRoute;
   "/api/preview": typeof ApiPreviewRoute;
   "/api/stats": typeof ApiStatsRoute;
@@ -246,6 +253,7 @@ export interface FileRoutesByTo {
   "/sitemap.md": typeof SitemapDotmdRoute;
   "/sitemap.xml": typeof SitemapDotxmlRoute;
   "/stack": typeof StackRoute;
+  "/telemetry": typeof TelemetryRoute;
   "/templates": typeof TemplatesRoute;
   "/api/preview": typeof ApiPreviewRoute;
   "/api/stats": typeof ApiStatsRoute;
@@ -280,6 +288,7 @@ export interface FileRoutesById {
   "/sitemap.md": typeof SitemapDotmdRoute;
   "/sitemap.xml": typeof SitemapDotxmlRoute;
   "/stack": typeof StackRoute;
+  "/telemetry": typeof TelemetryRoute;
   "/templates": typeof TemplatesRoute;
   "/api/preview": typeof ApiPreviewRoute;
   "/api/stats": typeof ApiStatsRoute;
@@ -315,6 +324,7 @@ export interface FileRouteTypes {
     | "/sitemap.md"
     | "/sitemap.xml"
     | "/stack"
+    | "/telemetry"
     | "/templates"
     | "/api/preview"
     | "/api/stats"
@@ -348,6 +358,7 @@ export interface FileRouteTypes {
     | "/sitemap.md"
     | "/sitemap.xml"
     | "/stack"
+    | "/telemetry"
     | "/templates"
     | "/api/preview"
     | "/api/stats"
@@ -381,6 +392,7 @@ export interface FileRouteTypes {
     | "/sitemap.md"
     | "/sitemap.xml"
     | "/stack"
+    | "/telemetry"
     | "/templates"
     | "/api/preview"
     | "/api/stats"
@@ -415,6 +427,7 @@ export interface RootRouteChildren {
   SitemapDotmdRoute: typeof SitemapDotmdRoute;
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute;
   StackRoute: typeof StackRoute;
+  TelemetryRoute: typeof TelemetryRoute;
   TemplatesRoute: typeof TemplatesRoute;
   ApiPreviewRoute: typeof ApiPreviewRoute;
   ApiStatsRoute: typeof ApiStatsRoute;
@@ -538,6 +551,13 @@ declare module "@tanstack/react-router" {
       path: "/stack";
       fullPath: "/stack";
       preLoaderRoute: typeof StackRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/telemetry": {
+      id: "/telemetry";
+      path: "/telemetry";
+      fullPath: "/telemetry";
+      preLoaderRoute: typeof TelemetryRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/templates": {
@@ -671,6 +691,7 @@ const rootRouteChildren: RootRouteChildren = {
   SitemapDotmdRoute: SitemapDotmdRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
   StackRoute: StackRoute,
+  TelemetryRoute: TelemetryRoute,
   TemplatesRoute: TemplatesRoute,
   ApiPreviewRoute: ApiPreviewRoute,
   ApiStatsRoute: ApiStatsRoute,

--- a/apps/web/src/routes/telemetry.tsx
+++ b/apps/web/src/routes/telemetry.tsx
@@ -1,52 +1,21 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+
+import type { TelemetryDashboardData } from "@/lib/telemetry-dashboard";
 
 import { TelemetryDecisionDashboard } from "@/components/analytics/telemetry-decision-dashboard";
 import Footer from "@/components/home/footer";
 import { NOINDEX_ROBOTS } from "@/lib/robots";
 import { canonicalUrl } from "@/lib/seo";
-import {
-  buildTelemetryDashboard,
-  type RawDailyTelemetry,
-  type RawEngagement,
-  type RawProductInsights,
-  type RawTelemetryStats,
-} from "@/lib/telemetry-dashboard";
 
 type LoaderResult =
-  | { status: "ready"; data: ReturnType<typeof buildTelemetryDashboard> }
-  | { status: "unconfigured" | "empty" | "unavailable" };
+  | { status: "ready"; data: TelemetryDashboardData }
+  | { status: "unconfigured" | "empty" | "unavailable" | "unauthorized" };
 
-async function loadTelemetry(): Promise<LoaderResult> {
-  const convexUrl = import.meta.env.VITE_CONVEX_URL;
-  if (!convexUrl) return { status: "unconfigured" };
-
-  try {
-    const [{ ConvexHttpClient }, { api }] = await Promise.all([
-      import("convex/browser"),
-      import("@better-fullstack/backend/convex/_generated/api"),
-    ]);
-    const client = new ConvexHttpClient(convexUrl);
-    const [stats, daily, engagement, insights] = await Promise.all([
-      client.query(api.analytics.getStats, {}),
-      client.query(api.analytics.getDailyStats, { days: 30 }),
-      client.query(api.analytics.getEngagement, {}),
-      client.query(api.analytics.getProductInsights, {}),
-    ]);
-    if (!stats) return { status: "empty" };
-
-    return {
-      status: "ready",
-      data: buildTelemetryDashboard({
-        stats: stats as RawTelemetryStats,
-        daily: daily as RawDailyTelemetry[],
-        engagement: engagement as RawEngagement,
-        insights: insights as RawProductInsights,
-      }),
-    };
-  } catch {
-    return { status: "unavailable" };
-  }
-}
+const loadTelemetry = createServerFn({ method: "GET" }).handler(async (): Promise<LoaderResult> => {
+  const { loadTelemetryForOwner } = await import("@/lib/telemetry-data.server");
+  return loadTelemetryForOwner();
+});
 
 export const Route = createFileRoute("/telemetry")({
   head: () => {
@@ -66,7 +35,7 @@ export const Route = createFileRoute("/telemetry")({
     };
   },
   staleTime: 60_000,
-  loader: loadTelemetry,
+  loader: () => loadTelemetry(),
   component: TelemetryRoute,
 });
 
@@ -89,10 +58,13 @@ function TelemetryRoute() {
 
 function TelemetryUnavailable({ status }: { status: Exclude<LoaderResult["status"], "ready"> }) {
   const copy = {
-    unconfigured: "Set VITE_CONVEX_URL to connect this deployment to aggregate telemetry.",
+    unconfigured:
+      "Set the same TELEMETRY_DASHBOARD_SECRET in the web and Convex deployments, then connect the web deployment to Convex.",
     empty: "The telemetry store is connected, but no aggregate events are available yet.",
     unavailable:
       "The aggregate telemetry query is temporarily unavailable. No raw event data was requested.",
+    unauthorized:
+      "Telemetry access was denied. Verify the owner credentials and matching deployment secrets.",
   }[status];
 
   return (

--- a/apps/web/src/routes/telemetry.tsx
+++ b/apps/web/src/routes/telemetry.tsx
@@ -1,0 +1,109 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { TelemetryDecisionDashboard } from "@/components/analytics/telemetry-decision-dashboard";
+import Footer from "@/components/home/footer";
+import { NOINDEX_ROBOTS } from "@/lib/robots";
+import { canonicalUrl } from "@/lib/seo";
+import {
+  buildTelemetryDashboard,
+  type RawDailyTelemetry,
+  type RawEngagement,
+  type RawProductInsights,
+  type RawTelemetryStats,
+} from "@/lib/telemetry-dashboard";
+
+type LoaderResult =
+  | { status: "ready"; data: ReturnType<typeof buildTelemetryDashboard> }
+  | { status: "unconfigured" | "empty" | "unavailable" };
+
+async function loadTelemetry(): Promise<LoaderResult> {
+  const convexUrl = import.meta.env.VITE_CONVEX_URL;
+  if (!convexUrl) return { status: "unconfigured" };
+
+  try {
+    const [{ ConvexHttpClient }, { api }] = await Promise.all([
+      import("convex/browser"),
+      import("@better-fullstack/backend/convex/_generated/api"),
+    ]);
+    const client = new ConvexHttpClient(convexUrl);
+    const [stats, daily, engagement, insights] = await Promise.all([
+      client.query(api.analytics.getStats, {}),
+      client.query(api.analytics.getDailyStats, { days: 30 }),
+      client.query(api.analytics.getEngagement, {}),
+      client.query(api.analytics.getProductInsights, {}),
+    ]);
+    if (!stats) return { status: "empty" };
+
+    return {
+      status: "ready",
+      data: buildTelemetryDashboard({
+        stats: stats as RawTelemetryStats,
+        daily: daily as RawDailyTelemetry[],
+        engagement: engagement as RawEngagement,
+        insights: insights as RawProductInsights,
+      }),
+    };
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
+export const Route = createFileRoute("/telemetry")({
+  head: () => {
+    const title = "Product telemetry — Better Fullstack";
+    const description =
+      "Aggregate lifecycle, reliability, adoption, and repeat-use signals for Better Fullstack product decisions.";
+    return {
+      meta: [
+        { title },
+        { name: "description", content: description },
+        { name: "robots", content: NOINDEX_ROBOTS },
+        { property: "og:title", content: title },
+        { property: "og:description", content: description },
+        { property: "og:url", content: canonicalUrl("/telemetry") },
+      ],
+      links: [{ rel: "canonical", href: canonicalUrl("/telemetry") }],
+    };
+  },
+  staleTime: 60_000,
+  loader: loadTelemetry,
+  component: TelemetryRoute,
+});
+
+function TelemetryRoute() {
+  const result = Route.useLoaderData();
+
+  return (
+    <main className="min-h-svh">
+      <div className="mx-auto max-w-[1480px] border-x border-border px-3 py-12 sm:px-6 sm:py-16 lg:px-10">
+        {result.status === "ready" ? (
+          <TelemetryDecisionDashboard data={result.data} />
+        ) : (
+          <TelemetryUnavailable status={result.status} />
+        )}
+      </div>
+      <Footer />
+    </main>
+  );
+}
+
+function TelemetryUnavailable({ status }: { status: Exclude<LoaderResult["status"], "ready"> }) {
+  const copy = {
+    unconfigured: "Set VITE_CONVEX_URL to connect this deployment to aggregate telemetry.",
+    empty: "The telemetry store is connected, but no aggregate events are available yet.",
+    unavailable:
+      "The aggregate telemetry query is temporarily unavailable. No raw event data was requested.",
+  }[status];
+
+  return (
+    <section className="mx-auto max-w-3xl border border-border bg-card px-6 py-16 text-center sm:px-10">
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-[#789018] dark:text-[#c6e853]">
+        Product signal / offline
+      </p>
+      <h1 className="mt-5 font-mono text-4xl font-semibold tracking-[-0.055em] sm:text-6xl">
+        Decision room
+      </h1>
+      <p className="mx-auto mt-5 max-w-xl text-sm leading-6 text-muted-foreground">{copy}</p>
+    </section>
+  );
+}

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -5,16 +5,31 @@ import {
   requestWithLocaleCookie,
   withLocaleResponseHeaders,
 } from "@/lib/i18n/country-locale";
+import {
+  getTelemetryPageAccess,
+  isTelemetryPageRequest,
+  telemetryAuthFailureResponse,
+  withPrivateTelemetryHeaders,
+} from "@/lib/telemetry-auth.server";
 import { paraglideMiddleware } from "@/paraglide/server.js";
 
 export default createServerEntry({
   async fetch(request) {
+    const telemetryRequest = isTelemetryPageRequest(request);
+    if (telemetryRequest) {
+      const access = getTelemetryPageAccess(request, process.env.TELEMETRY_DASHBOARD_SECRET);
+      if (access !== "authorized") return telemetryAuthFailureResponse(access);
+    }
+
     const countryLocale = resolveCountryLocale(request);
-    const requestWithLocale = countryLocale ? requestWithLocaleCookie(request, countryLocale) : request;
+    const requestWithLocale = countryLocale
+      ? requestWithLocaleCookie(request, countryLocale)
+      : request;
     const response = await paraglideMiddleware(requestWithLocale, ({ request: localizedRequest }) =>
       handler.fetch(localizedRequest),
     );
 
-    return withLocaleResponseHeaders(response, request, countryLocale);
+    const localizedResponse = withLocaleResponseHeaders(response, request, countryLocale);
+    return telemetryRequest ? withPrivateTelemetryHeaders(localizedResponse) : localizedResponse;
   },
 });

--- a/apps/web/test/seo-contract.test.ts
+++ b/apps/web/test/seo-contract.test.ts
@@ -83,10 +83,12 @@ describe("SEO contracts", () => {
     expect(paths).not.toContain("/stack");
     expect(paths).toContain("/stack/nextjs-hono-drizzle-better-auth");
     expect(paths).not.toContain("/analytics");
+    expect(paths).not.toContain("/telemetry");
     expect(xml).toContain(canonicalUrl("/docs/cli/create"));
     expect(xml).toContain(canonicalUrl("/guides/typescript/create-tanstack-start-project"));
     expect(xml).toContain(canonicalUrl("/stack/nextjs-hono-drizzle-better-auth"));
     expect(xml).not.toContain(canonicalUrl("/analytics"));
+    expect(xml).not.toContain(canonicalUrl("/telemetry"));
   });
 
   it("adds video discovery metadata when content declares an MP4", () => {

--- a/apps/web/test/telemetry-auth.test.ts
+++ b/apps/web/test/telemetry-auth.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  getTelemetryPageAccess,
+  isTelemetryPageRequest,
+  telemetryAuthFailureResponse,
+  withPrivateTelemetryHeaders,
+} from "../src/lib/telemetry-auth.server";
+
+const SECRET = "owner-only-telemetry-secret-0123456789";
+
+function telemetryRequest(credentials?: string, path = "/telemetry"): Request {
+  const headers = credentials ? { Authorization: `Basic ${btoa(credentials)}` } : undefined;
+  return new Request(`https://better-fullstack.dev${path}`, { headers });
+}
+
+describe("telemetry page access", () => {
+  it("matches only the private telemetry page", () => {
+    expect(isTelemetryPageRequest(telemetryRequest())).toBe(true);
+    expect(isTelemetryPageRequest(telemetryRequest(undefined, "/telemetry/"))).toBe(true);
+    expect(isTelemetryPageRequest(telemetryRequest(undefined, "/telemetry-export"))).toBe(false);
+    expect(isTelemetryPageRequest(telemetryRequest(undefined, "/"))).toBe(false);
+  });
+
+  it("fails closed when the secret is missing or too short", () => {
+    expect(getTelemetryPageAccess(telemetryRequest("owner:anything"), undefined)).toBe(
+      "unconfigured",
+    );
+    expect(getTelemetryPageAccess(telemetryRequest("owner:anything"), "too-short")).toBe(
+      "unconfigured",
+    );
+  });
+
+  it("allows only the owner username with the configured secret", () => {
+    expect(getTelemetryPageAccess(telemetryRequest(), SECRET)).toBe("unauthorized");
+    expect(getTelemetryPageAccess(telemetryRequest(`someone:${SECRET}`), SECRET)).toBe(
+      "unauthorized",
+    );
+    expect(getTelemetryPageAccess(telemetryRequest("owner:wrong-password"), SECRET)).toBe(
+      "unauthorized",
+    );
+    expect(getTelemetryPageAccess(telemetryRequest(`owner:${SECRET}`), SECRET)).toBe("authorized");
+  });
+
+  it("challenges unauthorized requests and never caches telemetry responses", () => {
+    const challenge = telemetryAuthFailureResponse("unauthorized");
+    expect(challenge.status).toBe(401);
+    expect(challenge.headers.get("WWW-Authenticate")).toContain("Basic");
+    expect(challenge.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(challenge.headers.get("X-Robots-Tag")).toContain("noindex");
+
+    const unconfigured = telemetryAuthFailureResponse("unconfigured");
+    expect(unconfigured.status).toBe(503);
+    expect(unconfigured.headers.has("WWW-Authenticate")).toBe(false);
+
+    const privateResponse = withPrivateTelemetryHeaders(
+      new Response("ok", { headers: { Vary: "Cookie" } }),
+    );
+    expect(privateResponse.headers.get("Vary")).toBe("Cookie, Authorization");
+    expect(privateResponse.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+});

--- a/apps/web/test/telemetry-dashboard.test.ts
+++ b/apps/web/test/telemetry-dashboard.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildTelemetryDashboard,
+  type RawEngagement,
+  type RawProductInsights,
+  type RawTelemetryStats,
+} from "../src/lib/telemetry-dashboard";
+
+const NOW = Date.parse("2026-08-07T12:00:00.000Z");
+
+function emptyInsights(overrides: Partial<RawProductInsights> = {}): RawProductInsights {
+  return {
+    totalEvents: 0,
+    decisionEvents: 0,
+    actions: {},
+    actionStatuses: {},
+    actionOutcomes: {},
+    clients: {},
+    sources: {},
+    errorNames: {},
+    failureStages: {},
+    failureReasons: {},
+    actionFailureStages: {},
+    actionFailureReasons: {},
+    setupFailureStats: {},
+    setupOutcomes: {},
+    installSelections: {},
+    ...overrides,
+  };
+}
+
+const stats: RawTelemetryStats = {
+  totalProjects: 120,
+  lastEventTime: NOW - 1_000,
+  ecosystem: { typescript: 80, rust: 25, python: 15 },
+};
+
+const engagement: RawEngagement = {
+  uniqueMachines: 70,
+  returningMachines: 20,
+  trackedEvents: 180,
+  newMachinesLast30d: 12,
+  activeMachinesLast7d: 10,
+  activeMachinesLast30d: 25,
+  returningMachinesLast7d: 4,
+  returningMachinesLast30d: 10,
+};
+
+describe("telemetry decision dashboard", () => {
+  it("uses sufficiently covered window aggregates for lifecycle decisions", () => {
+    const data = buildTelemetryDashboard(
+      {
+        stats,
+        insights: emptyInsights({
+          totalEvents: 500,
+          decisionEvents: 500,
+          setupFailureStats: { "install-dependencies": 3 },
+        }),
+        engagement,
+        daily: [
+          {
+            date: "2026-08-06",
+            count: 7,
+            totalEvents: 30,
+            successfulEvents: 12,
+            failedEvents: 2,
+            decisionEvents: 30,
+            actions: {
+              "builder-run-started": 5,
+              "builder-run-ready": 4,
+              "builder-run-failed": 1,
+              "builder-zip-started": 4,
+              "builder-zip-downloaded": 3,
+              "builder-zip-failed": 1,
+              "builder-file-edited": 2,
+            },
+            actionStatuses: {
+              "create:started": 6,
+              "create:succeeded": 5,
+              "create:failed": 1,
+              "doctor:started": 2,
+              "doctor:succeeded": 2,
+            },
+            actionOutcomes: {},
+            clients: { cli: 20, web: 10 },
+            sources: { "cli-flags": 12, "web-builder": 10, "cli-interactive": 8 },
+            ecosystems: { typescript: 5, rust: 2 },
+            setupOutcomes: { complete: 4, incomplete: 1, "not-requested": 2 },
+            installSelections: { requested: 5, skipped: 2 },
+            failureReasons: { install: 2, network: 1 },
+            actionFailureReasons: { "create:install": 1 },
+            failureStages: { setup: 1 },
+            actionFailureStages: { "create:setup": 1 },
+          },
+          {
+            date: "2026-08-07",
+            count: 3,
+            totalEvents: 10,
+            successfulEvents: 5,
+            failedEvents: 0,
+            decisionEvents: 10,
+            actions: { "builder-command-copied": 2 },
+            actionStatuses: {
+              "create:started": 2,
+              "create:succeeded": 2,
+              "check:started": 1,
+              "check:succeeded": 1,
+            },
+            actionOutcomes: {},
+            clients: { cli: 8, web: 2 },
+            sources: { "cli-flags": 8, "web-builder": 2 },
+            ecosystems: { typescript: 2, python: 1 },
+            setupOutcomes: { complete: 3 },
+            installSelections: { requested: 3 },
+          },
+        ],
+      },
+      { now: NOW, windowDays: 2 },
+    );
+
+    expect(data.operationScope).toBe("window");
+    expect(data.decisionCoverage).toBe(1);
+    expect(data.totalProjectsInWindow).toBe(10);
+    expect(data.setup.completionRate).toBe(7 / 8);
+    expect(data.installs.requestRate).toBe(8 / 10);
+    expect(data.browser.runReadyRate).toBe(4 / 5);
+    expect(data.browser.zipSuccessRate).toBe(3 / 4);
+    expect(data.operations.find((operation) => operation.id === "create")).toEqual({
+      id: "create",
+      label: "Create",
+      attempts: 8,
+      succeeded: 7,
+      failed: 1,
+      cancelled: 0,
+      successRate: 7 / 8,
+    });
+    expect(data.operations.find((operation) => operation.id === "check")?.succeeded).toBe(3);
+    expect(data.adoption.map((item) => item.name)).toEqual(["TypeScript", "Rust", "Python"]);
+    expect(data.repeatUse.repeat7dRate).toBe(0.4);
+    expect(data.failureReasons[0]?.name).toBe("Create / Install");
+    expect(data.failureReasons.map((item) => item.name)).toContain("Unattributed / Install");
+    expect(data.failureReasons.map((item) => item.name)).toContain("Unattributed / Network");
+    expect(data.activity).toHaveLength(2);
+  });
+
+  it("falls back to all-time aggregates when decision-window coverage is partial", () => {
+    const data = buildTelemetryDashboard(
+      {
+        stats,
+        insights: emptyInsights({
+          totalEvents: 100,
+          decisionEvents: 90,
+          actionStatuses: {
+            "update:started": 12,
+            "update:succeeded": 9,
+            "update:failed": 3,
+          },
+          sources: { mcp: 8, "cli-flags": 4 },
+          setupOutcomes: { complete: 6, incomplete: 2 },
+          installSelections: { requested: 7, skipped: 1 },
+        }),
+        engagement,
+        daily: [
+          {
+            date: "2026-08-07",
+            count: 2,
+            totalEvents: 10,
+            decisionEvents: 2,
+            actionStatuses: { "update:succeeded": 1 },
+          },
+        ],
+      },
+      { now: NOW, windowDays: 1 },
+    );
+
+    expect(data.operationScope).toBe("all-time");
+    expect(data.decisionCoverage).toBe(0.9);
+    expect(data.operations.find((operation) => operation.id === "update")?.successRate).toBe(0.75);
+    expect(data.setup.completionRate).toBe(0.75);
+    expect(data.adoption[0]?.name).toBe("TypeScript");
+  });
+});

--- a/docs/next-updates-roadmap.md
+++ b/docs/next-updates-roadmap.md
@@ -95,4 +95,9 @@ New ecosystems, libraries, and providers are not the default roadmap. Accept cat
 - browser run-ready, edit-rerun, and ZIP success rates;
 - verified recipe pass rate and evidence freshness.
 
+The internal `/telemetry` decision room is not a public product surface. It reads aggregates through
+internal Convex queries and fails closed unless the same random, 32-character-or-longer
+`TELEMETRY_DASHBOARD_SECRET` is configured in both the web and Convex deployments. The owner signs
+in with the username `owner` and that secret as the password.
+
 Theoretical combination count is not a roadmap metric.

--- a/packages/backend/convex/analytics-access.ts
+++ b/packages/backend/convex/analytics-access.ts
@@ -1,0 +1,32 @@
+export const MIN_TELEMETRY_SECRET_LENGTH = 32;
+
+export type TelemetryDashboardAccess = "authorized" | "unconfigured" | "unauthorized";
+
+function normalizeSecret(secret: string | undefined): string | undefined {
+  const normalized = secret?.trim();
+  return normalized && normalized.length >= MIN_TELEMETRY_SECRET_LENGTH ? normalized : undefined;
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  let equal = left.length === right.length;
+  const comparisons = Math.max(left.length, right.length);
+
+  for (let index = 0; index < comparisons; index += 1) {
+    if (left.charCodeAt(index) !== right.charCodeAt(index)) equal = false;
+  }
+
+  return equal;
+}
+
+export function getTelemetryDashboardAccess(
+  authorization: string | null,
+  secret: string | undefined,
+): TelemetryDashboardAccess {
+  const configuredSecret = normalizeSecret(secret);
+  if (!configuredSecret) return "unconfigured";
+
+  const token = authorization?.match(/^Bearer ([^\s]+)$/i)?.[1];
+  if (!token) return "unauthorized";
+
+  return constantTimeEqual(token, configuredSecret) ? "authorized" : "unauthorized";
+}

--- a/packages/backend/convex/analytics-core.ts
+++ b/packages/backend/convex/analytics-core.ts
@@ -1,5 +1,36 @@
 export type Distribution = Record<string, number>;
 
+export type ProjectSetupOutcome =
+  | "complete"
+  | "incomplete"
+  | "generation-only"
+  | "not-requested"
+  | "unknown";
+
+type ProjectSetupEvent = {
+  eventType?: string;
+  success?: boolean;
+  source?: string;
+  install?: boolean;
+  setupFailures?: readonly string[];
+};
+
+/**
+ * Classify successful project-generation events without pretending that MCP
+ * generation or an explicit `--no-install` ran the local setup pipeline.
+ */
+export function classifyProjectSetupOutcome(
+  event: ProjectSetupEvent,
+): ProjectSetupOutcome | undefined {
+  const isProjectCreation = event.eventType === undefined || event.eventType === "project_created";
+  if (!isProjectCreation || event.success === false) return undefined;
+  if (event.source === "mcp") return "generation-only";
+  if (event.setupFailures && event.setupFailures.length > 0) return "incomplete";
+  if (event.install === false) return "not-requested";
+  if (event.setupFailures === undefined) return "unknown";
+  return "complete";
+}
+
 export type FailureAggregates = {
   failureStages: Distribution;
   failureReasons: Distribution;

--- a/packages/backend/convex/analytics.ts
+++ b/packages/backend/convex/analytics.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { internalMutation, internalQuery, query } from "./_generated/server";
 import {
   applyFailureClassifications,
+  classifyProjectSetupOutcome,
   countReturningMachinesFromActivity,
   type Distribution,
 } from "./analytics-core";
@@ -218,6 +219,9 @@ type StatsShape = {
   actionFailureStages: Dist;
   actionFailureReasons: Dist;
   setupFailureStats: Dist;
+  setupOutcomes: Dist;
+  installSelections: Dist;
+  decisionEvents: number;
   durationBuckets: Dist;
   fileCountBuckets: Dist;
   changedFileCountBuckets: Dist;
@@ -267,6 +271,9 @@ function emptyStats(): StatsShape {
     actionFailureStages: {},
     actionFailureReasons: {},
     setupFailureStats: {},
+    setupOutcomes: {},
+    installSelections: {},
+    decisionEvents: 0,
     durationBuckets: {},
     fileCountBuckets: {},
     changedFileCountBuckets: {},
@@ -285,6 +292,102 @@ function emptyStats(): StatsShape {
   return stats;
 }
 
+type ProjectDecisionAggregates = {
+  setupOutcomes: Dist;
+  installSelections: Dist;
+};
+
+function applyProjectDecisionAggregates(
+  stats: ProjectDecisionAggregates,
+  ev: AnalyticsEvent,
+  stack = eventStack(ev),
+): void {
+  const setupOutcome = classifyProjectSetupOutcome({
+    ...ev,
+    install: typeof stack.install === "boolean" ? stack.install : undefined,
+  });
+  inc(stats.setupOutcomes, setupOutcome);
+  if (!setupOutcome) return;
+
+  const installSelection =
+    ev.source === "mcp"
+      ? "generation-only"
+      : typeof stack.install === "boolean"
+        ? stack.install
+          ? "requested"
+          : "skipped"
+        : "unknown";
+  inc(stats.installSelections, installSelection);
+}
+
+type DailyStatsShape = {
+  date: string;
+  count: number;
+  newMachines: number;
+  totalEvents: number;
+  successfulEvents: number;
+  failedEvents: number;
+  decisionEvents: number;
+  actions: Dist;
+  actionStatuses: Dist;
+  actionOutcomes: Dist;
+  clients: Dist;
+  sources: Dist;
+  ecosystems: Dist;
+  setupOutcomes: Dist;
+  installSelections: Dist;
+  failureStages: Dist;
+  failureReasons: Dist;
+  actionFailureStages: Dist;
+  actionFailureReasons: Dist;
+};
+
+function emptyDailyStats(date: string): DailyStatsShape {
+  return {
+    date,
+    count: 0,
+    newMachines: 0,
+    totalEvents: 0,
+    successfulEvents: 0,
+    failedEvents: 0,
+    decisionEvents: 0,
+    actions: {},
+    actionStatuses: {},
+    actionOutcomes: {},
+    clients: {},
+    sources: {},
+    ecosystems: {},
+    setupOutcomes: {},
+    installSelections: {},
+    failureStages: {},
+    failureReasons: {},
+    actionFailureStages: {},
+    actionFailureReasons: {},
+  };
+}
+
+function applyDailyEvent(daily: DailyStatsShape, ev: AnalyticsEvent): void {
+  daily.totalEvents += 1;
+  daily.decisionEvents += 1;
+  if (ev.success === true) daily.successfulEvents += 1;
+  else if (ev.success === false) daily.failedEvents += 1;
+
+  inc(daily.actions, ev.action);
+  if (ev.action && ev.status) inc(daily.actionStatuses, `${ev.action}:${ev.status}`);
+  if (ev.action && ev.success !== undefined) {
+    inc(daily.actionOutcomes, `${ev.action}:${ev.success ? "success" : "failure"}`);
+  }
+  inc(daily.clients, ev.client);
+  inc(daily.sources, ev.source ?? "unknown");
+  applyFailureClassifications(daily, ev);
+
+  if (!isCountedProject(ev)) return;
+  daily.count += 1;
+  const stack = eventStack(ev);
+  inc(daily.ecosystems, typeof stack.ecosystem === "string" ? stack.ecosystem : undefined);
+  applyProjectDecisionAggregates(daily, ev, stack);
+}
+
 /** Apply one event to the running aggregates (mutates `stats`). */
 function applyEvent(stats: StatsShape, ev: AnalyticsEvent): void {
   const now = ev.creationTime;
@@ -292,6 +395,7 @@ function applyEvent(stats: StatsShape, ev: AnalyticsEvent): void {
 
   // Envelope aggregates: every event type.
   stats.totalEvents += 1;
+  stats.decisionEvents += 1;
   inc(stats.eventTypes, ev.eventType ?? "project_created");
   inc(stats.sources, ev.source ?? "unknown");
   inc(stats.outcomes, ev.success === undefined ? "unknown" : ev.success ? "success" : "failure");
@@ -334,6 +438,9 @@ function applyEvent(stats: StatsShape, ev: AnalyticsEvent): void {
   if (ev.issueCount !== undefined) inc(stats.issueCountBuckets, countBucket(ev.issueCount));
   incBool(stats.retryUsage, ev.retry);
 
+  const stack = eventStack(ev);
+  applyProjectDecisionAggregates(stats, ev, stack);
+
   // Failed attempts stop here: no project or requested stack aggregates.
   if (ev.success === false) return;
 
@@ -351,7 +458,7 @@ function applyEvent(stats: StatsShape, ev: AnalyticsEvent): void {
       : ev.eventType === "stack_updated"
         ? "update."
         : `${ev.eventType}.`;
-  for (const [key, value] of Object.entries(eventStack(ev))) {
+  for (const [key, value] of Object.entries(stack)) {
     const dist = (stats.dimensions[prefix + key] ??= {});
     if (typeof value === "boolean") incBool(dist, value);
     else if (Array.isArray(value)) incAll(dist, value);
@@ -544,29 +651,28 @@ export const ingestEvent = internalMutation({
       await ctx.db.insert("analyticsStats", stats);
     }
 
-    const creation = isCountedProject(args);
     const daily = await ctx.db
       .query("analyticsDailyStats")
       .withIndex("by_date", (q) => q.eq("date", today))
       .first();
+    let dailyStats = emptyDailyStats(today);
     if (daily) {
-      await ctx.db.patch("analyticsDailyStats", daily._id, {
-        count: daily.count + (creation ? 1 : 0),
-        newMachines: (daily.newMachines ?? 0) + (newMachine ? 1 : 0),
-        totalEvents: (daily.totalEvents ?? daily.count) + 1,
-        successfulEvents: (daily.successfulEvents ?? 0) + (args.success === true ? 1 : 0),
-        failedEvents: (daily.failedEvents ?? 0) + (args.success === false ? 1 : 0),
-      });
-    } else {
-      await ctx.db.insert("analyticsDailyStats", {
-        date: today,
-        count: creation ? 1 : 0,
-        newMachines: newMachine ? 1 : 0,
-        totalEvents: 1,
-        successfulEvents: args.success === true ? 1 : 0,
-        failedEvents: args.success === false ? 1 : 0,
-      });
+      const { _id, _creationTime, ...plain } = daily;
+      dailyStats = {
+        ...dailyStats,
+        ...plain,
+        newMachines: daily.newMachines ?? 0,
+        totalEvents: daily.totalEvents ?? daily.count,
+        successfulEvents: daily.successfulEvents ?? 0,
+        failedEvents: daily.failedEvents ?? 0,
+        decisionEvents: daily.decisionEvents ?? 0,
+      };
     }
+    applyDailyEvent(dailyStats, { ...args, creationTime: now });
+    if (newMachine) dailyStats.newMachines += 1;
+
+    if (daily) await ctx.db.patch("analyticsDailyStats", daily._id, dailyStats);
+    else await ctx.db.insert("analyticsDailyStats", dailyStats);
 
     return null;
   },
@@ -612,6 +718,19 @@ export const getDailyStats = query({
       totalEvents: v.optional(v.number()),
       successfulEvents: v.optional(v.number()),
       failedEvents: v.optional(v.number()),
+      decisionEvents: v.optional(v.number()),
+      actions: v.optional(distributionValidator),
+      actionStatuses: v.optional(distributionValidator),
+      actionOutcomes: v.optional(distributionValidator),
+      clients: v.optional(distributionValidator),
+      sources: v.optional(distributionValidator),
+      ecosystems: v.optional(distributionValidator),
+      setupOutcomes: v.optional(distributionValidator),
+      installSelections: v.optional(distributionValidator),
+      failureStages: v.optional(distributionValidator),
+      failureReasons: v.optional(distributionValidator),
+      actionFailureStages: v.optional(distributionValidator),
+      actionFailureReasons: v.optional(distributionValidator),
     }),
   ),
   handler: async (ctx, args) => {
@@ -635,6 +754,19 @@ export const getDailyStats = query({
         totalEvents: d.totalEvents,
         successfulEvents: d.successfulEvents,
         failedEvents: d.failedEvents,
+        decisionEvents: d.decisionEvents,
+        actions: d.actions,
+        actionStatuses: d.actionStatuses,
+        actionOutcomes: d.actionOutcomes,
+        clients: d.clients,
+        sources: d.sources,
+        ecosystems: d.ecosystems,
+        setupOutcomes: d.setupOutcomes,
+        installSelections: d.installSelections,
+        failureStages: d.failureStages,
+        failureReasons: d.failureReasons,
+        actionFailureStages: d.actionFailureStages,
+        actionFailureReasons: d.actionFailureReasons,
       }));
   },
 });
@@ -711,6 +843,7 @@ export const getProductInsights = query({
   args: {},
   returns: v.object({
     totalEvents: v.number(),
+    decisionEvents: v.number(),
     actions: distributionValidator,
     statuses: distributionValidator,
     modes: distributionValidator,
@@ -738,12 +871,16 @@ export const getProductInsights = query({
     failureReasons: distributionValidator,
     actionFailureStages: distributionValidator,
     actionFailureReasons: distributionValidator,
+    setupFailureStats: distributionValidator,
+    setupOutcomes: distributionValidator,
+    installSelections: distributionValidator,
     dimensions: v.record(v.string(), distributionValidator),
   }),
   handler: async (ctx) => {
     const stats = await ctx.db.query("analyticsStats").first();
     return {
       totalEvents: stats?.totalEvents ?? 0,
+      decisionEvents: stats?.decisionEvents ?? 0,
       actions: stats?.actions ?? {},
       statuses: stats?.statuses ?? {},
       modes: stats?.modes ?? {},
@@ -771,6 +908,9 @@ export const getProductInsights = query({
       failureReasons: stats?.failureReasons ?? {},
       actionFailureStages: stats?.actionFailureStages ?? {},
       actionFailureReasons: stats?.actionFailureReasons ?? {},
+      setupFailureStats: stats?.setupFailureStats ?? {},
+      setupOutcomes: stats?.setupOutcomes ?? {},
+      installSelections: stats?.installSelections ?? {},
       dimensions: stats?.dimensions ?? {},
     };
   },
@@ -815,16 +955,7 @@ export const backfillStats = internalMutation({
     events.sort((a, b) => a._creationTime - b._creationTime);
 
     const stats = emptyStats();
-    const dailyCounts = new Map<
-      string,
-      {
-        count: number;
-        newMachines: number;
-        totalEvents: number;
-        successfulEvents: number;
-        failedEvents: number;
-      }
-    >();
+    const dailyCounts = new Map<string, DailyStatsShape>();
     const machines = new Map<
       string,
       {
@@ -846,17 +977,8 @@ export const backfillStats = internalMutation({
       applyEvent(stats, { ...ev, creationTime: now } as AnalyticsEvent);
 
       const date = utcDate(now);
-      const daily = dailyCounts.get(date) ?? {
-        count: 0,
-        newMachines: 0,
-        totalEvents: 0,
-        successfulEvents: 0,
-        failedEvents: 0,
-      };
-      if (isCountedProject(ev)) daily.count += 1;
-      daily.totalEvents += 1;
-      if (ev.success === false) daily.failedEvents += 1;
-      else if (ev.success === true) daily.successfulEvents += 1;
+      const daily = dailyCounts.get(date) ?? emptyDailyStats(date);
+      applyDailyEvent(daily, { ...ev, creationTime: now } as AnalyticsEvent);
 
       if (ev.machineId) {
         const activityKey = `${date}:${ev.machineId}`;
@@ -911,8 +1033,8 @@ export const backfillStats = internalMutation({
     if (stats.totalEvents > 0) {
       await ctx.db.insert("analyticsStats", stats);
     }
-    for (const [date, daily] of dailyCounts) {
-      await ctx.db.insert("analyticsDailyStats", { date, ...daily });
+    for (const daily of dailyCounts.values()) {
+      await ctx.db.insert("analyticsDailyStats", daily);
     }
     for (const [machineId, machine] of machines) {
       await ctx.db.insert("analyticsMachines", { machineId, ...machine });

--- a/packages/backend/convex/analytics.ts
+++ b/packages/backend/convex/analytics.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 
-import { internalMutation, internalQuery, query } from "./_generated/server";
+import { internalMutation, internalQuery } from "./_generated/server";
 import {
   applyFailureClassifications,
   classifyProjectSetupOutcome,
@@ -680,7 +680,7 @@ export const ingestEvent = internalMutation({
 
 const distributionValidator = v.record(v.string(), v.number());
 
-export const getStats = query({
+export const getStats = internalQuery({
   args: {},
   handler: async (ctx) => {
     const stats = await ctx.db.query("analyticsStats").first();
@@ -706,7 +706,7 @@ export const getStats = query({
   },
 });
 
-export const getDailyStats = query({
+export const getDailyStats = internalQuery({
   args: {
     days: v.optional(v.number()),
   },
@@ -771,7 +771,7 @@ export const getDailyStats = query({
   },
 });
 
-export const getEngagement = query({
+export const getEngagement = internalQuery({
   args: {},
   returns: v.object({
     uniqueMachines: v.number(),
@@ -839,7 +839,7 @@ export const getEngagement = query({
  * aggregate counters; anonymous machine identifiers and individual events are
  * never exposed by this query.
  */
-export const getProductInsights = query({
+export const getProductInsights = internalQuery({
   args: {},
   returns: v.object({
     totalEvents: v.number(),

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -2,6 +2,7 @@ import { httpRouter } from "convex/server";
 
 import { internal } from "./_generated/api";
 import { httpAction } from "./_generated/server";
+import { getTelemetryDashboardAccess } from "./analytics-access";
 
 type StackValue = string | boolean | string[];
 
@@ -83,6 +84,13 @@ const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
+};
+const PRIVATE_JSON_HEADERS = {
+  "Cache-Control": "private, no-store",
+  "Content-Type": "application/json; charset=utf-8",
+  Vary: "Authorization",
+  "X-Content-Type-Options": "nosniff",
+  "X-Robots-Tag": "noindex, nofollow, noarchive, nosnippet",
 };
 
 function sanitizeString(value: string): string | undefined {
@@ -288,6 +296,48 @@ http.route({
       return new Response("Internal Server Error", { status: 500, headers: CORS_HEADERS });
     }
     return new Response("ok", { headers: CORS_HEADERS });
+  }),
+});
+
+http.route({
+  path: "/api/analytics/dashboard",
+  method: "GET",
+  handler: httpAction(async (ctx, req) => {
+    const access = getTelemetryDashboardAccess(
+      req.headers.get("Authorization"),
+      process.env.TELEMETRY_DASHBOARD_SECRET,
+    );
+    if (access === "unconfigured") {
+      return new Response(JSON.stringify({ error: "Telemetry dashboard is not configured" }), {
+        status: 503,
+        headers: PRIVATE_JSON_HEADERS,
+      });
+    }
+    if (access === "unauthorized") {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: PRIVATE_JSON_HEADERS,
+      });
+    }
+
+    try {
+      const [stats, daily, engagement, insights] = await Promise.all([
+        ctx.runQuery(internal.analytics.getStats, {}),
+        ctx.runQuery(internal.analytics.getDailyStats, { days: 30 }),
+        ctx.runQuery(internal.analytics.getEngagement, {}),
+        ctx.runQuery(internal.analytics.getProductInsights, {}),
+      ]);
+
+      return new Response(JSON.stringify({ stats, daily, engagement, insights }), {
+        headers: PRIVATE_JSON_HEADERS,
+      });
+    } catch (error) {
+      console.error("Failed to load aggregate telemetry dashboard:", error);
+      return new Response(JSON.stringify({ error: "Internal Server Error" }), {
+        status: 500,
+        headers: PRIVATE_JSON_HEADERS,
+      });
+    }
   }),
 });
 

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -202,6 +202,9 @@ export default defineSchema({
     actionFailureStages: v.optional(distributionValidator),
     actionFailureReasons: v.optional(distributionValidator),
     setupFailureStats: v.optional(distributionValidator),
+    setupOutcomes: v.optional(distributionValidator),
+    installSelections: v.optional(distributionValidator),
+    decisionEvents: v.optional(v.number()),
     durationBuckets: v.optional(distributionValidator),
     fileCountBuckets: v.optional(distributionValidator),
     changedFileCountBuckets: v.optional(distributionValidator),
@@ -224,6 +227,21 @@ export default defineSchema({
     totalEvents: v.optional(v.number()),
     successfulEvents: v.optional(v.number()),
     failedEvents: v.optional(v.number()),
+    // Optional for compatibility with rows created before decision-window
+    // aggregates shipped. `decisionEvents / totalEvents` exposes coverage.
+    decisionEvents: v.optional(v.number()),
+    actions: v.optional(distributionValidator),
+    actionStatuses: v.optional(distributionValidator),
+    actionOutcomes: v.optional(distributionValidator),
+    clients: v.optional(distributionValidator),
+    sources: v.optional(distributionValidator),
+    ecosystems: v.optional(distributionValidator),
+    setupOutcomes: v.optional(distributionValidator),
+    installSelections: v.optional(distributionValidator),
+    failureStages: v.optional(distributionValidator),
+    failureReasons: v.optional(distributionValidator),
+    actionFailureStages: v.optional(distributionValidator),
+    actionFailureReasons: v.optional(distributionValidator),
   }).index("by_date", ["date"]),
 
   analyticsMachines: defineTable({

--- a/packages/backend/test/analytics-access.test.ts
+++ b/packages/backend/test/analytics-access.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import { getTelemetryDashboardAccess } from "../convex/analytics-access";
+
+const SECRET = "owner-only-telemetry-secret-0123456789";
+
+describe("telemetry dashboard API access", () => {
+  it("fails closed without a strong configured secret", () => {
+    expect(getTelemetryDashboardAccess(`Bearer ${SECRET}`, undefined)).toBe("unconfigured");
+    expect(getTelemetryDashboardAccess(`Bearer ${SECRET}`, "too-short")).toBe("unconfigured");
+  });
+
+  it("rejects missing, malformed, and incorrect bearer credentials", () => {
+    expect(getTelemetryDashboardAccess(null, SECRET)).toBe("unauthorized");
+    expect(getTelemetryDashboardAccess(`Basic ${SECRET}`, SECRET)).toBe("unauthorized");
+    expect(getTelemetryDashboardAccess("Bearer wrong-secret", SECRET)).toBe("unauthorized");
+  });
+
+  it("accepts only the configured bearer secret", () => {
+    expect(getTelemetryDashboardAccess(`Bearer ${SECRET}`, SECRET)).toBe("authorized");
+    expect(getTelemetryDashboardAccess(`bearer ${SECRET}`, SECRET)).toBe("authorized");
+  });
+});

--- a/packages/backend/test/analytics-core.test.ts
+++ b/packages/backend/test/analytics-core.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   applyFailureClassifications,
+  classifyProjectSetupOutcome,
   countReturningMachinesFromActivity,
   type FailureAggregates,
 } from "../convex/analytics-core";
@@ -48,5 +49,62 @@ describe("analytics aggregate helpers", () => {
       actionFailureStages: { "builder-generate:request": 1 },
       actionFailureReasons: { "builder-generate:network": 1 },
     });
+  });
+
+  it("separates completed setup from skipped and generation-only creation", () => {
+    expect(
+      classifyProjectSetupOutcome({
+        eventType: "project_created",
+        success: true,
+        install: true,
+        setupFailures: [],
+      }),
+    ).toBe("complete");
+    expect(
+      classifyProjectSetupOutcome({
+        eventType: "project_created",
+        success: true,
+        install: true,
+        setupFailures: ["install-dependencies"],
+      }),
+    ).toBe("incomplete");
+    expect(
+      classifyProjectSetupOutcome({
+        eventType: "project_created",
+        success: true,
+        install: false,
+        setupFailures: [],
+      }),
+    ).toBe("not-requested");
+    expect(
+      classifyProjectSetupOutcome({
+        eventType: "project_created",
+        success: true,
+        source: "mcp",
+        install: true,
+      }),
+    ).toBe("generation-only");
+    expect(
+      classifyProjectSetupOutcome({
+        eventType: "project_created",
+        success: true,
+        install: true,
+      }),
+    ).toBe("unknown");
+    expect(
+      classifyProjectSetupOutcome({
+        eventType: "project_created",
+        success: false,
+        install: true,
+        setupFailures: [],
+      }),
+    ).toBeUndefined();
+    expect(
+      classifyProjectSetupOutcome({
+        eventType: "command_used",
+        success: true,
+        setupFailures: [],
+      }),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- add daily and all-time aggregate decision signals for lifecycle actions, browser run/edit/ZIP outcomes, ecosystem adoption, failure classifications, setup completion, install selection, and aggregate coverage
- add an unlisted, no-index `/telemetry` decision room with a 30-day view and an explicit all-time fallback when historical daily coverage is below 80%
- keep repeat-use honest by treating CLI and browser identifiers as separate anonymous client IDs rather than a person-level funnel
- preserve unattributed failure counts alongside action-specific classifications
- add focused aggregate-model, dashboard, migration-edge, and sitemap-boundary tests

## Privacy and migration

This adds no user-content fields. Queries expose aggregate counters only; project names, paths, prompts, code, environment values, URLs, raw errors, and anonymous IDs remain excluded from the dashboard response.

Legacy daily rows remain readable through optional fields. The UI exposes aggregate coverage and falls back to all-time metrics while daily coverage is incomplete. After the backend is deployed, invoke the existing internal `analytics:backfillStats` mutation once to rebuild historical all-time and daily decision aggregates.

Setup outcomes deliberately distinguish:

- completed local setup
- incomplete setup
- generation-only MCP output
- explicitly skipped install
- unknown legacy rows

## Validation

- full pre-commit monorepo lint/typecheck hook
- `bun run --cwd packages/backend lint`
- `bunx tsc --noEmit -p apps/web/tsconfig.json`
- `bun test packages/backend/test/analytics-core.test.ts`
- `bun test test/telemetry-dashboard.test.ts test/seo-contract.test.ts` from `apps/web`
- `git diff --check origin/main...HEAD`

## Owner access and CI

- `/telemetry` is an internal owner-only surface protected by HTTP Basic authentication.
- Configure the same random, 32-character-or-longer `TELEMETRY_DASHBOARD_SECRET` in the web and Convex deployments. Sign in as `owner` with that secret as the password.
- Access fails closed when either deployment is unconfigured or the credentials do not match.
- Aggregate dashboard queries are internal Convex queries exposed only through the authenticated server-to-server endpoint; the secret and Convex query client are absent from the browser bundle.
- The flaky performance-budget step and its report publishing were removed from CI. Normal lint, tests, and build checks remain enabled.

## Additional validation

- full pre-commit monorepo lint/typecheck hook (zero errors)
- `bun test test/analytics-access.test.ts test/analytics-core.test.ts` from `packages/backend`
- `bun test test/telemetry-auth.test.ts test/telemetry-dashboard.test.ts test/seo-contract.test.ts` from `apps/web`
- production web build and full monorepo build
- production client-bundle inspection for secret/API leakage
