### PR TITLE
chore(release): 2.6.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Scaffold configurable fullstack projects in TypeScript, React Native, Rust, Go, Python, Java, .NET, and Elixir through a visual builder, CLI, and MCP server.",
   "keywords": [
     "ai-agent",
@@ -151,7 +151,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@better-fullstack/project-lifecycle": "^2.6.1",
+    "@better-fullstack/project-lifecycle": "^2.6.2",
     "@better-fullstack/template-generator": "^2.6.1",
     "@better-fullstack/types": "^2.6.1",
     "@clack/core": "^0.5.0",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -152,8 +152,8 @@
   },
   "dependencies": {
     "@better-fullstack/project-lifecycle": "^2.6.2",
-    "@better-fullstack/template-generator": "^2.6.1",
-    "@better-fullstack/types": "^2.6.1",
+    "@better-fullstack/template-generator": "^2.6.2",
+    "@better-fullstack/types": "^2.6.2",
     "@clack/core": "^0.5.0",
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/server": "^2.0.0",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -81,6 +81,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.6.1"
+    "create-better-fullstack": "^2.6.2"
   }
 }

--- a/packages/project-lifecycle/package.json
+++ b/packages/project-lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/project-lifecycle",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Transactional project lifecycle contracts and recovery for Better Fullstack",
   "license": "MIT",
   "files": [

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -63,7 +63,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.6.1",
+    "@better-fullstack/types": "^2.6.2",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-fullstack",
   "displayName": "Better Fullstack",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-fullstack",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "better-fullstack",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Scaffold and safely evolve verified fullstack projects with Better Fullstack skills and its official MCP server.",
   "author": {
     "name": "Better Fullstack",


### PR DESCRIPTION
## Problem

PR #407 is merged, but the publishable packages and plugin manifests still identify the previous 2.6.1 release.

## Solution

This bumps the CLI, alias package, lifecycle package, shared types, template generator, and all three plugin manifests to 2.6.2. It also raises every internal dependency floor to 2.6.2 so the published CLI cannot resolve pre-#407 package versions.

Merging this PR will hand the release to the existing workflow. This PR does not publish packages by itself.

## Confidence

98% - the changes match the repository's patch-release script, and the CLI build, package checks, and plugin-bundle validator pass. The remaining risk is the protected publish workflow, which runs only after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Released version 2.6.2 across the CLI, project creation, lifecycle, template generation, types, and plugin packages.
  - Updated related package versions to keep the release components aligned.
  - Updated plugin metadata to reflect the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the outstanding stale lockfile prevents the frozen dependency installation required by the release workflow.

The manifests now require 2.6.2, but bun.lock still records the affected workspaces and internal ranges as 2.6.1, so the gating and release workflows cannot complete their frozen-lockfile installation.

**Files Needing Attention:** bun.lock and apps/cli/package.json
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/package.json | Bumps the CLI and its first-party dependency floors to 2.6.2. |
| packages/create-bfs/package.json | Bumps the alias package and its create-better-fullstack dependency floor to 2.6.2. |
| packages/project-lifecycle/package.json | Bumps the lifecycle package version to 2.6.2. |
| packages/template-generator/package.json | Bumps the generator and its shared-types dependency floor to 2.6.2. |
| packages/types/package.json | Bumps the shared-types package version to 2.6.2. |
| plugin/.claude-plugin/plugin.json | Aligns the Claude plugin manifest with version 2.6.2. |
| plugin/.codex-plugin/plugin.json | Aligns the Codex plugin manifest with version 2.6.2. |
| plugin/plugin.json | Aligns the generic plugin manifest with version 2.6.2. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): align CLI dependency floor..."](https://github.com/marve10s/better-fullstack/commit/03528db2faf7bdfa41621011fcc7d68ac8901e58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57431585)</sub>

<!-- /greptile_comment -->