### PR TITLE
feat: add Vercel Analytics integration

### DIFF
--- a/apps/cli/src/prompts/analytics.ts
+++ b/apps/cli/src/prompts/analytics.ts
@@ -1,6 +1,7 @@
 import type { Analytics, Frontend } from "../types";
 import type { PromptSingleResolution } from "./prompt-contract";
 
+import { isVercelAnalyticsFrontend } from "../types";
 import { exitCancelled } from "../utils/errors";
 import { isCancel, navigableSelect } from "./navigable";
 
@@ -29,23 +30,28 @@ type AnalyticsPromptContext = {
 export function resolveAnalyticsPrompt(
   context: AnalyticsPromptContext = {},
 ): PromptSingleResolution<Analytics> {
-  if (
-    !context.frontend?.some((frontend) => frontend !== "none" && !frontend.startsWith("native-"))
-  ) {
+  const webFrontends = (context.frontend ?? []).filter(
+    (frontend) => frontend !== "none" && !frontend.startsWith("native-"),
+  );
+  if (webFrontends.length === 0) {
     return { shouldPrompt: false, mode: "single", options: [], autoValue: "none" };
   }
+
+  const options = webFrontends.every((frontend) => isVercelAnalyticsFrontend(frontend))
+    ? ANALYTICS_PROMPT_OPTIONS
+    : ANALYTICS_PROMPT_OPTIONS.filter((option) => option.value !== "vercel-analytics");
 
   return context.analytics !== undefined
     ? {
         shouldPrompt: false,
         mode: "single",
-        options: ANALYTICS_PROMPT_OPTIONS,
+        options,
         autoValue: context.analytics,
       }
     : {
         shouldPrompt: true,
         mode: "single",
-        options: ANALYTICS_PROMPT_OPTIONS,
+        options,
         initialValue: "none",
       };
 }

--- a/apps/cli/src/prompts/analytics.ts
+++ b/apps/cli/src/prompts/analytics.ts
@@ -1,0 +1,64 @@
+import type { Analytics, Frontend } from "../types";
+import type { PromptSingleResolution } from "./prompt-contract";
+
+import { exitCancelled } from "../utils/errors";
+import { isCancel, navigableSelect } from "./navigable";
+
+const ANALYTICS_PROMPT_OPTIONS = [
+  {
+    value: "vercel-analytics" as const,
+    label: "Vercel Analytics",
+    hint: "First-party web analytics for Vercel deployments",
+  },
+  {
+    value: "plausible" as const,
+    label: "Plausible",
+    hint: "Lightweight, privacy-focused analytics",
+  },
+  { value: "umami" as const, label: "Umami", hint: "Open-source analytics with self-hosting" },
+  { value: "posthog" as const, label: "PostHog", hint: "Product analytics and session replay" },
+  { value: "ga4" as const, label: "Google Analytics 4", hint: "Google web analytics" },
+  { value: "none" as const, label: "None", hint: "Skip analytics setup" },
+];
+
+type AnalyticsPromptContext = {
+  analytics?: Analytics;
+  frontend?: Frontend[];
+};
+
+export function resolveAnalyticsPrompt(
+  context: AnalyticsPromptContext = {},
+): PromptSingleResolution<Analytics> {
+  if (
+    !context.frontend?.some((frontend) => frontend !== "none" && !frontend.startsWith("native-"))
+  ) {
+    return { shouldPrompt: false, mode: "single", options: [], autoValue: "none" };
+  }
+
+  return context.analytics !== undefined
+    ? {
+        shouldPrompt: false,
+        mode: "single",
+        options: ANALYTICS_PROMPT_OPTIONS,
+        autoValue: context.analytics,
+      }
+    : {
+        shouldPrompt: true,
+        mode: "single",
+        options: ANALYTICS_PROMPT_OPTIONS,
+        initialValue: "none",
+      };
+}
+
+export async function getAnalyticsChoice(analytics?: Analytics, frontend?: Frontend[]) {
+  const resolution = resolveAnalyticsPrompt({ analytics, frontend });
+  if (!resolution.shouldPrompt) return resolution.autoValue ?? "none";
+
+  const response = await navigableSelect<Analytics>({
+    message: "Select a web analytics provider",
+    options: resolution.options,
+    initialValue: resolution.initialValue as Analytics,
+  });
+  if (isCancel(response)) return exitCancelled("Operation cancelled");
+  return response;
+}

--- a/apps/cli/src/prompts/config-prompts.ts
+++ b/apps/cli/src/prompts/config-prompts.ts
@@ -156,6 +156,7 @@ import { hasWebStyling, requiresChatSdkVercelAI } from "../utils/compatibility-r
 import { exitCancelled } from "../utils/errors";
 import { getUserPkgManager } from "../utils/get-package-manager";
 import { getAddonsChoice, getAppPlatformsChoice } from "./addons";
+import { getAnalyticsChoice } from "./analytics";
 import { getAIChoice } from "./ai";
 import { getAiDocsChoice } from "./ai-docs";
 import { getAnimationChoice } from "./animation";
@@ -1084,7 +1085,7 @@ export async function gatherConfig(
       getEcommerceChoice(flags.ecommerce, results.backend, results.ecosystem),
     analytics: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as Analytics);
-      return Promise.resolve(flags.analytics || "none") as Promise<Analytics>;
+      return getAnalyticsChoice(flags.analytics, results.frontend);
     },
     cms: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as CMS);

--- a/apps/cli/src/prompts/multi-ecosystem-composer.ts
+++ b/apps/cli/src/prompts/multi-ecosystem-composer.ts
@@ -16,6 +16,7 @@ import {
 import { hasWebStyling } from "../utils/compatibility-rules";
 import { exitCancelled } from "../utils/errors";
 import { getAddonsChoice, getAppPlatformsChoice } from "./addons";
+import { getAnalyticsChoice } from "./analytics";
 import { getAiDocsChoice } from "./ai-docs";
 import { getAstroIntegrationChoice } from "./astro-integration";
 import { getBackendFrameworkChoice } from "./backend";
@@ -344,7 +345,7 @@ export async function gatherMultiEcosystemConfig(
           await getConfigSectionsChoice(
             "typescript",
             [],
-            ["app-platforms", "ui-styling", "deploy", "addons-examples"],
+            ["app-platforms", "ui-styling", "content", "deploy", "addons-examples"],
           ),
         )
       : [];
@@ -456,6 +457,12 @@ export async function gatherMultiEcosystemConfig(
         getCSSFrameworkChoice(flags.cssFramework, uiLibrary, frontendList),
       )
     : "none";
+  const analytics =
+    frontendEcosystem === "typescript"
+      ? await scopedPromptValue("typescript", "analytics", configScope, typeScriptSections, () =>
+          getAnalyticsChoice(flags.analytics, frontendList),
+        )
+      : "none";
 
   const backendEcosystem = await selectBackendEcosystem();
   const backendSections =
@@ -466,6 +473,9 @@ export async function gatherMultiEcosystemConfig(
   }
   if (frontendEcosystem === "typescript" && frontend !== "none") {
     stackPartSpecs.push(`frontend:typescript:${frontend}`);
+    if (analytics !== "none") {
+      stackPartSpecs.push(`frontend.analytics:typescript:${analytics}`);
+    }
   }
   if (frontendEcosystem === "dotnet" && selectedDotnetFrontend !== "none") {
     stackPartSpecs.push(`frontend:dotnet:${selectedDotnetFrontend}`);
@@ -1576,6 +1586,7 @@ export async function gatherMultiEcosystemConfig(
     uiLibrary,
     ...shadcnOptions,
     cssFramework,
+    analytics,
     addons: selectedAddons,
     examples: [],
     dbSetup,

--- a/apps/cli/test/analytics-prompt.test.ts
+++ b/apps/cli/test/analytics-prompt.test.ts
@@ -10,6 +10,13 @@ describe("analytics prompt", () => {
     expect(resolution.options.map((option) => option.value)).toContain("vercel-analytics");
   });
 
+  it("hides Vercel Analytics for unsupported web frontends", () => {
+    const resolution = resolveAnalyticsPrompt({ frontend: ["angular"] });
+
+    expect(resolution.shouldPrompt).toBe(true);
+    expect(resolution.options.map((option) => option.value)).not.toContain("vercel-analytics");
+  });
+
   it("respects flags and skips non-web projects", () => {
     expect(
       resolveAnalyticsPrompt({ analytics: "vercel-analytics", frontend: ["next"] }).autoValue,

--- a/apps/cli/test/analytics-prompt.test.ts
+++ b/apps/cli/test/analytics-prompt.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveAnalyticsPrompt } from "../src/prompts/analytics";
+
+describe("analytics prompt", () => {
+  it("offers Vercel Analytics for web frontends", () => {
+    const resolution = resolveAnalyticsPrompt({ frontend: ["next"] });
+
+    expect(resolution.shouldPrompt).toBe(true);
+    expect(resolution.options.map((option) => option.value)).toContain("vercel-analytics");
+  });
+
+  it("respects flags and skips non-web projects", () => {
+    expect(
+      resolveAnalyticsPrompt({ analytics: "vercel-analytics", frontend: ["next"] }).autoValue,
+    ).toBe("vercel-analytics");
+    expect(resolveAnalyticsPrompt({ frontend: ["native-bare"] }).autoValue).toBe("none");
+  });
+});

--- a/apps/cli/test/preflight-validation.test.ts
+++ b/apps/cli/test/preflight-validation.test.ts
@@ -250,7 +250,13 @@ describe("preflight validation", () => {
 
   describe("analytics", () => {
     test("passes with Astro frontend", () => {
-      expect(ruleIds(config({ analytics: "plausible", frontend: ["astro"] }))).not.toContain(
+      expect(ruleIds(config({ analytics: "vercel-analytics", frontend: ["astro"] }))).not.toContain(
+        "analytics-no-frontend",
+      );
+    });
+
+    test("warns when the provider has no Astro template", () => {
+      expect(ruleIds(config({ analytics: "plausible", frontend: ["astro"] }))).toContain(
         "analytics-no-frontend",
       );
     });

--- a/apps/cli/test/preflight-validation.test.ts
+++ b/apps/cli/test/preflight-validation.test.ts
@@ -249,8 +249,8 @@ describe("preflight validation", () => {
   });
 
   describe("analytics", () => {
-    test("warns without supported frontend", () => {
-      expect(ruleIds(config({ analytics: "plausible", frontend: ["astro"] }))).toContain(
+    test("passes with Astro frontend", () => {
+      expect(ruleIds(config({ analytics: "plausible", frontend: ["astro"] }))).not.toContain(
         "analytics-no-frontend",
       );
     });

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -1429,6 +1429,14 @@ export const TECH_OPTIONS: Record<
   ],
   analytics: [
     {
+      id: "vercel-analytics",
+      name: "Vercel Analytics",
+      description: "Privacy-friendly page views and custom events, best when deployed to Vercel",
+      icon: "https://cdn.simpleicons.org/vercel/000000",
+      color: "from-zinc-700 to-black",
+      default: false,
+    },
+    {
       id: "ga4",
       name: "Google Analytics 4",
       description: "Google web analytics with configurable event tracking",

--- a/apps/web/src/lib/constant.ts
+++ b/apps/web/src/lib/constant.ts
@@ -1432,7 +1432,7 @@ export const TECH_OPTIONS: Record<
       id: "vercel-analytics",
       name: "Vercel Analytics",
       description: "Privacy-friendly page views and custom events, best when deployed to Vercel",
-      icon: "https://cdn.simpleicons.org/vercel/000000",
+      icon: "",
       color: "from-zinc-700 to-black",
       default: false,
     },

--- a/apps/web/src/lib/docs/cli-flags-data.ts
+++ b/apps/web/src/lib/docs/cli-flags-data.ts
@@ -649,6 +649,7 @@ export const CLI_FLAG_GROUPS: CliFlagGroup[] = [
           "umami",
           "posthog",
           "ga4",
+          "vercel-analytics",
           "none"
         ],
         "valueHint": null,

--- a/apps/web/src/lib/tech-icons.ts
+++ b/apps/web/src/lib/tech-icons.ts
@@ -73,6 +73,7 @@ export const ICON_REGISTRY: Record<string, IconConfig> = {
   "openapi-typescript": { type: "si", slug: "openapiinitiative", hex: "6BA539" },
   "apollo-client": { type: "si", slug: "apollographql", hex: "311C87" },
   ga4: { type: "si", slug: "googleanalytics", hex: "E37400" },
+  "vercel-analytics": { type: "si", slug: "vercel", hex: "000000" },
   paypal: { type: "si", slug: "paypal", hex: "003087" },
   xendit: { type: "local", src: "https://www.xendit.co/favicon.ico" },
   medusa: { type: "si", slug: "medusa", hex: "000000" },

--- a/apps/web/src/lib/tech-resource-links.ts
+++ b/apps/web/src/lib/tech-resource-links.ts
@@ -6,6 +6,10 @@ type TechResourceLinks = {
 type LinkMap = Record<string, TechResourceLinks>;
 
 const BASE_LINKS: LinkMap = {
+  "vercel-analytics": {
+    docsUrl: "https://vercel.com/docs/analytics/quickstart",
+    githubUrl: "https://github.com/vercel/analytics",
+  },
   "blazor-webassembly": {
     docsUrl: "https://learn.microsoft.com/aspnet/core/blazor/hosting-models",
     githubUrl: "https://github.com/dotnet/aspnetcore",

--- a/apps/web/test/tech-icons.test.ts
+++ b/apps/web/test/tech-icons.test.ts
@@ -4,6 +4,14 @@ import { existsSync } from "node:fs";
 import { ICON_REGISTRY } from "../src/lib/tech-icons";
 
 describe("tech icon registry", () => {
+  test("renders Vercel Analytics through the theme-aware registry", () => {
+    expect(ICON_REGISTRY["vercel-analytics"]).toEqual({
+      type: "si",
+      slug: "vercel",
+      hex: "000000",
+    });
+  });
+
   test("renders Nango from the bundled official icon", () => {
     expect(ICON_REGISTRY.nango).toEqual({
       type: "local",

--- a/packages/template-generator/src/post-process/flatten-single-app.ts
+++ b/packages/template-generator/src/post-process/flatten-single-app.ts
@@ -68,6 +68,7 @@ export function qualifiesForSingleApp(config: ProjectConfig): boolean {
   const webFrontends = (config.frontend ?? []).filter((f) => f && f !== "none");
   if (webFrontends.length !== 1) return false;
   if (!SINGLE_APP_WEB_FRONTENDS.has(webFrontends[0] as string)) return false;
+  if (config.analytics !== "none" && config.analytics !== "vercel-analytics") return false;
 
   const siblingPackageScalars = [
     config.api,
@@ -87,7 +88,6 @@ export function qualifiesForSingleApp(config: ProjectConfig): boolean {
     config.fileStorage,
     config.cms,
     config.ai,
-    config.analytics,
     config.featureFlags,
     config.integrations,
     config.ecommerce,

--- a/packages/template-generator/src/preflight-validation.ts
+++ b/packages/template-generator/src/preflight-validation.ts
@@ -60,9 +60,11 @@ const SOLID_FRONTENDS = new Set(["solid", "solid-start"]);
 const hasReact = (f: readonly string[]) => f.some((x) => REACT_FRONTENDS.has(x));
 const hasSvelte = (f: readonly string[]) => f.includes("svelte");
 const hasNuxt = (f: readonly string[]) => f.includes("nuxt");
+const hasVue = (f: readonly string[]) => f.includes("vue");
+const hasAstro = (f: readonly string[]) => f.includes("astro");
 const hasSolid = (f: readonly string[]) => f.some((x) => SOLID_FRONTENDS.has(x));
 const hasAnyWebFrontend = (f: readonly string[]) =>
-  hasReact(f) || hasSvelte(f) || hasNuxt(f) || hasSolid(f);
+  hasReact(f) || hasSvelte(f) || hasNuxt(f) || hasVue(f) || hasAstro(f) || hasSolid(f);
 
 const hasGraphBackend = (config: ProjectConfig) =>
   config.stackParts?.some(
@@ -199,7 +201,7 @@ const PREFLIGHT_RULES: readonly PreflightRule[] = [
     featureKey: "analytics",
     displayName: "Analytics",
     willSkip: (c) => c.analytics !== "none" && !hasAnyWebFrontend(c.frontend),
-    reason: "Analytics requires a React, Svelte, Nuxt, or Solid frontend.",
+    reason: "Analytics requires a supported web frontend.",
     suggestions: ["Add a supported web frontend", "Remove analytics"],
   },
 

--- a/packages/template-generator/src/preflight-validation.ts
+++ b/packages/template-generator/src/preflight-validation.ts
@@ -66,6 +66,17 @@ const hasSolid = (f: readonly string[]) => f.some((x) => SOLID_FRONTENDS.has(x))
 const hasAnyWebFrontend = (f: readonly string[]) =>
   hasReact(f) || hasSvelte(f) || hasNuxt(f) || hasVue(f) || hasAstro(f) || hasSolid(f);
 
+const ANALYTICS_FRONTEND_SUPPORT: Record<string, (f: readonly string[]) => boolean> = {
+  ga4: hasAnyWebFrontend,
+  plausible: hasReact,
+  posthog: (f) => hasReact(f) || hasSvelte(f) || hasVue(f) || hasNuxt(f) || hasSolid(f),
+  umami: (f) => hasReact(f) || hasSvelte(f) || hasVue(f) || hasNuxt(f) || hasSolid(f),
+  "vercel-analytics": hasAnyWebFrontend,
+};
+
+const supportsAnalyticsFrontend = (config: ProjectConfig) =>
+  (ANALYTICS_FRONTEND_SUPPORT[config.analytics] ?? hasAnyWebFrontend)(config.frontend);
+
 const hasGraphBackend = (config: ProjectConfig) =>
   config.stackParts?.some(
     (part) =>
@@ -200,9 +211,9 @@ const PREFLIGHT_RULES: readonly PreflightRule[] = [
     id: "analytics-no-frontend",
     featureKey: "analytics",
     displayName: "Analytics",
-    willSkip: (c) => c.analytics !== "none" && !hasAnyWebFrontend(c.frontend),
-    reason: "Analytics requires a supported web frontend.",
-    suggestions: ["Add a supported web frontend", "Remove analytics"],
+    willSkip: (c) => c.analytics !== "none" && !supportsAnalyticsFrontend(c),
+    reason: "The selected analytics provider does not support the chosen frontend.",
+    suggestions: ["Add a web frontend supported by the analytics provider", "Remove analytics"],
   },
 
   {

--- a/packages/template-generator/src/processors/analytics-deps.ts
+++ b/packages/template-generator/src/processors/analytics-deps.ts
@@ -1,4 +1,4 @@
-import type { ProjectConfig } from "@better-fullstack/types";
+import { type ProjectConfig, isVercelAnalyticsFrontend } from "@better-fullstack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
 
@@ -43,7 +43,10 @@ export function processAnalyticsDeps(vfs: VirtualFileSystem, config: ProjectConf
     }
   }
 
-  if (analytics === "vercel-analytics" && hasWebFrontend) {
+  if (
+    analytics === "vercel-analytics" &&
+    frontend.some((candidate) => isVercelAnalyticsFrontend(candidate))
+  ) {
     const webPath = getWebPackagePath(frontend, backend);
     if (vfs.exists(webPath)) {
       addPackageDependency({

--- a/packages/template-generator/src/processors/analytics-deps.ts
+++ b/packages/template-generator/src/processors/analytics-deps.ts
@@ -43,6 +43,17 @@ export function processAnalyticsDeps(vfs: VirtualFileSystem, config: ProjectConf
     }
   }
 
+  if (analytics === "vercel-analytics" && hasWebFrontend) {
+    const webPath = getWebPackagePath(frontend, backend);
+    if (vfs.exists(webPath)) {
+      addPackageDependency({
+        vfs,
+        packagePath: webPath,
+        dependencies: ["@vercel/analytics"],
+      });
+    }
+  }
+
   // Umami uses a script tag approach - no npm dependencies needed
   // The umami.tsx template handles loading the script dynamically
 }

--- a/packages/template-generator/src/processors/readme-generator.ts
+++ b/packages/template-generator/src/processors/readme-generator.ts
@@ -576,6 +576,15 @@ ${packageManagerRunCmd} dev
 \`\`\`
 
 ${generateRunningInstructions(frontend, backend, webPort, hasWeb, hasNative, isConvex)}
+${
+  options.analytics === "vercel-analytics"
+    ? `
+## Vercel Web Analytics
+
+The analytics component is already mounted and requires no environment variables. Enable Web Analytics for the project in the Vercel dashboard, then deploy to Vercel to begin collecting privacy-friendly page views.
+`
+    : ""
+}
 ${ai === "ai-cli" ? `\n${generateAICLISection(packageManagerRunCmd, packageManager)}\n` : ""}
 ${
   examples.includes("chat-sdk")

--- a/packages/template-generator/src/template-handlers/analytics.ts
+++ b/packages/template-generator/src/template-handlers/analytics.ts
@@ -1,4 +1,4 @@
-import type { ProjectConfig } from "@better-fullstack/types";
+import { type ProjectConfig, isVercelAnalyticsFrontend } from "@better-fullstack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
 
@@ -20,11 +20,16 @@ const NUXT_FRONTENDS = new Set(["nuxt"]);
 const SOLID_FRONTENDS = new Set(["solid", "solid-start"]);
 const ASTRO_FRONTENDS = new Set(["astro"]);
 
-function getAnalyticsTemplateVariant(frontend: readonly string[]): string | null {
+function getAnalyticsTemplateVariant(
+  frontend: readonly string[],
+  analytics: ProjectConfig["analytics"],
+): string | null {
   if (frontend.some((f) => REACT_FRONTENDS.has(f))) return "react";
   if (frontend.some((f) => SVELTE_FRONTENDS.has(f))) return "svelte";
   if (frontend.some((f) => VUE_FRONTENDS.has(f))) return "vue";
-  if (frontend.some((f) => NUXT_FRONTENDS.has(f))) return "nuxt";
+  if (frontend.some((f) => NUXT_FRONTENDS.has(f))) {
+    return analytics === "vercel-analytics" ? "nuxt" : "vue";
+  }
   if (frontend.some((f) => SOLID_FRONTENDS.has(f))) return "solid";
   if (frontend.some((f) => ASTRO_FRONTENDS.has(f))) return "astro";
   return null;
@@ -102,7 +107,7 @@ function mountVercelAnalytics(vfs: VirtualFileSystem, frontend: string) {
         path,
         source.replace(
           '<script lang="ts">',
-          '<script lang="ts">\n\timport "$lib/vercel-analytics";',
+          '<script lang="ts">\n\timport { startVercelAnalytics } from "$lib/vercel-analytics";\n\n\tstartVercelAnalytics();',
         ),
       );
     }
@@ -156,7 +161,18 @@ export async function processAnalyticsTemplates(
     return;
   }
 
-  const variant = getAnalyticsTemplateVariant(config.frontend);
+  const webFrontends = config.frontend.filter(
+    (frontend) => frontend !== "none" && !frontend.startsWith("native-"),
+  );
+  if (
+    config.analytics === "vercel-analytics" &&
+    (webFrontends.length === 0 ||
+      webFrontends.some((frontend) => !isVercelAnalyticsFrontend(frontend)))
+  ) {
+    throw new Error("Vercel Analytics is not yet mounted for the selected frontend");
+  }
+
+  const variant = getAnalyticsTemplateVariant(config.frontend, config.analytics);
   if (!variant) return;
 
   const targetPath =

--- a/packages/template-generator/src/template-handlers/analytics.ts
+++ b/packages/template-generator/src/template-handlers/analytics.ts
@@ -1,8 +1,8 @@
 import type { ProjectConfig } from "@better-fullstack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
-import { getWebPackagePath } from "../utils/project-paths";
 
+import { getWebPackagePath } from "../utils/project-paths";
 import { type TemplateData, processTemplatesFromPrefix } from "./utils";
 
 const REACT_FRONTENDS = new Set([
@@ -15,15 +15,124 @@ const REACT_FRONTENDS = new Set([
 ]);
 
 const SVELTE_FRONTENDS = new Set(["svelte"]);
-const VUE_FRONTENDS = new Set(["nuxt", "vue"]);
+const VUE_FRONTENDS = new Set(["vue"]);
+const NUXT_FRONTENDS = new Set(["nuxt"]);
 const SOLID_FRONTENDS = new Set(["solid", "solid-start"]);
+const ASTRO_FRONTENDS = new Set(["astro"]);
 
 function getAnalyticsTemplateVariant(frontend: readonly string[]): string | null {
   if (frontend.some((f) => REACT_FRONTENDS.has(f))) return "react";
   if (frontend.some((f) => SVELTE_FRONTENDS.has(f))) return "svelte";
   if (frontend.some((f) => VUE_FRONTENDS.has(f))) return "vue";
+  if (frontend.some((f) => NUXT_FRONTENDS.has(f))) return "nuxt";
   if (frontend.some((f) => SOLID_FRONTENDS.has(f))) return "solid";
+  if (frontend.some((f) => ASTRO_FRONTENDS.has(f))) return "astro";
   return null;
+}
+
+function prependImport(vfs: VirtualFileSystem, path: string, statement: string) {
+  const source = vfs.readFile(path);
+  if (!source || source.includes(statement)) return false;
+  vfs.writeFile(path, `${statement}\n${source}`);
+  return true;
+}
+
+function insertBeforeLast(source: string, marker: string, content: string) {
+  const index = source.lastIndexOf(marker);
+  if (index === -1) return source;
+  return `${source.slice(0, index)}${content}${source.slice(index)}`;
+}
+
+function mountReactAnalytics(vfs: VirtualFileSystem, frontend: string) {
+  const path =
+    frontend === "next" || frontend === "vinext"
+      ? "apps/web/src/app/layout.tsx"
+      : frontend === "react-router"
+        ? "apps/web/src/root.tsx"
+        : frontend === "react-vite"
+          ? "apps/web/src/app-shell.tsx"
+          : "apps/web/src/routes/__root.tsx";
+  const source = vfs.readFile(path);
+  if (!source || source.includes("<Analytics />")) return;
+
+  let next = `import { Analytics } from "@/lib/vercel-analytics";\n${source}`;
+  if (
+    frontend === "next" ||
+    frontend === "vinext" ||
+    frontend === "react-router" ||
+    frontend === "tanstack-start"
+  ) {
+    next = insertBeforeLast(next, "</body>", "        <Analytics />\n      ");
+  } else if (frontend === "react-vite") {
+    next = next.replace(
+      "      <Toaster richColors />",
+      "      <Toaster richColors />\n      <Analytics />",
+    );
+  } else {
+    next = insertBeforeLast(next, "</>", "      <Analytics />\n    ");
+  }
+  vfs.writeFile(path, next);
+}
+
+function mountVueAnalytics(vfs: VirtualFileSystem, frontend: string) {
+  const path = frontend === "nuxt" ? "apps/web/app/app.vue" : "apps/web/src/App.vue";
+  const source = vfs.readFile(path);
+  if (!source || source.includes("<Analytics />")) return;
+  const importStatement = 'import { Analytics } from "./lib/vercel-analytics";';
+  const withImport = source.includes('<script setup lang="ts">')
+    ? source.replace('<script setup lang="ts">', `<script setup lang="ts">\n${importStatement}`)
+    : `<script setup lang="ts">\n${importStatement}\n</script>\n\n${source}`;
+  vfs.writeFile(path, withImport.replace("<template>", "<template>\n  <Analytics />"));
+}
+
+function mountVercelAnalytics(vfs: VirtualFileSystem, frontend: string) {
+  if (REACT_FRONTENDS.has(frontend)) {
+    mountReactAnalytics(vfs, frontend);
+    return;
+  }
+  if (VUE_FRONTENDS.has(frontend) || NUXT_FRONTENDS.has(frontend)) {
+    mountVueAnalytics(vfs, frontend);
+    return;
+  }
+  if (SVELTE_FRONTENDS.has(frontend)) {
+    const path = "apps/web/src/routes/+layout.svelte";
+    const source = vfs.readFile(path);
+    if (source && !source.includes("$lib/vercel-analytics")) {
+      vfs.writeFile(
+        path,
+        source.replace(
+          '<script lang="ts">',
+          '<script lang="ts">\n\timport "$lib/vercel-analytics";',
+        ),
+      );
+    }
+    return;
+  }
+  if (SOLID_FRONTENDS.has(frontend)) {
+    const path =
+      frontend === "solid-start" ? "apps/web/src/app.tsx" : "apps/web/src/routes/__root.tsx";
+    if (
+      prependImport(vfs, path, 'import { startVercelAnalytics } from "@/lib/vercel-analytics";')
+    ) {
+      const source = vfs.readFile(path) ?? "";
+      const marker =
+        frontend === "solid-start"
+          ? "export default function App() {"
+          : "function RootComponent() {";
+      vfs.writeFile(path, source.replace(marker, `${marker}\n  startVercelAnalytics();`));
+    }
+    return;
+  }
+  if (ASTRO_FRONTENDS.has(frontend)) {
+    const path = "apps/web/src/layouts/Layout.astro";
+    const source = vfs.readFile(path);
+    if (!source || source.includes("<VercelAnalytics />")) return;
+    const withImport = source.replace(
+      "import Header from '@/components/Header.astro';",
+      "import Header from '@/components/Header.astro';\nimport VercelAnalytics from '@/components/vercel-analytics.astro';",
+    );
+    vfs.writeFile(path, insertBeforeLast(withImport, "</body>", "\t\t<VercelAnalytics />\n\t"));
+  }
 }
 
 export async function processAnalyticsTemplates(
@@ -50,11 +159,22 @@ export async function processAnalyticsTemplates(
   const variant = getAnalyticsTemplateVariant(config.frontend);
   if (!variant) return;
 
+  const targetPath =
+    config.analytics === "vercel-analytics" && config.frontend.includes("nuxt")
+      ? "apps/web/app"
+      : "apps/web";
   processTemplatesFromPrefix(
     vfs,
     templates,
     `analytics/${config.analytics}/web/${variant}`,
-    "apps/web",
+    targetPath,
     config,
   );
+
+  if (config.analytics === "vercel-analytics") {
+    const frontend = config.frontend.find(
+      (entry) => entry !== "none" && !entry.startsWith("native-"),
+    );
+    if (frontend) mountVercelAnalytics(vfs, frontend);
+  }
 }

--- a/packages/template-generator/src/utils/add-deps.ts
+++ b/packages/template-generator/src/utils/add-deps.ts
@@ -898,6 +898,9 @@ export const dependencyVersionMap = {
 
   // Analytics - Plausible
   "plausible-tracker": "^0.3.9",
+
+  // Analytics - Vercel
+  "@vercel/analytics": "^2.0.1",
 } as const;
 
 export type AvailableDependencies = keyof typeof dependencyVersionMap;

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/astro/src/components/vercel-analytics.astro.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/astro/src/components/vercel-analytics.astro.hbs
@@ -1,0 +1,5 @@
+---
+import Analytics from "@vercel/analytics/astro";
+---
+
+<Analytics />

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/nuxt/lib/vercel-analytics.ts.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/nuxt/lib/vercel-analytics.ts.hbs
@@ -1,0 +1,1 @@
+export { Analytics } from "@vercel/analytics/nuxt";

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/react/src/lib/vercel-analytics.tsx.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/react/src/lib/vercel-analytics.tsx.hbs
@@ -1,0 +1,5 @@
+{{#if (eq frontend.[0] "next")}}
+export { Analytics } from "@vercel/analytics/next";
+{{else}}
+export { Analytics } from "@vercel/analytics/react";
+{{/if}}

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/react/src/lib/vercel-analytics.tsx.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/react/src/lib/vercel-analytics.tsx.hbs
@@ -1,4 +1,4 @@
-{{#if (eq frontend.[0] "next")}}
+{{#if (includes frontend "next")}}
 export { Analytics } from "@vercel/analytics/next";
 {{else}}
 export { Analytics } from "@vercel/analytics/react";

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/solid/src/lib/vercel-analytics.ts.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/solid/src/lib/vercel-analytics.ts.hbs
@@ -1,0 +1,9 @@
+import { inject } from "@vercel/analytics";
+
+let started = false;
+
+export function startVercelAnalytics() {
+  if (started || typeof window === "undefined") return;
+  inject();
+  started = true;
+}

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/svelte/src/lib/vercel-analytics.ts.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/svelte/src/lib/vercel-analytics.ts.hbs
@@ -1,0 +1,3 @@
+import { injectAnalytics } from "@vercel/analytics/sveltekit";
+
+injectAnalytics();

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/svelte/src/lib/vercel-analytics.ts.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/svelte/src/lib/vercel-analytics.ts.hbs
@@ -1,3 +1,5 @@
 import { injectAnalytics } from "@vercel/analytics/sveltekit";
 
-injectAnalytics();
+export function startVercelAnalytics() {
+  injectAnalytics();
+}

--- a/packages/template-generator/templates/analytics/vercel-analytics/web/vue/src/lib/vercel-analytics.ts.hbs
+++ b/packages/template-generator/templates/analytics/vercel-analytics/web/vue/src/lib/vercel-analytics.ts.hbs
@@ -1,0 +1,1 @@
+export { Analytics } from "@vercel/analytics/vue";

--- a/packages/template-generator/test/preflight-analytics.test.ts
+++ b/packages/template-generator/test/preflight-analytics.test.ts
@@ -1,0 +1,36 @@
+import type { Analytics, Frontend } from "@better-fullstack/types";
+
+import { describe, expect, it } from "bun:test";
+
+import { validatePreflightConfig } from "../src/preflight-validation";
+import { makeConfig } from "./_fixtures/config-factory";
+
+function analyticsWarning(frontend: Frontend, analytics: Analytics) {
+	const result = validatePreflightConfig(
+		makeConfig({
+			frontend: [frontend],
+			backend: "hono",
+			runtime: "bun",
+			database: "none",
+			orm: "none",
+			api: "none",
+			auth: "none",
+			analytics,
+		}),
+	);
+	return result.warnings.find((warning) => warning.ruleId === "analytics-no-frontend");
+}
+
+describe("analytics preflight", () => {
+	it("warns when the provider has no template for the chosen frontend", () => {
+		expect(analyticsWarning("vue", "plausible")).toBeDefined();
+		expect(analyticsWarning("astro", "posthog")).toBeDefined();
+		expect(analyticsWarning("astro", "umami")).toBeDefined();
+	});
+
+	it("stays quiet for provider-supported frontends", () => {
+		expect(analyticsWarning("vue", "posthog")).toBeUndefined();
+		expect(analyticsWarning("astro", "vercel-analytics")).toBeUndefined();
+		expect(analyticsWarning("vue", "ga4")).toBeUndefined();
+	});
+});

--- a/packages/template-generator/test/vercel-analytics.test.ts
+++ b/packages/template-generator/test/vercel-analytics.test.ts
@@ -1,0 +1,91 @@
+import type { Frontend } from "@better-fullstack/types";
+
+import { describe, expect, it } from "bun:test";
+
+import type { VirtualFile, VirtualNode } from "../src/types";
+
+import { generateVirtualProject } from "../src/generator";
+import { EMBEDDED_TEMPLATES } from "../src/templates.generated";
+import { makeConfig } from "./_fixtures/config-factory";
+
+function files(node: VirtualNode): VirtualFile[] {
+  return node.type === "file" ? [node] : node.children.flatMap(files);
+}
+
+async function generate(frontend: Frontend, overrides: Parameters<typeof makeConfig>[0] = {}) {
+  const selfFrontend = [
+    "next",
+    "vinext",
+    "tanstack-start",
+    "svelte",
+    "nuxt",
+    "solid-start",
+  ].includes(frontend);
+  const result = await generateVirtualProject({
+    config: makeConfig({
+      frontend: [frontend],
+      backend: selfFrontend ? "self" : "hono",
+      runtime: selfFrontend ? "none" : "bun",
+      database: "none",
+      orm: "none",
+      api: "none",
+      auth: "none",
+      analytics: "vercel-analytics",
+      ...overrides,
+    }),
+    templates: EMBEDDED_TEMPLATES,
+  });
+  expect(result.success).toBe(true);
+  return new Map(files(result.tree!.root).map((file) => [file.path, file.content]));
+}
+
+describe("Vercel Analytics generation", () => {
+  it("mounts the Next.js component and adds the current package without env vars", async () => {
+    const output = await generate("next");
+
+    expect(output.get("apps/web/package.json")).toContain('"@vercel/analytics": "^2.0.1"');
+    expect(output.get("apps/web/src/lib/vercel-analytics.tsx")).toContain(
+      'from "@vercel/analytics/next"',
+    );
+    expect(output.get("apps/web/src/app/layout.tsx")).toContain("<Analytics />");
+    expect(output.get("apps/web/.env") ?? "").not.toContain("VERCEL_ANALYTICS");
+  });
+
+  it.each([
+    ["vinext", "apps/web/src/app/layout.tsx", "<Analytics />"],
+    ["react-router", "apps/web/src/root.tsx", "<Analytics />"],
+    ["react-vite", "apps/web/src/app-shell.tsx", "<Analytics />"],
+    ["tanstack-router", "apps/web/src/routes/__root.tsx", "<Analytics />"],
+    ["tanstack-start", "apps/web/src/routes/__root.tsx", "<Analytics />"],
+    ["svelte", "apps/web/src/routes/+layout.svelte", "$lib/vercel-analytics"],
+    ["vue", "apps/web/src/App.vue", "<Analytics />"],
+    ["nuxt", "apps/web/app/app.vue", "<Analytics />"],
+    ["solid", "apps/web/src/routes/__root.tsx", "startVercelAnalytics()"],
+    ["solid-start", "apps/web/src/app.tsx", "startVercelAnalytics()"],
+    ["astro", "apps/web/src/layouts/Layout.astro", "<VercelAnalytics />"],
+  ] as const)(
+    "mounts the framework-specific integration for %s",
+    async (frontend, path, marker) => {
+      const output = await generate(frontend);
+      expect(output.get(path)).toContain(marker);
+    },
+  );
+
+  it("retains the mounted component and dependency in single-app output", async () => {
+    const output = await generate("next", { workspaceShape: "single-app" });
+
+    expect(output.get("package.json")).toContain('"@vercel/analytics": "^2.0.1"');
+    expect(output.get("src/app/layout.tsx")).toContain("<Analytics />");
+    expect(output.get("src/lib/vercel-analytics.tsx")).toContain("@vercel/analytics/next");
+  });
+
+  it("does not broaden single-app support to analytics integrations with workspace assumptions", async () => {
+    const output = await generate("next", {
+      analytics: "plausible",
+      workspaceShape: "single-app",
+    });
+
+    expect(output.has("apps/web/package.json")).toBe(true);
+    expect(output.has("src/app/layout.tsx")).toBe(false);
+  });
+});

--- a/packages/template-generator/test/vercel-analytics.test.ts
+++ b/packages/template-generator/test/vercel-analytics.test.ts
@@ -68,8 +68,49 @@ describe("Vercel Analytics generation", () => {
     async (frontend, path, marker) => {
       const output = await generate(frontend);
       expect(output.get(path)).toContain(marker);
+      if (frontend === "svelte") {
+        expect(output.get("apps/web/src/lib/vercel-analytics.ts")).not.toContain(
+          "\ninjectAnalytics();",
+        );
+        expect(output.get(path)).toContain("startVercelAnalytics();");
+      }
     },
   );
+
+  it("rejects unsupported frontends before installing an unused package", async () => {
+    const result = await generateVirtualProject({
+      config: makeConfig({
+        frontend: ["angular"],
+        backend: "self",
+        runtime: "none",
+        analytics: "vercel-analytics",
+      }),
+      templates: EMBEDDED_TEMPLATES,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not yet mounted");
+  });
+
+  for (const analytics of ["posthog", "umami"] as const) {
+    it(`keeps the ${analytics} Vue helper for Nuxt`, async () => {
+      const result = await generateVirtualProject({
+        config: makeConfig({
+          frontend: ["nuxt"],
+          backend: "self",
+          runtime: "none",
+          analytics,
+        }),
+        templates: EMBEDDED_TEMPLATES,
+      });
+
+      expect(result.success).toBe(true);
+      const output = new Map(files(result.tree!.root).map((file) => [file.path, file.content]));
+      expect(output.has(`apps/web/src/lib/${analytics === "posthog" ? "posthog" : "umami"}.ts`)).toBe(
+        true,
+      );
+    });
+  }
 
   it("retains the mounted component and dependency in single-app output", async () => {
     const output = await generate("next", { workspaceShape: "single-app" });

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -55,6 +55,20 @@ const SIGNOZ_SUPPORTED_GO_WEB_FRAMEWORKS = new Set([
   "stdlib",
 ]);
 const SIGNOZ_SUPPORTED_PYTHON_WEB_FRAMEWORKS = new Set(["fastapi"]);
+const VERCEL_ANALYTICS_FRONTENDS = new Set([
+  "next",
+  "vinext",
+  "tanstack-router",
+  "tanstack-start",
+  "react-router",
+  "react-vite",
+  "svelte",
+  "nuxt",
+  "vue",
+  "solid",
+  "solid-start",
+  "astro",
+]);
 
 export function isSignozSupportedGoWebFramework(framework: string): boolean {
   return SIGNOZ_SUPPORTED_GO_WEB_FRAMEWORKS.has(framework);
@@ -475,6 +489,7 @@ export function stackQualifiesForSingleApp(stack: CompatibilityInput): boolean {
   const webFrontends = (stack.webFrontend ?? []).filter((f) => f && f !== "none");
   if (webFrontends.length !== 1) return false;
   if (webFrontends[0] !== SINGLE_APP_WEB_FRONTEND_BY_BACKEND[stack.backend]) return false;
+  if (stack.analytics !== "none" && stack.analytics !== "vercel-analytics") return false;
 
   const siblingPackageScalars = [
     stack.api,
@@ -494,7 +509,6 @@ export function stackQualifiesForSingleApp(stack: CompatibilityInput): boolean {
     stack.fileStorage,
     stack.cms,
     stack.aiSdk,
-    stack.analytics,
     stack.featureFlags,
     stack.integrations,
     stack.ecommerce,
@@ -2340,6 +2354,18 @@ export const analyzeStackCompatibility = (
     });
   }
 
+  if (
+    nextStack.analytics === "vercel-analytics" &&
+    !nextStack.webFrontend.some((frontend) => VERCEL_ANALYTICS_FRONTENDS.has(frontend))
+  ) {
+    nextStack.analytics = "none";
+    changed = true;
+    changes.push({
+      category: "analytics",
+      message: "Analytics set to 'None' (Vercel Analytics is not mounted for this frontend)",
+    });
+  }
+
   // Workspace shape: single-app (flat) only applies to a qualifying thin self
   // app; normalize back to monorepo for anything else so we never emit a broken
   // flat layout.
@@ -2777,6 +2803,22 @@ export const getDisabledReason = (
     FULLSTACK_SELF_BACKENDS.has(currentStack.backend)
   ) {
     return "Nango's Node SDK is not available on Cloudflare Workers";
+  }
+
+  if (category === "analytics" && optionId === "vercel-analytics") {
+    const webFrontends = currentStack.webFrontend.filter((frontend) => frontend !== "none");
+    if (webFrontends.length === 0) return "Vercel Analytics requires a web frontend";
+    if (webFrontends.some((frontend) => !VERCEL_ANALYTICS_FRONTENDS.has(frontend))) {
+      return "Vercel Analytics is not yet mounted for the selected frontend";
+    }
+  }
+  if (
+    category === "webFrontend" &&
+    currentStack.analytics === "vercel-analytics" &&
+    optionId !== "none" &&
+    !VERCEL_ANALYTICS_FRONTENDS.has(optionId)
+  ) {
+    return "The selected frontend does not yet mount Vercel Analytics";
   }
 
   const graphDisabledReason =

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -70,6 +70,10 @@ const VERCEL_ANALYTICS_FRONTENDS = new Set([
   "astro",
 ]);
 
+export function isVercelAnalyticsFrontend(frontend: string) {
+  return VERCEL_ANALYTICS_FRONTENDS.has(frontend);
+}
+
 export function isSignozSupportedGoWebFramework(framework: string): boolean {
   return SIGNOZ_SUPPORTED_GO_WEB_FRAMEWORKS.has(framework);
 }
@@ -2356,7 +2360,7 @@ export const analyzeStackCompatibility = (
 
   if (
     nextStack.analytics === "vercel-analytics" &&
-    !nextStack.webFrontend.some((frontend) => VERCEL_ANALYTICS_FRONTENDS.has(frontend))
+    !nextStack.webFrontend.some((frontend) => isVercelAnalyticsFrontend(frontend))
   ) {
     nextStack.analytics = "none";
     changed = true;
@@ -2808,7 +2812,7 @@ export const getDisabledReason = (
   if (category === "analytics" && optionId === "vercel-analytics") {
     const webFrontends = currentStack.webFrontend.filter((frontend) => frontend !== "none");
     if (webFrontends.length === 0) return "Vercel Analytics requires a web frontend";
-    if (webFrontends.some((frontend) => !VERCEL_ANALYTICS_FRONTENDS.has(frontend))) {
+    if (webFrontends.some((frontend) => !isVercelAnalyticsFrontend(frontend))) {
       return "Vercel Analytics is not yet mounted for the selected frontend";
     }
   }
@@ -2816,7 +2820,7 @@ export const getDisabledReason = (
     category === "webFrontend" &&
     currentStack.analytics === "vercel-analytics" &&
     optionId !== "none" &&
-    !VERCEL_ANALYTICS_FRONTENDS.has(optionId)
+    !isVercelAnalyticsFrontend(optionId)
   ) {
     return "The selected frontend does not yet mount Vercel Analytics";
   }

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -1234,6 +1234,7 @@ const EXACT_LABEL_OVERRIDES: Partial<Record<OptionCategory, Partial<Record<strin
     plausible: "Plausible",
     umami: "Umami",
     ga4: "Google Analytics 4",
+    "vercel-analytics": "Vercel Analytics",
   },
   mobileNavigation: {
     "expo-router": "Expo Router",

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -441,7 +441,7 @@ export const IntegrationsSchema = z
 export const EcommerceSchema = z.enum(["medusa", "none"]).describe("E-commerce platform SDK");
 
 export const AnalyticsSchema = z
-  .enum(["plausible", "umami", "posthog", "ga4", "none"])
+  .enum(["plausible", "umami", "posthog", "ga4", "vercel-analytics", "none"])
   .describe("Product analytics provider");
 
 export const MobileNavigationSchema = z

--- a/packages/types/test/compatibility.test.ts
+++ b/packages/types/test/compatibility.test.ts
@@ -12,6 +12,33 @@ import {
 import { DEFAULT_STACK_SELECTION } from "../src/stack-translation";
 
 describe("compatibility issue helpers", () => {
+  it("offers Vercel Analytics only where its generated mount is wired", () => {
+    expect(
+      getDisabledReason(
+        { ...DEFAULT_STACK_SELECTION, webFrontend: ["next"] },
+        "analytics",
+        "vercel-analytics",
+      ),
+    ).toBeNull();
+    expect(
+      getDisabledReason(
+        { ...DEFAULT_STACK_SELECTION, webFrontend: ["vanilla-vite"] },
+        "analytics",
+        "vercel-analytics",
+      ),
+    ).toContain("not yet mounted");
+
+    const unsupported = {
+      ...DEFAULT_STACK_SELECTION,
+      webFrontend: ["vanilla-vite" as const],
+      analytics: "vercel-analytics" as const,
+    };
+    expect(getDisabledReason(unsupported, "webFrontend", "qwik")).toContain(
+      "does not yet mount",
+    );
+    expect(analyzeStackCompatibility(unsupported).adjustedStack?.analytics).toBe("none");
+  });
+
   it("keeps SigNoz off stacks without a generated server target", () => {
     for (const backend of ["none", "convex"] as const) {
       const stack = {

--- a/packages/types/test/stack-translation.test.ts
+++ b/packages/types/test/stack-translation.test.ts
@@ -615,7 +615,7 @@ describe("stack selection translation", () => {
       animation: "framer-motion",
       fileUpload: "uploadthing",
       i18n: "i18next",
-      analytics: "plausible",
+      analytics: "vercel-analytics",
     });
 
     expect(command).toContain("--part frontend:typescript:next");
@@ -626,7 +626,7 @@ describe("stack selection translation", () => {
     expect(command).toContain("--part frontend.animation:typescript:framer-motion");
     expect(command).toContain("--part frontend.fileUpload:typescript:uploadthing");
     expect(command).toContain("--part frontend.i18n:typescript:i18next");
-    expect(command).toContain("--part frontend.analytics:typescript:plausible");
+    expect(command).toContain("--part frontend.analytics:typescript:vercel-analytics");
     expect(command).not.toContain("--css-framework scss");
     expect(command).not.toContain("--ui-library radix-ui");
     expect(command).not.toContain("--forms formik");
@@ -634,7 +634,7 @@ describe("stack selection translation", () => {
     expect(command).not.toContain("--animation framer-motion");
     expect(command).not.toContain("--file-upload uploadthing");
     expect(command).not.toContain("--i18n i18next");
-    expect(command).not.toContain("--analytics plausible");
+    expect(command).not.toContain("--analytics vercel-analytics");
   });
 
   it("emits changed graph infrastructure as scoped graph parts", () => {


### PR DESCRIPTION
## Summary
- add Vercel Analytics to the shared schema, option metadata, visual builder, CLI prompt flow, and multi-ecosystem graph composition
- install and mount `@vercel/analytics` for supported React, SvelteKit, Vue, Nuxt, Solid, and Astro outputs, including eligible single-app projects
- add bidirectional compatibility guards, generated README setup guidance, and focused schema/generation coverage

## Validation
- 99 focused generator, compatibility, graph, CLI prompt, schema coverage, and generated-command tests pass
- CLI and template-generator TypeScript checks pass
- targeted Oxlint passes (four unrelated pre-existing `prefer-set-has` warnings in compatibility.ts)
- all generated TypeScript/TSX variants parse successfully
- release lane passed its completed stages, including lifecycle tests, before the sandbox blocked registry.npmjs.org
- web typecheck could not complete because the sandbox blocked cdn.jsdelivr.net during i18n compilation

Closes #387