### PR TITLE
chore(release): 2.6.1

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Scaffold production-ready fullstack apps in TypeScript, React Native, Rust, Go, Python, Java, .NET, and Elixir — visual builder, CLI, and MCP server, with every integration wired together.",
   "keywords": [
     "ai-agent",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -81,6 +81,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.6.0"
+    "create-better-fullstack": "^2.6.1"
   }
 }

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -63,7 +63,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.6.0",
+    "@better-fullstack/types": "^2.6.1",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-fullstack",
   "displayName": "Better Fullstack",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-fullstack",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "better-fullstack",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Scaffold and safely evolve verified fullstack projects with Better Fullstack skills and its official MCP server.",
   "author": {
     "name": "Better Fullstack",


### PR DESCRIPTION
## Release v2.6.1

This PR bumps the version to `2.6.1`. Hotfix release — no changelog or release-notes changes.

### Changes
- Updated `create-better-fullstack` to v2.6.1
- Updated `create-bfs` to v2.6.1
- Updated `@better-fullstack/types` to v2.6.1
- Updated `@better-fullstack/template-generator` to v2.6.1
- Updated Better Fullstack plugin manifests to v2.6.1