### PR TITLE
Stop offering Kotlin and Swift options that React Native can never use

### DIFF
--- a/apps/web/content/docs/reference/options/react-native.mdx
+++ b/apps/web/content/docs/reference/options/react-native.mdx
@@ -9,6 +9,10 @@ React Native options are selected with `--ecosystem react-native`. They generate
 `native-uniwind` selects `mobile-ui: uniwind`. `native-unistyles` selects `mobile-ui: unistyles`. Tamagui and gluestack-ui are intended for `native-bare` to avoid conflicting style systems.
 </Callout>
 
+<Callout kind="info" title="Other mobile platforms">
+Jetpack Compose, Compose Multiplatform, SwiftUI and Flutter apps are not part of this ecosystem, and neither are their libraries. Build them with `--shape mobile` or in multi-ecosystem mode, which composes them as stack graph parts.
+</Callout>
+
 <Callout kind="tip" title="Valid values vs. valid combinations">
 This page lists valid React Native option values, not which combinations work together. Check the [Compatibility Matrix](/docs/reference/compatibility/) to validate a stack, and [Verified Combinations](/docs/reference/verified-combinations/) for scaffolds with current passing evidence.
 </Callout>

--- a/apps/web/src/components/docs/mdx/compatibility-matrix.tsx
+++ b/apps/web/src/components/docs/mdx/compatibility-matrix.tsx
@@ -3,6 +3,7 @@ import {
   getCategoryDisplayName,
   getCategoryOrderForEcosystem,
   getDisabledReason,
+  isMultiEcosystemMobileCategory,
   isMultiSelectCategory,
   isOptionCompatible,
   OPTION_CATEGORY_METADATA,
@@ -54,7 +55,9 @@ function getDocsCategories(ecosystem: Ecosystem): SelectCategory[] {
   return [
     ...getCategoryOrderForEcosystem(ecosystem).filter(
       (category) =>
-        Boolean(OPTION_CATEGORY_METADATA[category]) && !DOCS_CATEGORY_EXCLUSIONS.has(category),
+        Boolean(OPTION_CATEGORY_METADATA[category]) &&
+        !DOCS_CATEGORY_EXCLUSIONS.has(category) &&
+        !isMultiEcosystemMobileCategory(category),
     ),
     ...(DOCS_EXTRA_CATEGORIES_BY_ECOSYSTEM[ecosystem] ?? []),
   ];

--- a/apps/web/src/components/docs/mdx/option-reference.tsx
+++ b/apps/web/src/components/docs/mdx/option-reference.tsx
@@ -1,6 +1,7 @@
 import {
   getCategoryDisplayName,
   getCategoryOrderForEcosystem,
+  isMultiEcosystemMobileCategory,
   OPTION_CATEGORY_METADATA,
   type OptionCategoryEcosystem,
 } from "@better-fullstack/types";
@@ -63,8 +64,17 @@ const OPTION_REFERENCE_ROWS: OptionReferenceRow[] = [
   },
 ];
 
+// Kotlin, Swift and Flutter apps are not reachable with `--ecosystem
+// react-native`, so listing their categories on the React Native page would
+// document values the ecosystem rejects.
+function getReferenceCategories(ecosystem: OptionCategoryEcosystem) {
+  return getCategoryOrderForEcosystem(ecosystem).filter(
+    (category) => !isMultiEcosystemMobileCategory(category),
+  );
+}
+
 function getEcosystemStats(ecosystem: OptionCategoryEcosystem) {
-  const categories = getCategoryOrderForEcosystem(ecosystem);
+  const categories = getReferenceCategories(ecosystem);
   const optionCount = categories.reduce(
     (sum, category) => sum + OPTION_CATEGORY_METADATA[category].options.length,
     0,
@@ -119,7 +129,7 @@ export function OptionReferenceSummary() {
 }
 
 export function OptionCategoryTable({ ecosystem }: { ecosystem: OptionCategoryEcosystem }) {
-  const categories = getCategoryOrderForEcosystem(ecosystem);
+  const categories = getReferenceCategories(ecosystem);
 
   return (
     <div className="not-prose my-6 overflow-hidden rounded-lg border border-[var(--docs-border-subtle)] bg-[var(--docs-surface-elevated)]/70 shadow-sm">

--- a/apps/web/src/components/stack-builder/section-groups.ts
+++ b/apps/web/src/components/stack-builder/section-groups.ts
@@ -117,15 +117,18 @@ const TYPESCRIPT_SECTIONS: readonly BuilderSectionDef[] = [
  * selected, and the other mobile platforms never appear in the section list
  * (the multi-ecosystem composer renders those itself), so a React Native stack
  * is never offered Kotlin or Swift options.
+ *
+ * Yolo skips compatibility normalization, so an Expo selection survives losing
+ * its app. Keep those categories visible there or the values stay in the
+ * generated command with no control left to clear them.
  */
 export function isHiddenMobilePlatformCategory(
-  stack: Pick<StackState, "nativeFrontend">,
+  stack: Pick<StackState, "nativeFrontend" | "yolo">,
   category: string,
 ): boolean {
-  return (
-    isMultiEcosystemMobileCategory(category) ||
-    (isReactNativeOnlyCategory(category) && !hasReactNativeApp(stack))
-  );
+  if (isMultiEcosystemMobileCategory(category)) return true;
+  if (stack.yolo === "true") return false;
+  return isReactNativeOnlyCategory(category) && !hasReactNativeApp(stack);
 }
 
 const REACT_NATIVE_SECTIONS: readonly BuilderSectionDef[] = [

--- a/apps/web/src/components/stack-builder/section-groups.ts
+++ b/apps/web/src/components/stack-builder/section-groups.ts
@@ -1,7 +1,13 @@
 import type { Ecosystem } from "@better-fullstack/types";
 
-import { getCategoryDisplayName } from "@better-fullstack/types";
+import {
+  getCategoryDisplayName,
+  hasReactNativeApp,
+  isMultiEcosystemMobileCategory,
+  isReactNativeOnlyCategory,
+} from "@better-fullstack/types";
 
+import type { StackState } from "@/lib/stack-defaults";
 import type { TechCategory } from "@/lib/types";
 
 export type BuilderSectionDef = {
@@ -105,6 +111,22 @@ const TYPESCRIPT_SECTIONS: readonly BuilderSectionDef[] = [
     "install",
   ]),
 ];
+
+/**
+ * React Native's own categories stay hidden until a React Native app is
+ * selected, and the other mobile platforms never appear in the section list
+ * (the multi-ecosystem composer renders those itself), so a React Native stack
+ * is never offered Kotlin or Swift options.
+ */
+export function isHiddenMobilePlatformCategory(
+  stack: Pick<StackState, "nativeFrontend">,
+  category: string,
+): boolean {
+  return (
+    isMultiEcosystemMobileCategory(category) ||
+    (isReactNativeOnlyCategory(category) && !hasReactNativeApp(stack))
+  );
+}
 
 const REACT_NATIVE_SECTIONS: readonly BuilderSectionDef[] = [
   section("mobileFrameworks", "Mobile Frameworks", [

--- a/apps/web/src/components/stack-builder/stack-builder.tsx
+++ b/apps/web/src/components/stack-builder/stack-builder.tsx
@@ -128,7 +128,11 @@ import { m } from "@/paraglide/messages.js";
 
 import { BuilderShareModal } from "./builder-share-modal";
 import { PresetsPanel } from "./presets-panel";
-import { type BuilderSectionDef, getBuilderSections } from "./section-groups";
+import {
+  type BuilderSectionDef,
+  getBuilderSections,
+  isHiddenMobilePlatformCategory,
+} from "./section-groups";
 import { SavedStacksPanel } from "./saved-stacks-panel";
 import { ShareButton } from "./share-button";
 import { TechIcon } from "./tech-icon";
@@ -1510,7 +1514,8 @@ function shouldSkipCategory(stack: StackState, categoryKey: string): boolean {
   return (
     categoryKey === "astroIntegration" ||
     SHADCN_SUB_CATEGORIES.has(categoryKey as keyof typeof TECH_OPTIONS) ||
-    (stack.ecosystem === "go" && categoryKey === "auth")
+    (stack.ecosystem === "go" && categoryKey === "auth") ||
+    isHiddenMobilePlatformCategory(stack, categoryKey)
   );
 }
 
@@ -1798,6 +1803,9 @@ function CreationModeComposer({
     ...stack,
     ecosystem: "react-native",
   };
+  // The react-native ecosystem rejects every non-Expo option, so a Kotlin app's
+  // libraries have to be checked outside it.
+  const kotlinMobileCompatibilityStack: StackState = stack;
 
   const applyGraphSelection = useCallback(
     (nextSelection: GraphSelection) => {
@@ -2425,7 +2433,7 @@ function CreationModeComposer({
                     ),
                     category,
                     testIdPrefix: `multi-mobile-${category}`,
-                    compatibilityStack: mobileCompatibilityStack,
+                    compatibilityStack: kotlinMobileCompatibilityStack,
                   })}
                 </div>
               ))}

--- a/apps/web/test/builder-section-groups.test.ts
+++ b/apps/web/test/builder-section-groups.test.ts
@@ -63,7 +63,7 @@ describe("builder section groups", () => {
   });
 
   it("keeps Kotlin, Swift and Flutter categories out of the React Native ecosystem", () => {
-    const expoStack = { nativeFrontend: ["native-bare"] };
+    const expoStack = { nativeFrontend: ["native-bare"], yolo: "false" };
     const rendered = getBuilderSections(
       "react-native",
       getCategoryOrderForEcosystem("react-native"),
@@ -80,14 +80,25 @@ describe("builder section groups", () => {
   });
 
   it("hides Expo categories until a React Native app is selected", () => {
-    const emptyStack = { nativeFrontend: ["none"] };
+    const emptyStack = { nativeFrontend: ["none"], yolo: "false" };
 
     expect(isHiddenMobilePlatformCategory(emptyStack, "mobileLibraries")).toBe(true);
     expect(isHiddenMobilePlatformCategory(emptyStack, "mobileNavigation")).toBe(true);
     expect(isHiddenMobilePlatformCategory(emptyStack, "nativeFrontend")).toBe(false);
     expect(
-      isHiddenMobilePlatformCategory({ nativeFrontend: ["native-uniwind"] }, "mobileLibraries"),
+      isHiddenMobilePlatformCategory(
+        { nativeFrontend: ["native-uniwind"], yolo: "false" },
+        "mobileLibraries",
+      ),
     ).toBe(false);
+  });
+
+  it("keeps Expo categories reachable under yolo, which skips the clearing pass", () => {
+    const yoloStack = { nativeFrontend: ["none"], yolo: "true" };
+
+    expect(isHiddenMobilePlatformCategory(yoloStack, "mobileUI")).toBe(false);
+    expect(isHiddenMobilePlatformCategory(yoloStack, "mobileLibraries")).toBe(false);
+    expect(isHiddenMobilePlatformCategory(yoloStack, "kotlinMobileLibraries")).toBe(true);
   });
 
   it("falls back to a single-category section for unmapped categories", () => {

--- a/apps/web/test/builder-section-groups.test.ts
+++ b/apps/web/test/builder-section-groups.test.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   getBuilderSections,
+  isHiddenMobilePlatformCategory,
   SECTION_EMBEDDED_CATEGORIES,
   SECTIONS_BY_ECOSYSTEM,
 } from "../src/components/stack-builder/section-groups";
@@ -59,6 +60,34 @@ describe("builder section groups", () => {
     for (const section of sections) {
       expect(knownKeys.has(section.key)).toBe(true);
     }
+  });
+
+  it("keeps Kotlin, Swift and Flutter categories out of the React Native ecosystem", () => {
+    const expoStack = { nativeFrontend: ["native-bare"] };
+    const rendered = getBuilderSections(
+      "react-native",
+      getCategoryOrderForEcosystem("react-native"),
+    )
+      .flatMap((section) => section.categories)
+      .filter((category) => !isHiddenMobilePlatformCategory(expoStack, category));
+
+    expect(rendered).not.toContain("kotlinMobile");
+    expect(rendered).not.toContain("kotlinMobileLibraries");
+    expect(rendered).not.toContain("swiftMobile");
+    expect(rendered).not.toContain("dartMobile");
+    expect(rendered).toContain("nativeFrontend");
+    expect(rendered).toContain("mobileLibraries");
+  });
+
+  it("hides Expo categories until a React Native app is selected", () => {
+    const emptyStack = { nativeFrontend: ["none"] };
+
+    expect(isHiddenMobilePlatformCategory(emptyStack, "mobileLibraries")).toBe(true);
+    expect(isHiddenMobilePlatformCategory(emptyStack, "mobileNavigation")).toBe(true);
+    expect(isHiddenMobilePlatformCategory(emptyStack, "nativeFrontend")).toBe(false);
+    expect(
+      isHiddenMobilePlatformCategory({ nativeFrontend: ["native-uniwind"] }, "mobileLibraries"),
+    ).toBe(false);
   });
 
   it("falls back to a single-category section for unmapped categories", () => {

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -18,7 +18,12 @@ import type {
 
 import { getCapabilityDisabledReason, normalizeCapabilitySelection } from "./capabilities";
 import { ANALYTICS_VALUES } from "./schemas";
-import { CATEGORY_ORDER, getCategoryDisplayName, type OptionCategory } from "./option-metadata";
+import {
+  CATEGORY_ORDER,
+  getCategoryDisplayName,
+  isMultiEcosystemMobileCategory,
+  type OptionCategory,
+} from "./option-metadata";
 import {
   getUnsupportedWebDeployFrontend,
   hasPWACompatibleFrontend,
@@ -2717,7 +2722,16 @@ export const getDisabledReason = (
       return "React Native payments currently support RevenueCat only";
     }
 
-    if (!reactNativeCategories.has(category) && optionId !== "none" && optionId !== "false") {
+    // A graph selection whose only primary part is a Kotlin, Swift or Flutter
+    // app still lowers to the react-native ecosystem (`ecosystemForLegacy`), so
+    // this allowlist cannot speak for those categories. Their own gates above
+    // enforce the real constraint.
+    if (
+      !reactNativeCategories.has(category) &&
+      !isMultiEcosystemMobileCategory(category) &&
+      optionId !== "none" &&
+      optionId !== "false"
+    ) {
       return "React Native ecosystem only supports native mobile options";
     }
   }

--- a/packages/types/src/compatibility.ts
+++ b/packages/types/src/compatibility.ts
@@ -210,6 +210,38 @@ export function getKotlinJavaIncompatibilityReason(stack: KotlinJavaGateInput): 
   return null;
 }
 
+// ============================================
+// MOBILE PLATFORM GATE
+// ============================================
+// Mobile spans four independent platforms (React Native, Kotlin, Swift,
+// Flutter) whose library catalogs never mix. This is the single source of truth
+// for which categories belong to React Native — `getDisabledReason` and the web
+// builder's category visibility both read it, so Expo options can never be
+// offered without an Expo app and Kotlin libraries can never be offered for one.
+
+const REACT_NATIVE_ONLY_CATEGORIES: ReadonlySet<string> = new Set([
+  "mobileNavigation",
+  "mobileUI",
+  "mobileStorage",
+  "mobileTesting",
+  "mobilePush",
+  "mobileOTA",
+  "mobileDeepLinking",
+  "mobileLibraries",
+]);
+
+export function isReactNativeOnlyCategory(category: string): boolean {
+  return REACT_NATIVE_ONLY_CATEGORIES.has(category);
+}
+
+export function hasReactNativeApp(stack: { nativeFrontend?: string[] }): boolean {
+  return (stack.nativeFrontend ?? []).some((frontend) => frontend !== "none");
+}
+
+function hasKotlinMobileApp(stack: { kotlinMobile?: string }): boolean {
+  return (stack.kotlinMobile ?? "none") !== "none";
+}
+
 export type CompatibilityIssue = {
   code: string;
   message: string;
@@ -2507,6 +2539,14 @@ export const getDisabledReason = (
   optionId: string,
 ): string | null => {
   if (
+    optionId !== "none" &&
+    category === "kotlinMobileLibraries" &&
+    !hasKotlinMobileApp(currentStack)
+  ) {
+    return "Kotlin mobile libraries require a Jetpack Compose or Compose Multiplatform app";
+  }
+
+  if (
     currentStack.ecosystem === "react-native" &&
     category === "codeQuality" &&
     optionId !== "knip" &&
@@ -3651,20 +3691,8 @@ export const getDisabledReason = (
     }
   }
 
-  const mobileCategories = new Set([
-    "mobileNavigation",
-    "mobileUI",
-    "mobileStorage",
-    "mobileTesting",
-    "mobilePush",
-    "mobileOTA",
-    "mobileDeepLinking",
-    "mobileLibraries",
-  ]);
-
-  if (mobileCategories.has(category)) {
-    const hasNativeFrontend = currentStack.nativeFrontend.some((f) => f !== "none");
-    if (!hasNativeFrontend && optionId !== "none") {
+  if (isReactNativeOnlyCategory(category)) {
+    if (!hasReactNativeApp(currentStack) && optionId !== "none") {
       return `${getCategoryDisplayName(category)} requires a native Expo frontend`;
     }
 
@@ -5684,6 +5712,18 @@ export function evaluateCompatibility(input: CompatibilityInput): CompatibilityE
         message: reason,
         category: "mobileLibraries",
         optionId: mobileLibrary,
+      });
+    }
+  }
+
+  for (const kotlinLibrary of input.kotlinMobileLibraries ?? []) {
+    const reason = getDisabledReason(input, "kotlinMobileLibraries", kotlinLibrary);
+    if (reason) {
+      issues.push({
+        code: "INCOMPATIBLE_KOTLIN_MOBILE_LIBRARY",
+        message: reason,
+        category: "kotlinMobileLibraries",
+        optionId: kotlinLibrary,
       });
     }
   }

--- a/packages/types/src/option-metadata.ts
+++ b/packages/types/src/option-metadata.ts
@@ -431,6 +431,24 @@ export const TYPESCRIPT_CATEGORY_ORDER = [
   "install",
 ] as const satisfies readonly OptionCategory[];
 
+/**
+ * Kotlin, Swift and Flutter apps exist only as stack graph parts: they are
+ * composed in multi-ecosystem mode or through `--shape mobile`, and the
+ * `react-native` ecosystem rejects them outright. They ride along in the mobile
+ * category order so their metadata stays reachable, so every surface that
+ * presents the react-native ecosystem to a user must filter them out.
+ */
+export const MULTI_ECOSYSTEM_MOBILE_CATEGORIES: ReadonlySet<string> = new Set([
+  "kotlinMobile",
+  "kotlinMobileLibraries",
+  "swiftMobile",
+  "dartMobile",
+]);
+
+export function isMultiEcosystemMobileCategory(category: string): boolean {
+  return MULTI_ECOSYSTEM_MOBILE_CATEGORIES.has(category);
+}
+
 export const REACT_NATIVE_CATEGORY_ORDER = [
   "nativeFrontend",
   "kotlinMobile",

--- a/packages/types/test/compatibility.test.ts
+++ b/packages/types/test/compatibility.test.ts
@@ -1058,6 +1058,36 @@ describe("compatibility issue helpers", () => {
     ).toBeNull();
   });
 
+  it("keeps Kotlin mobile libraries selectable for a mobile-only Kotlin graph selection", () => {
+    // A graph selection whose only primary part is a Kotlin app lowers to the
+    // react-native ecosystem, which must not reject the Kotlin categories.
+    const kotlinOnlyStack = {
+      ...DEFAULT_STACK_SELECTION,
+      ecosystem: "react-native",
+      webFrontend: ["none"],
+      nativeFrontend: ["none"],
+      kotlinMobile: "jetpack-compose",
+    };
+
+    expect(getDisabledReason(kotlinOnlyStack, "kotlinMobileLibraries", "koin")).toBeNull();
+    expect(getDisabledReason(kotlinOnlyStack, "kotlinMobile", "jetpack-compose")).toBeNull();
+    expect(
+      getDisabledReason({ ...kotlinOnlyStack, swiftMobile: "swiftui" }, "swiftMobile", "swiftui"),
+    ).toBeNull();
+
+    expect(
+      getDisabledReason(
+        { ...kotlinOnlyStack, kotlinMobile: "none" },
+        "kotlinMobileLibraries",
+        "koin",
+      ),
+    ).toBe("Kotlin mobile libraries require a Jetpack Compose or Compose Multiplatform app");
+
+    expect(getDisabledReason(kotlinOnlyStack, "database", "postgres")).toBe(
+      "React Native ecosystem only supports native mobile options",
+    );
+  });
+
   it("reports Kotlin mobile libraries requested alongside a React Native app", () => {
     const { issues } = evaluateCompatibility({
       ...DEFAULT_STACK_SELECTION,

--- a/packages/types/test/compatibility.test.ts
+++ b/packages/types/test/compatibility.test.ts
@@ -1037,6 +1037,42 @@ describe("compatibility issue helpers", () => {
     ).toBeNull();
   });
 
+  it("blocks Kotlin mobile libraries unless a Kotlin mobile app is selected", () => {
+    const withReactNativeApp = {
+      ...DEFAULT_STACK_SELECTION,
+      nativeFrontend: ["native-bare"],
+      kotlinMobile: "none",
+    };
+
+    expect(getDisabledReason(withReactNativeApp, "kotlinMobileLibraries", "koin")).toBe(
+      "Kotlin mobile libraries require a Jetpack Compose or Compose Multiplatform app",
+    );
+    expect(getDisabledReason(withReactNativeApp, "kotlinMobileLibraries", "none")).toBeNull();
+
+    expect(
+      getDisabledReason(
+        { ...withReactNativeApp, kotlinMobile: "jetpack-compose" },
+        "kotlinMobileLibraries",
+        "koin",
+      ),
+    ).toBeNull();
+  });
+
+  it("reports Kotlin mobile libraries requested alongside a React Native app", () => {
+    const { issues } = evaluateCompatibility({
+      ...DEFAULT_STACK_SELECTION,
+      nativeFrontend: ["native-bare"],
+      kotlinMobile: "none",
+      kotlinMobileLibraries: ["koin", "ktor-client"],
+    });
+
+    const kotlinIssues = issues.filter((issue) => issue.category === "kotlinMobileLibraries");
+    expect(kotlinIssues.map((issue) => issue.optionId)).toEqual(["koin", "ktor-client"]);
+    for (const issue of kotlinIssues) {
+      expect(issue.code).toBe("INCOMPATIBLE_KOTLIN_MOBILE_LIBRARY");
+    }
+  });
+
   it("allows RevenueCat payments for React Native stacks without enabling web payment providers", () => {
     const reactNativeStack = {
       ...DEFAULT_STACK_SELECTION,


### PR DESCRIPTION
## Problem

Pick React Native in the stack builder and the Mobile Frameworks section offers Jetpack Compose, Compose Multiplatform, SwiftUI, Flutter and the full Kotlin library catalog — Koin, Ktor Client, kotlinx.serialization, DataStore, Coil, MockK, Turbine — none of which can run in an Expo app.

None of it was selectable either. `getDisabledReason` rejects every category outside a fixed allowlist when the ecosystem is `react-native` (`compatibility.ts:2726`), and that allowlist has only the Expo categories in it. So the four platforms and their libraries rendered as permanently disabled cards: enough to look like an offer, never enough to click. They are in `REACT_NATIVE_CATEGORY_ORDER` because their option metadata has to live somewhere, not because the ecosystem supports them. The CLI already treats them correctly — `project-shape.ts` asks for a mobile platform first and only reaches the Kotlin library prompt for a Kotlin app, and it scaffolds that app with `ecosystem: "typescript"` because Kotlin, Swift and Flutter apps exist only as stack graph parts.

The same leak reached the docs. The compatibility matrix let you select those categories under React Native and then marked every option incompatible, and the React Native option reference table listed Kotlin libraries as accepted values on a page whose opening line is "React Native options are selected with `--ecosystem react-native`".

Two smaller gaps sat behind the same allowlist:

**The Kotlin library step in multi-ecosystem mode was broken.** The mobile step builds its compatibility stack as `{...stack, ecosystem: "react-native"}` and reused it for the Kotlin app's libraries. The react-native allowlist then disabled all eleven of them, so the one place Kotlin libraries are supposed to work offered nothing selectable.

**Nothing told you when a Kotlin library was wrong for your stack.** `kotlinMobileLibraries` had no compatibility rule at all — only a normalization step that silently emptied the array at generate time if no Kotlin app was selected. A CLI or MCP caller passing `--kotlin-mobile-libraries koin` next to an Expo app got a project without Koin and no explanation.

## Solution

Kotlin, Swift and Flutter categories are named once, in `option-metadata.ts` next to the category order that carries them, and every surface that presents the react-native ecosystem filters on that one set: the builder sections, the compatibility matrix, and the option reference table. The React Native docs page now says where those platforms are built instead of listing their flags as its own.

Expo categories are gated on an Expo app the same way, so the tab opens on the framework choice and reveals navigation, UI, storage, deep linking, push, OTA and the Expo libraries once one is picked — the CLI's platform-first flow, in the builder:

```
no mobile app picked          Expo picked
  Mobile Frameworks             Mobile Frameworks
  Auth & Payments               App Experience
  Deploy & Scaffold             Testing & Delivery
                                Auth & Payments
                                Deploy & Scaffold
```

One rule drives all of it. `shouldSkipCategory` is the only category-visibility hook in the builder and already feeds the main grid, the navigation drawer and the command-palette search index, so filtering there fixes every path at once. The react-native category list it consults now comes from `compatibility.ts` rather than a second copy inlined in `getDisabledReason`, which is what let the builder and the compat engine disagree in the first place.

The multi-ecosystem Kotlin step checks its libraries against the unmodified stack, matching how the CLI scaffolds a Kotlin app. Its eleven libraries are selectable again.

`kotlinMobileLibraries` now has a real gate: a disabled reason without a Jetpack Compose or Compose Multiplatform app, and an `INCOMPATIBLE_KOTLIN_MOBILE_LIBRARY` issue from `evaluateCompatibility`, so `bfs_check_compatibility` and the CLI say what is wrong instead of dropping the libraries during generation.

Auth and payments still render in the React Native tab before any mobile app is selected, so better-auth and RevenueCat are offered with nothing to attach them to. Same class of problem, different owner rule, left for its own change.

Confidence: 95% — the gate is proven against the real option data rather than a fixture: replaying the builder's own section resolution over `REACT_NATIVE_CATEGORY_ORDER` produces the two states above, and probing `getDisabledReason` confirms the four platforms were already blocked under `react-native` and that Kotlin libraries resolve cleanly once the ecosystem is not react-native. The residual risk is a product judgement, not a mechanical one: solo mode now has no Compose, SwiftUI or Flutter entry point at all, which was already true in behaviour and is now true in the UI.
