### PR TITLE
Hide Java-only integrations from the Kotlin builder surface

### DIFF
--- a/apps/cli/src/prompts/core/config-prompts.ts
+++ b/apps/cli/src/prompts/core/config-prompts.ts
@@ -708,6 +708,17 @@ export function resolveDatabaseFlagForEcosystem(
   return "none";
 }
 
+function getSharedPromptJavaLanguage(
+  results: { javaLanguage?: JavaLanguage },
+  flags: Partial<ProjectConfig>,
+): JavaLanguage | undefined {
+  if (results.javaLanguage === "kotlin") return "kotlin";
+  if (flags.javaLanguage !== "kotlin") return results.javaLanguage;
+  if (flags.javaWebFramework === undefined || flags.javaWebFramework === "spring-boot") {
+    return "kotlin";
+  }
+  return results.javaLanguage;
+}
 function getPromptResolutionValue(
   key: ConfigPromptKey,
   results: Partial<PromptGroupResults>,
@@ -975,10 +986,11 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Email);
       }
-      if (results.ecosystem === "java" && results.javaLanguage === "kotlin" && flags.email === undefined) {
+      const javaLanguage = getSharedPromptJavaLanguage(results, flags);
+      if (results.ecosystem === "java" && javaLanguage === "kotlin" && flags.email === undefined) {
         return Promise.resolve("none" as Email);
       }
-      return getEmailChoice(flags.email, results.backend, results.ecosystem, results.javaLanguage);
+      return getEmailChoice(flags.email, results.backend, results.ecosystem, javaLanguage);
     },
     effect: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as Effect);
@@ -1112,9 +1124,10 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Observability);
       }
+      const javaLanguage = getSharedPromptJavaLanguage(results, flags);
       if (
         results.ecosystem === "java" &&
-        results.javaLanguage === "kotlin" &&
+        javaLanguage === "kotlin" &&
         flags.observability === undefined
       ) {
         return Promise.resolve("none" as Observability);
@@ -1123,7 +1136,7 @@ export async function gatherConfig(
         flags.observability,
         results.backend,
         results.ecosystem,
-        results.javaLanguage,
+        javaLanguage,
       );
     },
     featureFlags: ({ results }) => {
@@ -1155,14 +1168,15 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Caching);
       }
+      const javaLanguage = getSharedPromptJavaLanguage(results, flags);
       if (
         results.ecosystem === "java" &&
-        results.javaLanguage === "kotlin" &&
+        javaLanguage === "kotlin" &&
         flags.caching === undefined
       ) {
         return Promise.resolve("none" as Caching);
       }
-      return getCachingChoice(flags.caching, results.backend, results.ecosystem, results.javaLanguage);
+      return getCachingChoice(flags.caching, results.backend, results.ecosystem, javaLanguage);
     },
     rateLimit: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as RateLimit);
@@ -1186,14 +1200,15 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Search);
       }
+      const javaLanguage = getSharedPromptJavaLanguage(results, flags);
       if (
         results.ecosystem === "java" &&
-        results.javaLanguage === "kotlin" &&
+        javaLanguage === "kotlin" &&
         flags.search === undefined
       ) {
         return Promise.resolve("none" as Search);
       }
-      return getSearchChoice(flags.search, results.backend, results.ecosystem, results.javaLanguage);
+      return getSearchChoice(flags.search, results.backend, results.ecosystem, javaLanguage);
     },
     vectorDb: ({ results }) => {
       if (results.ecosystem !== "typescript") {

--- a/apps/cli/src/prompts/core/config-prompts.ts
+++ b/apps/cli/src/prompts/core/config-prompts.ts
@@ -975,7 +975,19 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Email);
       }
-      return getEmailChoice(flags.email, results.backend, results.ecosystem);
+      if (
+        results.ecosystem === "java" &&
+        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
+        flags.email === undefined
+      ) {
+        return Promise.resolve("none" as Email);
+      }
+      return getEmailChoice(
+        flags.email,
+        results.backend,
+        results.ecosystem,
+        results.javaLanguage ?? flags.javaLanguage,
+      );
     },
     effect: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as Effect);
@@ -1109,7 +1121,19 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Observability);
       }
-      return getObservabilityChoice(flags.observability, results.backend, results.ecosystem);
+      if (
+        results.ecosystem === "java" &&
+        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
+        flags.observability === undefined
+      ) {
+        return Promise.resolve("none" as Observability);
+      }
+      return getObservabilityChoice(
+        flags.observability,
+        results.backend,
+        results.ecosystem,
+        results.javaLanguage ?? flags.javaLanguage,
+      );
     },
     featureFlags: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as FeatureFlags);
@@ -1140,7 +1164,19 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Caching);
       }
-      return getCachingChoice(flags.caching, results.backend, results.ecosystem);
+      if (
+        results.ecosystem === "java" &&
+        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
+        flags.caching === undefined
+      ) {
+        return Promise.resolve("none" as Caching);
+      }
+      return getCachingChoice(
+        flags.caching,
+        results.backend,
+        results.ecosystem,
+        results.javaLanguage ?? flags.javaLanguage,
+      );
     },
     rateLimit: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as RateLimit);
@@ -1164,7 +1200,19 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Search);
       }
-      return getSearchChoice(flags.search, results.backend, results.ecosystem);
+      if (
+        results.ecosystem === "java" &&
+        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
+        flags.search === undefined
+      ) {
+        return Promise.resolve("none" as Search);
+      }
+      return getSearchChoice(
+        flags.search,
+        results.backend,
+        results.ecosystem,
+        results.javaLanguage ?? flags.javaLanguage,
+      );
     },
     vectorDb: ({ results }) => {
       if (results.ecosystem !== "typescript") {

--- a/apps/cli/src/prompts/core/config-prompts.ts
+++ b/apps/cli/src/prompts/core/config-prompts.ts
@@ -975,19 +975,10 @@ export async function gatherConfig(
       if (results.ecosystem === "react-native" || results.ecosystem === "elixir") {
         return Promise.resolve("none" as Email);
       }
-      if (
-        results.ecosystem === "java" &&
-        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
-        flags.email === undefined
-      ) {
+      if (results.ecosystem === "java" && results.javaLanguage === "kotlin" && flags.email === undefined) {
         return Promise.resolve("none" as Email);
       }
-      return getEmailChoice(
-        flags.email,
-        results.backend,
-        results.ecosystem,
-        results.javaLanguage ?? flags.javaLanguage,
-      );
+      return getEmailChoice(flags.email, results.backend, results.ecosystem, results.javaLanguage);
     },
     effect: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as Effect);
@@ -1123,7 +1114,7 @@ export async function gatherConfig(
       }
       if (
         results.ecosystem === "java" &&
-        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
+        results.javaLanguage === "kotlin" &&
         flags.observability === undefined
       ) {
         return Promise.resolve("none" as Observability);
@@ -1132,7 +1123,7 @@ export async function gatherConfig(
         flags.observability,
         results.backend,
         results.ecosystem,
-        results.javaLanguage ?? flags.javaLanguage,
+        results.javaLanguage,
       );
     },
     featureFlags: ({ results }) => {
@@ -1166,17 +1157,12 @@ export async function gatherConfig(
       }
       if (
         results.ecosystem === "java" &&
-        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
+        results.javaLanguage === "kotlin" &&
         flags.caching === undefined
       ) {
         return Promise.resolve("none" as Caching);
       }
-      return getCachingChoice(
-        flags.caching,
-        results.backend,
-        results.ecosystem,
-        results.javaLanguage ?? flags.javaLanguage,
-      );
+      return getCachingChoice(flags.caching, results.backend, results.ecosystem, results.javaLanguage);
     },
     rateLimit: ({ results }) => {
       if (results.ecosystem !== "typescript") return Promise.resolve("none" as RateLimit);
@@ -1202,17 +1188,12 @@ export async function gatherConfig(
       }
       if (
         results.ecosystem === "java" &&
-        (results.javaLanguage === "kotlin" || flags.javaLanguage === "kotlin") &&
+        results.javaLanguage === "kotlin" &&
         flags.search === undefined
       ) {
         return Promise.resolve("none" as Search);
       }
-      return getSearchChoice(
-        flags.search,
-        results.backend,
-        results.ecosystem,
-        results.javaLanguage ?? flags.javaLanguage,
-      );
+      return getSearchChoice(flags.search, results.backend, results.ecosystem, results.javaLanguage);
     },
     vectorDb: ({ results }) => {
       if (results.ecosystem !== "typescript") {

--- a/apps/cli/src/prompts/data/caching.ts
+++ b/apps/cli/src/prompts/data/caching.ts
@@ -33,12 +33,30 @@ type CachingPromptContext = {
   caching?: Caching;
   backend?: Backend;
   ecosystem?: Ecosystem;
+  javaLanguage?: string;
 };
 
 export function resolveCachingPrompt(
   context: CachingPromptContext = {},
 ): PromptSingleResolution<Caching> {
   if (context.ecosystem === "react-native" || context.ecosystem === "elixir") {
+    return {
+      shouldPrompt: false,
+      mode: "single",
+      options: [],
+      autoValue: "none",
+    };
+  }
+
+  if (context.ecosystem === "java" && context.javaLanguage === "kotlin") {
+    if (context.caching !== undefined) {
+      return {
+        shouldPrompt: false,
+        mode: "single",
+        options: [],
+        autoValue: context.caching,
+      };
+    }
     return {
       shouldPrompt: false,
       mode: "single",
@@ -87,8 +105,13 @@ export function resolveCachingPrompt(
       };
 }
 
-export async function getCachingChoice(caching?: Caching, backend?: Backend, ecosystem?: Ecosystem) {
-  const resolution = resolveCachingPrompt({ caching, backend, ecosystem });
+export async function getCachingChoice(
+  caching?: Caching,
+  backend?: Backend,
+  ecosystem?: Ecosystem,
+  javaLanguage?: string,
+) {
+  const resolution = resolveCachingPrompt({ caching, backend, ecosystem, javaLanguage });
   if (!resolution.shouldPrompt) {
     return resolution.autoValue ?? "none";
   }

--- a/apps/cli/src/prompts/data/search.ts
+++ b/apps/cli/src/prompts/data/search.ts
@@ -72,12 +72,30 @@ type SearchPromptContext = {
   search?: Search;
   backend?: Backend;
   ecosystem?: Ecosystem;
+  javaLanguage?: string;
 };
 
 export function resolveSearchPrompt(
   context: SearchPromptContext = {},
 ): PromptSingleResolution<Search> {
   if (context.ecosystem === "react-native" || context.ecosystem === "elixir") {
+    return {
+      shouldPrompt: false,
+      mode: "single",
+      options: [],
+      autoValue: "none",
+    };
+  }
+
+  if (context.ecosystem === "java" && context.javaLanguage === "kotlin") {
+    if (context.search !== undefined) {
+      return {
+        shouldPrompt: false,
+        mode: "single",
+        options: [],
+        autoValue: context.search,
+      };
+    }
     return {
       shouldPrompt: false,
       mode: "single",
@@ -126,8 +144,9 @@ export async function getSearchChoice(
   search?: Search,
   backend?: Backend,
   ecosystem?: Ecosystem,
+  javaLanguage?: string,
 ) {
-  const resolution = resolveSearchPrompt({ search, backend, ecosystem });
+  const resolution = resolveSearchPrompt({ search, backend, ecosystem, javaLanguage });
   if (!resolution.shouldPrompt) {
     return resolution.autoValue ?? "none";
   }

--- a/apps/cli/src/prompts/services/email.ts
+++ b/apps/cli/src/prompts/services/email.ts
@@ -61,12 +61,30 @@ type EmailPromptContext = {
   email?: Email;
   backend?: Backend;
   ecosystem?: Ecosystem;
+  javaLanguage?: string;
 };
 
 export function resolveEmailPrompt(
   context: EmailPromptContext = {},
 ): PromptSingleResolution<Email> {
   if (context.ecosystem === "react-native" || context.ecosystem === "elixir") {
+    return {
+      shouldPrompt: false,
+      mode: "single",
+      options: [],
+      autoValue: "none",
+    };
+  }
+
+  if (context.ecosystem === "java" && context.javaLanguage === "kotlin") {
+    if (context.email !== undefined) {
+      return {
+        shouldPrompt: false,
+        mode: "single",
+        options: [],
+        autoValue: context.email,
+      };
+    }
     return {
       shouldPrompt: false,
       mode: "single",
@@ -107,8 +125,13 @@ export function resolveEmailPrompt(
       };
 }
 
-export async function getEmailChoice(email?: Email, backend?: Backend, ecosystem?: Ecosystem) {
-  const resolution = resolveEmailPrompt({ email, backend, ecosystem });
+export async function getEmailChoice(
+  email?: Email,
+  backend?: Backend,
+  ecosystem?: Ecosystem,
+  javaLanguage?: string,
+) {
+  const resolution = resolveEmailPrompt({ email, backend, ecosystem, javaLanguage });
   if (!resolution.shouldPrompt) {
     return resolution.autoValue ?? "none";
   }

--- a/apps/cli/src/prompts/services/observability.ts
+++ b/apps/cli/src/prompts/services/observability.ts
@@ -55,12 +55,30 @@ type ObservabilityPromptContext = {
   observability?: Observability;
   backend?: Backend;
   ecosystem?: Ecosystem;
+  javaLanguage?: string;
 };
 
 export function resolveObservabilityPrompt(
   context: ObservabilityPromptContext = {},
 ): PromptSingleResolution<Observability> {
   if (context.ecosystem === "react-native" || context.ecosystem === "elixir") {
+    return {
+      shouldPrompt: false,
+      mode: "single",
+      options: [],
+      autoValue: "none",
+    };
+  }
+
+  if (context.ecosystem === "java" && context.javaLanguage === "kotlin") {
+    if (context.observability !== undefined) {
+      return {
+        shouldPrompt: false,
+        mode: "single",
+        options: [],
+        autoValue: context.observability,
+      };
+    }
     return {
       shouldPrompt: false,
       mode: "single",
@@ -105,8 +123,9 @@ export async function getObservabilityChoice(
   observability?: Observability,
   backend?: Backend,
   ecosystem?: Ecosystem,
+  javaLanguage?: string,
 ) {
-  const resolution = resolveObservabilityPrompt({ observability, backend, ecosystem });
+  const resolution = resolveObservabilityPrompt({ observability, backend, ecosystem, javaLanguage });
   if (!resolution.shouldPrompt) {
     return resolution.autoValue ?? "none";
   }

--- a/apps/web/src/components/stack-builder/stack-builder.tsx
+++ b/apps/web/src/components/stack-builder/stack-builder.tsx
@@ -2334,8 +2334,18 @@ function CreationModeComposer({
 
   useEffect(() => {
     if (!kotlinAdvancedPatch) return;
-    onChange(kotlinAdvancedPatch);
-  }, [kotlinAdvancedPatch, onChange]);
+    onChange((current) => {
+      const view = getEditorStack(current);
+      const nextView = patchGraphScopedSelections(view, kotlinAdvancedPatch);
+      const specs = reconcileComposerSpecs(
+        current.stackPartSpecs,
+        view.stackPartSpecs,
+        nextView.stackPartSpecs ?? view.stackPartSpecs,
+        getGraphSelection(view).rootIds,
+      );
+      return { ...kotlinAdvancedPatch, ...stackPatchFromGraphSpecs(specs) };
+    });
+  }, [kotlinAdvancedPatch, onChange, getEditorStack]);
 
   const getStepSelection = (
     stepId: ComposerRole,
@@ -3789,7 +3799,30 @@ const StackBuilderInner = ({ initialStack }: { initialStack?: StackState }) => {
   };
 
   const handleTechSelect = (category: keyof typeof TECH_OPTIONS, techId: string) => {
-    if (!isOptionCompatible(getCompatibilityStackForCategory(category), category, techId)) return;
+    const compatibilityStack = getCompatibilityStackForCategory(category);
+    if (
+      category === "javaLanguage" &&
+      techId === "kotlin" &&
+      (compatibilityStack.ecosystem as string) === "java"
+    ) {
+      const prospective: StackState = {
+        ...compatibilityStack,
+        caching: "none",
+        search: "none",
+        email: "none",
+        observability: "none",
+        javaLibraries: ((compatibilityStack.javaLibraries ?? []) as string[]).filter(
+          (library) => !isKotlinIncompatibleOption("javaLibraries", library),
+        ),
+        javaTestingLibraries: ((compatibilityStack.javaTestingLibraries ?? []) as string[]).filter(
+          (library) => !isKotlinIncompatibleOption("javaTestingLibraries", library),
+        ),
+        ...(compatibilityStack.javaBuildTool === "none" ? { javaBuildTool: "maven" } : null),
+      };
+      if (!isOptionCompatible(prospective, category, techId)) return;
+    } else if (!isOptionCompatible(compatibilityStack, category, techId)) {
+      return;
+    }
 
     selectionEngagedRef.current = true;
     selectionCompletedRef.current = false;
@@ -3820,6 +3853,9 @@ const StackBuilderInner = ({ initialStack }: { initialStack?: StackState }) => {
           );
           if (filteredTesting.length !== testingLibraries.length) {
             (update as Record<string, unknown>).javaTestingLibraries = filteredTesting;
+          }
+          if (currentStack.javaBuildTool === "none") {
+            (update as Record<string, unknown>).javaBuildTool = "maven";
           }
         }
         return Object.keys(update).length > 0 ? update : {};

--- a/apps/web/src/components/stack-builder/stack-builder.tsx
+++ b/apps/web/src/components/stack-builder/stack-builder.tsx
@@ -3,7 +3,10 @@ import {
   getCategoryOrderForEcosystem,
   getStarterTrackCatalog,
   getStackPartOptions,
+  isKotlinBackendSelection,
+  isKotlinIncompatibleOption,
   isMultiSelectCategory,
+  KOTLIN_HIDDEN_SHARED_CATEGORIES,
   parseStackPartSpecs,
   stackPartsToLegacyProjectConfigPartial,
   STARTER_TRACK_DEFINITIONS,
@@ -475,16 +478,22 @@ function BuilderSearchField({
 
 function filterKotlinBackendCapabilityOptions(
   selection: Pick<GraphSelection, "backendEcosystem" | "backendLanguage">,
-  role: Extract<StackPartRole, "orm" | "api">,
+  role: Extract<StackPartRole, "orm" | "api" | "libraries" | "testing" | "buildTool">,
   options: TechOption[],
 ) {
-  if (selection.backendEcosystem !== "java" || selection.backendLanguage !== "kotlin") {
+  if (!isKotlinBackendSelection(selection.backendEcosystem, selection.backendLanguage)) {
     return options;
   }
 
-  const supportedIds =
-    role === "orm" ? new Set(["spring-data-jpa", "none"]) : new Set(["spring-graphql", "none"]);
-  return options.filter((option) => supportedIds.has(option.id));
+  const categoryByRole = {
+    orm: "javaOrm",
+    api: "javaApi",
+    libraries: "javaLibraries",
+    testing: "javaTestingLibraries",
+    buildTool: "javaBuildTool",
+  } as const;
+  const category = categoryByRole[role];
+  return options.filter((option) => !isKotlinIncompatibleOption(category, option.id));
 }
 
 const GRAPH_FRONTEND_CONFIGS: GraphFrontendConfig[] = [
@@ -1261,6 +1270,18 @@ function stackPatchFromGraphSpecs(specs: string[]): Partial<StackState> {
         backend && isGraphBackendEcosystem(backend.ecosystem) ? backend.ecosystem : undefined,
       ),
     );
+
+    if (backend?.ecosystem === "java") {
+      const languagePart = selectedParts.find(
+        (part) => part.role === "language" && part.ownerPartId === backend.id,
+      );
+      if (languagePart?.toolId === "kotlin") {
+        (patch as Record<string, unknown>).caching = "none";
+        (patch as Record<string, unknown>).search = "none";
+        (patch as Record<string, unknown>).email = "none";
+        (patch as Record<string, unknown>).observability = "none";
+      }
+    }
   } catch {
     return patch;
   }
@@ -1696,6 +1717,13 @@ function categoryHasNonDefaultSelection(
 }
 
 function shouldSkipCategory(stack: StackState, categoryKey: string): boolean {
+  if (
+    stack.ecosystem === "java" &&
+    stack.javaLanguage === "kotlin" &&
+    KOTLIN_HIDDEN_SHARED_CATEGORIES.has(categoryKey)
+  ) {
+    return true;
+  }
   return (
     categoryKey === "astroIntegration" ||
     SHADCN_SUB_CATEGORIES.has(categoryKey as keyof typeof TECH_OPTIONS) ||
@@ -2025,12 +2053,12 @@ function CreationModeComposer({
     "backend",
     graphSelection.backendEcosystem,
   );
-  const backendOptions =
-    graphSelection.backendEcosystem === "java" && graphSelection.backendLanguage === "kotlin"
-      ? allBackendOptions.filter(
-          (option) => option.id === "spring-boot" || option.id === "ktor" || option.id === "none",
-        )
-      : allBackendOptions;
+  const backendOptions = isKotlinBackendSelection(
+    graphSelection.backendEcosystem,
+    graphSelection.backendLanguage,
+  )
+    ? allBackendOptions.filter((option) => !isKotlinIncompatibleOption("javaWebFramework", option.id))
+    : allBackendOptions;
   const databaseOptions = getGraphToolOptions("database", "database", "universal");
   const allBackendOrmOptions = getGraphToolOptions(
     backendConfig.ormCategory,
@@ -2069,7 +2097,15 @@ function CreationModeComposer({
   const backendAdvancedCategories =
     graphSelection.backend === "none"
       ? []
-      : getGraphBackendAdvancedCategoryOrder(graphSelection.backendEcosystem);
+      : getGraphBackendAdvancedCategoryOrder(graphSelection.backendEcosystem).filter(
+          (category) =>
+            !(
+              isKotlinBackendSelection(
+                graphSelection.backendEcosystem,
+                graphSelection.backendLanguage,
+              ) && KOTLIN_HIDDEN_SHARED_CATEGORIES.has(category as string)
+            ),
+        );
   const backendCompatibilityStack: StackState = {
     ...optionStack,
     ecosystem: graphSelection.backendEcosystem as Ecosystem,
@@ -2264,6 +2300,42 @@ function CreationModeComposer({
     if (!hasStaleKotlinBackendCapability) return;
     updateGraphSelection(reconciledBackendCapabilities);
   }, [hasStaleKotlinBackendCapability, reconciledBackendCapabilities, updateGraphSelection]);
+
+  const kotlinAdvancedPatch = useMemo(() => {
+    if (!isKotlinBackendSelection(graphSelection.backendEcosystem, graphSelection.backendLanguage)) {
+      return null;
+    }
+    const patch: Partial<StackState> = {};
+    const libraries = (optionStack.javaLibraries ?? []) as string[];
+    const filteredLibraries = libraries.filter(
+      (library) => !isKotlinIncompatibleOption("javaLibraries", library),
+    );
+    if (filteredLibraries.length !== libraries.length) {
+      (patch as Record<string, unknown>).javaLibraries = filteredLibraries;
+    }
+    const testingLibraries = (optionStack.javaTestingLibraries ?? []) as string[];
+    const filteredTesting = testingLibraries.filter(
+      (library) => !isKotlinIncompatibleOption("javaTestingLibraries", library),
+    );
+    if (filteredTesting.length !== testingLibraries.length) {
+      (patch as Record<string, unknown>).javaTestingLibraries = filteredTesting;
+    }
+    if ((optionStack.javaBuildTool as string) === "none" && graphSelection.backend !== "none") {
+      (patch as Record<string, unknown>).javaBuildTool = "maven";
+    }
+    for (const category of KOTLIN_HIDDEN_SHARED_CATEGORIES) {
+      const key = getStackKeyForCategory(category as keyof typeof TECH_OPTIONS);
+      if ((optionStack as Record<string, unknown>)[key] !== "none") {
+        (patch as Record<string, unknown>)[key] = "none";
+      }
+    }
+    return Object.keys(patch).length > 0 ? patch : null;
+  }, [graphSelection, optionStack]);
+
+  useEffect(() => {
+    if (!kotlinAdvancedPatch) return;
+    onChange(kotlinAdvancedPatch);
+  }, [kotlinAdvancedPatch, onChange]);
 
   const getStepSelection = (
     stepId: ComposerRole,
@@ -3724,6 +3796,32 @@ const StackBuilderInner = ({ initialStack }: { initialStack?: StackState }) => {
     startTransition(() => {
       setStack((currentStack: StackState) => {
         const update = getStackOptionUpdate(currentStack, category, techId);
+        const nextEcosystem = (update.ecosystem ?? currentStack.ecosystem) as string;
+        const nextLanguage =
+          ((update as Record<string, unknown>).javaLanguage as string | undefined) ??
+          currentStack.javaLanguage;
+        if (nextEcosystem === "java" && nextLanguage === "kotlin") {
+          for (const hidden of KOTLIN_HIDDEN_SHARED_CATEGORIES) {
+            const key = getStackKeyForCategory(hidden as keyof typeof TECH_OPTIONS);
+            if ((currentStack as Record<string, unknown>)[key] !== "none") {
+              (update as Record<string, unknown>)[key] = "none";
+            }
+          }
+          const libraries = (currentStack.javaLibraries ?? []) as string[];
+          const filteredLibraries = libraries.filter(
+            (library) => !isKotlinIncompatibleOption("javaLibraries", library),
+          );
+          if (filteredLibraries.length !== libraries.length) {
+            (update as Record<string, unknown>).javaLibraries = filteredLibraries;
+          }
+          const testingLibraries = (currentStack.javaTestingLibraries ?? []) as string[];
+          const filteredTesting = testingLibraries.filter(
+            (library) => !isKotlinIncompatibleOption("javaTestingLibraries", library),
+          );
+          if (filteredTesting.length !== testingLibraries.length) {
+            (update as Record<string, unknown>).javaTestingLibraries = filteredTesting;
+          }
+        }
         return Object.keys(update).length > 0 ? update : {};
       });
     });

--- a/apps/web/src/components/stack-builder/utils.ts
+++ b/apps/web/src/components/stack-builder/utils.ts
@@ -9,7 +9,9 @@ import {
   getToolingSelectionOptions,
   hasPWACompatibleFrontend,
   hasTauriCompatibleFrontend,
+  isKotlinIncompatibleOption,
   isOptionCompatible as isOptionCompatibleShared,
+  KOTLIN_HIDDEN_SHARED_CATEGORIES,
   validateProjectName,
 } from "@better-fullstack/types";
 
@@ -142,6 +144,25 @@ export const getVisibleOptions = (
   category: keyof typeof TECH_OPTIONS,
   options: (typeof TECH_OPTIONS)[keyof typeof TECH_OPTIONS],
 ) => {
+  const isKotlin =
+    currentStack.ecosystem === "java" && currentStack.javaLanguage === "kotlin";
+
+  if (isKotlin) {
+    if (KOTLIN_HIDDEN_SHARED_CATEGORIES.has(category as string)) {
+      return options.filter((option) => option.id === "none");
+    }
+    if (
+      category === "javaWebFramework" ||
+      category === "javaBuildTool" ||
+      category === "javaOrm" ||
+      category === "javaApi" ||
+      category === "javaLibraries" ||
+      category === "javaTestingLibraries"
+    ) {
+      return options.filter((option) => !isKotlinIncompatibleOption(category, option.id));
+    }
+  }
+
   if (category !== "auth") return options;
 
   switch (currentStack.ecosystem) {

--- a/packages/types/src/stack/compatibility.ts
+++ b/packages/types/src/stack/compatibility.ts
@@ -197,6 +197,74 @@ export const KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES: ReadonlySet<string> = ne
 // blocks: data classes replace Lombok, and MapStruct would need kapt.
 export const KOTLIN_DROPPED_JAVA_LIBRARIES: ReadonlySet<string> = new Set(["lombok", "mapstruct"]);
 
+export const KOTLIN_SUPPORTED_JAVA_WEB_FRAMEWORKS: ReadonlySet<string> = new Set([
+  "spring-boot",
+  "ktor",
+  "none",
+]);
+
+export const KOTLIN_SUPPORTED_JAVA_ORM: ReadonlySet<string> = new Set(["spring-data-jpa", "none"]);
+
+export const KOTLIN_SUPPORTED_JAVA_API: ReadonlySet<string> = new Set([
+  "spring-graphql",
+  "none",
+]);
+
+export const KOTLIN_JAVA_ONLY_SHARED_TOOLS: Readonly<Record<string, ReadonlySet<string>>> = {
+  email: new Set(["resend"]),
+  search: new Set(["meilisearch"]),
+  caching: new Set(["upstash-redis"]),
+  observability: new Set(["sentry"]),
+};
+
+export const KOTLIN_HIDDEN_SHARED_CATEGORIES: ReadonlySet<string> = new Set([
+  "caching",
+  "search",
+  "email",
+  "observability",
+]);
+
+export function isKotlinJavaStack(stack: {
+  ecosystem?: string;
+  javaLanguage?: string;
+}): boolean {
+  return stack.ecosystem === "java" && stack.javaLanguage === "kotlin";
+}
+
+export function isKotlinBackendSelection(
+  backendEcosystem: string | undefined,
+  backendLanguage: string | undefined,
+): boolean {
+  return backendEcosystem === "java" && backendLanguage === "kotlin";
+}
+
+export function isKotlinIncompatibleOption(category: string, optionId: string): boolean {
+  switch (category) {
+    case "javaWebFramework":
+      if (optionId === "none") return false;
+      return !KOTLIN_SUPPORTED_JAVA_WEB_FRAMEWORKS.has(optionId);
+    case "javaBuildTool":
+      return optionId === "none";
+    case "javaOrm":
+    case "javaApi":
+      if (optionId === "none") return false;
+      return category === "javaOrm"
+        ? !KOTLIN_SUPPORTED_JAVA_ORM.has(optionId)
+        : !KOTLIN_SUPPORTED_JAVA_API.has(optionId);
+    case "javaLibraries":
+      return KOTLIN_DROPPED_JAVA_LIBRARIES.has(optionId);
+    case "javaTestingLibraries":
+      return KOTLIN_UNSUPPORTED_JAVA_TESTING_LIBRARIES.has(optionId);
+    case "email":
+    case "search":
+    case "caching":
+    case "observability":
+      return KOTLIN_JAVA_ONLY_SHARED_TOOLS[category]?.has(optionId) ?? false;
+    default:
+      return false;
+  }
+}
+
 export type KotlinJavaGateInput = {
   javaWebFramework?: string;
   javaBuildTool?: string;


### PR DESCRIPTION
## Problem

Selecting Kotlin in the builder shows caching and search options that can never generate. Upstash Redis and Meilisearch are Java-only with no Kotlin sources, while every other option in those sections is TypeScript/Go-only. The result is a wall of all-disabled cards ending in No Caching and No Search, with the same Java-only mixing in email, observability, and the Java library lists.

## Solution

Kotlin now only shows libraries both JVM variants can use. The shared caching, search, email, and observability sections are hidden for Kotlin since none of their tools has a Kotlin implementation, and the Java capability lists are filtered to the Kotlin-supported subset. Switching between Java and Kotlin clears stale selections that would otherwise persist invisibly. Explicit CLI flags are still preserved, so conflicting combinations keep falling back to Java with a warning instead of silently dropping the flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Kotlin support in the stack builder with compatibility filtering for frameworks, libraries, testing tools, and build tools.
  * Automatically selects Maven when Kotlin is chosen.
  * Hides or defaults unsupported shared services, including email, search, caching, and observability.
* **Bug Fixes**
  * Preserves existing configuration values while skipping unnecessary prompts for unsupported Kotlin options.
  * Applies Kotlin compatibility rules consistently across stack-builder categories and configuration prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63023993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because no reportable new finding remains and the sole previous thread was manually resolved.

<sub>Reviews (3) · Last reviewed commit: ["fix(cli): hide shared prompts only when ..."](https://github.com/marve10s/better-fullstack/commit/61b4880d9ec8458809d66772797c872e8519bb62)</sub>

<!-- /greptile_comment -->