### PR TITLE
Make the Vite+ toolchain's quality commands work in generated projects

### DIFF
--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -50,7 +50,21 @@ const VITE_PLUS_PACKAGE_SCRIPTS = {
 
 // `vp fmt` reads .gitignore and .prettierignore from its own working directory, and
 // the per-workspace scripts above run it inside each package.
-const VITE_PLUS_FORMAT_IGNORE = ["dist", ".output", ".vercel", ".nitro", "*.gen.ts"].join("\n");
+const VITE_PLUS_FORMAT_IGNORE = [
+  "dist",
+  "build",
+  "out",
+  ".next",
+  ".nuxt",
+  ".output",
+  ".vercel",
+  ".nitro",
+  ".svelte-kit",
+  ".astro",
+  ".expo",
+  ".turbo",
+  "*.gen.ts",
+].join("\n");
 
 // processPackageConfigs runs more than once over the same root package.json.
 function withVitePlusPrepare(existing: string | undefined): string {
@@ -289,7 +303,8 @@ function applyVitePlusWorkspaceScripts(vfs: VirtualFileSystem, config: ProjectCo
   for (const filePath of vfs.getAllFiles()) {
     if (filePath === "package.json" || !filePath.endsWith("/package.json")) continue;
     const pkgJson = vfs.readJson<PackageJson>(filePath);
-    if (!pkgJson?.scripts) continue;
+    if (!pkgJson) continue;
+    pkgJson.scripts ??= {};
 
     for (const [name, script] of Object.entries(pkgJson.scripts)) {
       // `vp` is not a node entrypoint, so scripts that boot the aliased vite bin

--- a/packages/template-generator/src/post-process/package-configs.ts
+++ b/packages/template-generator/src/post-process/package-configs.ts
@@ -7,6 +7,7 @@ import type { ProjectConfig } from "@better-fullstack/types";
 
 import type { VirtualFileSystem } from "../core/virtual-fs";
 
+import { dependencyVersionMap } from "../utils/add-deps";
 import { getGraphBackendConnection, getGraphBackendConnections } from "../utils/graph-backend";
 import { getServerPackagePath } from "../utils/project-paths";
 
@@ -36,6 +37,27 @@ type PackageManagerConfig = {
 type WorkspaceTool = "turbo" | "nx" | "vite-plus" | null;
 
 const VITE_PLUS_BUNDLED_VITEST_VERSION = "4.1.10";
+
+const VITE_PLUS_PREPARE_COMMAND = "vp config --no-agent --hooks-dir .vite-hooks";
+
+// vp resolves each package's vite config from the process cwd, so the root scripts
+// must delegate per workspace instead of linting the whole tree in one pass.
+const VITE_PLUS_PACKAGE_SCRIPTS = {
+  lint: "vp lint --no-error-on-unmatched-pattern",
+  format: "vp fmt",
+  check: "vp check --no-error-on-unmatched-pattern",
+};
+
+// `vp fmt` reads .gitignore and .prettierignore from its own working directory, and
+// the per-workspace scripts above run it inside each package.
+const VITE_PLUS_FORMAT_IGNORE = ["dist", ".output", ".vercel", ".nitro", "*.gen.ts"].join("\n");
+
+// processPackageConfigs runs more than once over the same root package.json.
+function withVitePlusPrepare(existing: string | undefined): string {
+  if (!existing) return VITE_PLUS_PREPARE_COMMAND;
+  if (existing.includes(VITE_PLUS_PREPARE_COMMAND)) return existing;
+  return `${existing} && ${VITE_PLUS_PREPARE_COMMAND}`;
+}
 
 const VIRTUAL_PACKAGE_MANAGER_VERSIONS: Record<ProjectConfig["packageManager"], string> = {
   npm: "10.9.2",
@@ -206,13 +228,11 @@ function updateRootPackageJson(vfs: VirtualFileSystem, config: ProjectConfig): v
   applyGeneratedPackageTestScripts(vfs, config);
   const testCommands = getWorkspaceTestCommands(vfs, packageManager);
   if (workspaceTool === "vite-plus") {
-    scripts.check = "vp check";
-    scripts.lint = "vp lint";
-    scripts.format = "vp fmt";
+    scripts.check = "vp run -r check";
+    scripts.lint = "vp run -r lint";
+    scripts.format = "vp run -r format";
     scripts.test = "vp run -r test";
-    scripts.prepare = scripts.prepare
-      ? `${scripts.prepare} && vp config --no-agent --hooks-dir .vite-hooks`
-      : "vp config --no-agent --hooks-dir .vite-hooks";
+    scripts.prepare = withVitePlusPrepare(scripts.prepare);
   } else if (testCommands.length > 0) {
     scripts.test = testCommands.join(" && ");
   } else {
@@ -271,29 +291,28 @@ function applyVitePlusWorkspaceScripts(vfs: VirtualFileSystem, config: ProjectCo
     const pkgJson = vfs.readJson<PackageJson>(filePath);
     if (!pkgJson?.scripts) continue;
 
-    let changed = false;
     for (const [name, script] of Object.entries(pkgJson.scripts)) {
       // `vp` is not a node entrypoint, so scripts that boot the aliased vite bin
       // under the node inspector have no Vite+ equivalent.
       if (script.includes("node_modules/vite/bin/vite.js")) {
         delete pkgJson.scripts[name];
-        changed = true;
         continue;
       }
-      const rewritten = script.split("&&").map(rewriteSegment).join("&&");
-      if (rewritten !== script) {
-        pkgJson.scripts[name] = rewritten;
-        changed = true;
-      }
+      pkgJson.scripts[name] = script.split("&&").map(rewriteSegment).join("&&");
     }
-    if (changed) vfs.writeJson(filePath, pkgJson);
+
+    Object.assign(pkgJson.scripts, VITE_PLUS_PACKAGE_SCRIPTS);
+    vfs.writeJson(filePath, pkgJson);
+
+    const ignorePath = filePath.replace(/package\.json$/, ".prettierignore");
+    if (!vfs.fileExists(ignorePath)) vfs.writeFile(ignorePath, `${VITE_PLUS_FORMAT_IGNORE}\n`);
   }
 }
 
 function applyVitePlusOverrides(pkgJson: PackageJson, config: ProjectConfig): void {
   if (!config.addons.includes("vite-plus")) return;
   const overrides = {
-    vite: "npm:@voidzero-dev/vite-plus-core@^0.2.9",
+    vite: `npm:@voidzero-dev/vite-plus-core@${dependencyVersionMap["@voidzero-dev/vite-plus-core"]}`,
     vitest: VITE_PLUS_BUNDLED_VITEST_VERSION,
     "@vitest/ui": VITE_PLUS_BUNDLED_VITEST_VERSION,
     "@vitest/coverage-v8": VITE_PLUS_BUNDLED_VITEST_VERSION,

--- a/packages/template-generator/templates/addons/vite-plus/.vite-hooks/pre-commit.hbs
+++ b/packages/template-generator/templates/addons/vite-plus/.vite-hooks/pre-commit.hbs
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-vp check
+vpr check

--- a/packages/template-generator/test/generator-output-cleanliness.test.ts
+++ b/packages/template-generator/test/generator-output-cleanliness.test.ts
@@ -5,6 +5,7 @@ import type { VirtualFile, VirtualNode } from "../src/types";
 
 import { generateVirtualProject } from "../src/generator";
 import { EMBEDDED_TEMPLATES } from "../src/templates.generated";
+import { dependencyVersionMap } from "../src/utils/add-deps";
 import { makeConfig } from "./_fixtures/config-factory";
 
 function listFiles(node: VirtualNode): VirtualFile[] {
@@ -268,21 +269,29 @@ describe("generated output cleanliness", () => {
       overrides?: Record<string, string>;
     };
     expect(rootPackage.scripts).toMatchObject({
-      check: "vp check",
-      lint: "vp lint",
-      format: "vp fmt",
+      check: "vp run -r check",
+      lint: "vp run -r lint",
+      format: "vp run -r format",
       test: "vp run -r test",
       prepare: "vp config --no-agent --hooks-dir .vite-hooks",
     });
     expect(rootPackage.devDependencies).toMatchObject({
-      "vite-plus": "^0.2.9",
-      "@voidzero-dev/vite-plus-core": "^0.2.9",
+      "vite-plus": dependencyVersionMap["vite-plus"],
+      "@voidzero-dev/vite-plus-core": dependencyVersionMap["@voidzero-dev/vite-plus-core"],
     });
     expect(rootPackage.overrides).toMatchObject({
-      vite: "npm:@voidzero-dev/vite-plus-core@^0.2.9",
+      vite: `npm:@voidzero-dev/vite-plus-core@${dependencyVersionMap["@voidzero-dev/vite-plus-core"]}`,
       vitest: "4.1.10",
     });
-    expect(getFile(".vite-hooks/pre-commit")).toContain("vp check");
+    const webPackage = JSON.parse(getFile("apps/web/package.json") ?? "{}") as {
+      scripts?: Record<string, string>;
+    };
+    expect(webPackage.scripts).toMatchObject({
+      lint: "vp lint --no-error-on-unmatched-pattern",
+      format: "vp fmt",
+      check: "vp check --no-error-on-unmatched-pattern",
+    });
+    expect(getFile(".vite-hooks/pre-commit")).toContain("vpr check");
     expect(getFile(".gitignore")).toContain(".vite-hooks/_");
     const workflow = getFile(".github/workflows/ci.yml") ?? "";
     expect(workflow).toContain("voidzero-dev/setup-vp@v1.17.0");

--- a/packages/template-generator/test/post-process/package-configs.test.ts
+++ b/packages/template-generator/test/post-process/package-configs.test.ts
@@ -2,6 +2,7 @@ import { cliInputToProjectConfigPartial, parseStackPartSpecs } from "@better-ful
 import { describe, expect, it } from "bun:test";
 
 import { processPackageConfigs } from "../../src/post-process/package-configs";
+import { dependencyVersionMap } from "../../src/utils/add-deps";
 import { makeConfig } from "../_fixtures/config-factory";
 import { createSeededVFS } from "../_fixtures/vfs-factory";
 
@@ -175,16 +176,36 @@ describe("processPackageConfigs", () => {
       "dev:native": "vp run --fail-if-no-match --filter native dev",
       "dev:server": "cd apps/server && go run cmd/server/main.go",
       "db:push": "vp run --fail-if-no-match --filter @vite-plus-demo/db db:push",
-      check: "vp check",
-      lint: "vp lint",
-      format: "vp fmt",
+      check: "vp run -r check",
+      lint: "vp run -r lint",
+      format: "vp run -r format",
       test: "vp run -r test",
       prepare: "vp config --no-agent --hooks-dir .vite-hooks",
     });
     expect(vfs.readJson<PackageJson>("package.json")?.overrides).toMatchObject({
-      vite: "npm:@voidzero-dev/vite-plus-core@^0.2.9",
+      vite: `npm:@voidzero-dev/vite-plus-core@${dependencyVersionMap["@voidzero-dev/vite-plus-core"]}`,
       vitest: "4.1.10",
     });
+  });
+
+  it("keeps the Vite+ prepare hook single when processed more than once", () => {
+    const vfs = createSeededVFS();
+    vfs.writeJson("package.json", { name: "starter", scripts: {}, workspaces: [] });
+    const config = makeConfig({
+      projectName: "vite-plus-demo",
+      addons: ["vite-plus"],
+      stackParts: parseStackPartSpecs([
+        "frontend:typescript:next",
+        "toolchain:universal:vite-plus",
+      ]),
+    });
+
+    processPackageConfigs(vfs, config);
+    processPackageConfigs(vfs, config);
+
+    expect(vfs.readJson<PackageJson>("package.json")?.scripts?.prepare).toBe(
+      "vp config --no-agent --hooks-dir .vite-hooks",
+    );
   });
 
   it("rewrites workspace vite scripts to vp because the override ships no vite binary", () => {

--- a/packages/template-generator/test/post-process/package-configs.test.ts
+++ b/packages/template-generator/test/post-process/package-configs.test.ts
@@ -208,6 +208,30 @@ describe("processPackageConfigs", () => {
     );
   });
 
+  it("gives Vite+ quality scripts to workspaces that ship no scripts field", () => {
+    const vfs = createSeededVFS();
+    vfs.writeJson("package.json", { name: "starter", scripts: {}, workspaces: [] });
+    vfs.writeJson("packages/env/package.json", { name: "env" });
+
+    processPackageConfigs(
+      vfs,
+      makeConfig({
+        projectName: "vite-plus-demo",
+        addons: ["vite-plus"],
+        stackParts: parseStackPartSpecs([
+          "frontend:typescript:next",
+          "toolchain:universal:vite-plus",
+        ]),
+      }),
+    );
+
+    expect(vfs.readJson<PackageJson>("packages/env/package.json")?.scripts).toMatchObject({
+      lint: "vp lint --no-error-on-unmatched-pattern",
+      format: "vp fmt",
+      check: "vp check --no-error-on-unmatched-pattern",
+    });
+  });
+
   it("rewrites workspace vite scripts to vp because the override ships no vite binary", () => {
     const vfs = createSeededVFS();
     vfs.writeJson("package.json", { name: "starter", scripts: {}, workspaces: [] });

--- a/testing/lib/presets.test.ts
+++ b/testing/lib/presets.test.ts
@@ -48,6 +48,7 @@ const PR_BROAD_PRESET_NAMES = [
   "preset-angular-fets",
   "preset-vinext-minimal",
   "preset-vinext-basic",
+  "preset-vite-plus-toolchain",
 ];
 
 describe("preset groups", () => {

--- a/testing/lib/presets.ts
+++ b/testing/lib/presets.ts
@@ -444,6 +444,19 @@ const SMOKE_TEST_PRESETS: Record<string, PresetDef> = {
     },
   },
 
+  "vite-plus-toolchain": {
+    ecosystem: "typescript",
+    overrides: {
+      frontend: ["tanstack-start"],
+      backend: "self",
+      runtime: "none",
+      api: "orpc",
+      cssFramework: "tailwind",
+      webDeploy: "vercel",
+      addons: ["vite-plus"],
+    },
+  },
+
   "version-channel-latest": {
     ecosystem: "typescript",
     overrides: {
@@ -1045,6 +1058,7 @@ const PRESET_GROUPS = {
     "angular-fets",
     "vinext-minimal",
     "vinext-basic",
+    "vite-plus-toolchain",
   ],
 } as const satisfies Record<Exclude<PresetGroupId, "all">, readonly string[]>;
 


### PR DESCRIPTION
Every project scaffolded with the Vite+ toolchain shipped a broken quality gate. `bun run lint`, `format`, and `check` all crashed at the workspace root, and the generated pre-commit hook crashed with them, so the linting and formatting the option exists to provide never ran.

The cause is that `vp` resolves each package's Vite config relative to the process working directory. Invoked from the root, oxlint loads `apps/web/vite.config.ts`, but TanStack Start then resolves its router entry against `<root>/src` instead of `apps/web/src` and aborts with `Could not resolve entry for router entry: router`. The same command run inside `apps/web` succeeds, which is why the root scripts are the thing that has to change: they now delegate per workspace via `vp run -r`, and each package carries the `vp` builtin with `--no-error-on-unmatched-pattern` so packages holding no lintable files do not fail the recursive run. The pre-commit hook calls `vpr check` to run that delegating script rather than the crashing builtin.

Each package also gets a `.prettierignore` covering build output and generated files. `vp fmt` reads that file from its own working directory, and without it every fresh project failed formatting on `src/routeTree.gen.ts`, which TanStack generates during install — so the hook would have kept failing even once it stopped crashing.

Two smaller defects in the same option are fixed alongside it. The `prepare` script arrived duplicated because `processPackageConfigs` runs three times over the same root `package.json` and that one line appended where every neighbouring line assigns; it is now idempotent. The `vite` alias override hardcoded `^0.2.9` in a spot neither `check-deps` nor `sync-versions` can reach, so the next version bump would have silently paired a newer `vite-plus` CLI with an older core — it now derives from `dependencyVersionMap`, and the tests assert that linkage instead of the literal.

Coverage is the reason all of this shipped unnoticed: the option rewrites every workspace script and aliases the `vite` package, and had no end-to-end verification at all. This adds a `vite-plus-toolchain` smoke preset to `pr-broad`, which surfaced the lint crash on its first run.

Confidence: 90% — a generated TanStack Start + Vite+ project now passes lint, format, check, check-types, build, and its pre-commit hook, every one of which crashed or failed beforehand. The remaining risk is that only TanStack Start was exercised end to end; other frontends share the same root scripts but were not individually run.

## Out of scope

`apps/web/vercel.json` sets `"outputDirectory": ".output"` for TanStack Start while the build emits `dist/`. A control project generated without Vite+ has the identical mismatch, so this predates the toolchain option — likely a leftover from when Start used nitro. Untouched here, and worth a separate look.