### PR TITLE
chore(release): 2.7.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-better-fullstack",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Scaffold configurable fullstack projects in TypeScript, React Native, Rust, Go, Python, Java, .NET, and Elixir through a visual builder, CLI, and MCP server.",
   "keywords": [
     "ai-agent",

--- a/packages/create-bfs/package.json
+++ b/packages/create-bfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bfs",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Alias for create-better-fullstack - A CLI-first toolkit for building fullstack applications.",
   "keywords": [
     "algolia",
@@ -81,6 +81,6 @@
     "lint": "oxlint ."
   },
   "dependencies": {
-    "create-better-fullstack": "^2.6.2"
+    "create-better-fullstack": "^2.7.0"
   }
 }

--- a/packages/project-lifecycle/package.json
+++ b/packages/project-lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/project-lifecycle",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "private": true,
   "description": "Transactional project lifecycle contracts and recovery for Better Fullstack",
   "license": "MIT",

--- a/packages/template-generator/package.json
+++ b/packages/template-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/template-generator",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Virtual file system generator for Better-Fullstack templates - works in browsers and Node.js",
   "keywords": [
     "better-fullstack",
@@ -63,7 +63,7 @@
     "sync-versions:fix": "bun scripts/sync-template-versions.ts --fix"
   },
   "dependencies": {
-    "@better-fullstack/types": "^2.6.2",
+    "@better-fullstack/types": "^2.7.0",
     "handlebars": "^4.7.9",
     "pathe": "^2.0.3",
     "ts-morph": "^27.0.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-fullstack/types",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "TypeScript types and schemas for Better Fullstack CLI",
   "keywords": [
     "better-fullstack",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "better-fullstack",
   "displayName": "Better Fullstack",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "better-fullstack",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Let your AI assistant scaffold and extend Better Fullstack projects through the official MCP server and focused skills.",
   "author": {
     "name": "Better Fullstack",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "better-fullstack",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "description": "Scaffold and safely evolve verified fullstack projects with Better Fullstack skills and its official MCP server.",
   "author": {
     "name": "Better Fullstack",


### PR DESCRIPTION
Release v2.7.0. Bumps create-better-fullstack, create-bfs, @better-fullstack/types, @better-fullstack/template-generator, @better-fullstack/project-lifecycle, and the plugin manifests. Headline change: the bfs install command (#415).

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The release should not merge until bun.lock is regenerated and committed so clean and frozen installations use a consistent 2.7.0 workspace graph.

The manifests now advertise 2.7.0 packages and dependency ranges, but the committed Bun lockfile still records the affected workspace packages and internal edges at 2.6.x.

**Files Needing Attention:** packages/create-bfs/package.json, packages/template-generator/package.json, and bun.lock
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/cli/package.json | Correctly bumps the primary CLI package to 2.7.0, but its workspace lockfile record remains stale. |
| packages/create-bfs/package.json | Bumps the alias and its CLI dependency to 2.7.0 without updating the corresponding bun.lock package and dependency records. |
| packages/template-generator/package.json | Bumps the generator and types dependency to 2.7.0 while bun.lock retains both at 2.6.2. |
| packages/types/package.json | Correctly bumps the types package manifest, but the workspace lockfile still records version 2.6.2. |
| packages/project-lifecycle/package.json | Correctly bumps the lifecycle package manifest, but the workspace lockfile still records version 2.6.2. |
| plugin/.claude-plugin/plugin.json | Synchronizes the Claude plugin manifest to release version 2.7.0. |
| plugin/.codex-plugin/plugin.json | Synchronizes the Codex plugin manifest to release version 2.7.0. |
| plugin/plugin.json | Synchronizes the generic plugin manifest to release version 2.7.0. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): 2.7.0"](https://github.com/marve10s/better-fullstack/commit/036f5d915fb4ab100c67e63268a0f41c5a0653d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58666966)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.7.0 across the CLI, project tooling, template generator, type definitions, and plugins.
  * Updated related package references to ensure all components use the 2.7.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->